### PR TITLE
feat: add reporter group clearing helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ Plugin Stacking Policy (additive)
 43. Prefer convenience helpers alongside new classes (e.g., `make_datapair`, `encode_datapair`, `decode_datapair`) without removing or narrowing any existing APIs.
 44. Test runner policy: Treat `pytest` as unavailable/unstable in this environment; the agent SHALL run tests using `unittest` modules by default (leveraging rule 26’s fallback). Only use `pytest` if the user explicitly requests it and stability is verified.
 45. Neuroplasticity: Add new capabilities conservatively with default plugins that are safe and minimally invasive. Hook them into `Wanderer` via plugin registries and ensure all actions are logged via `REPORTER`.
+46. Clear reporter state between tests using `Reporter.clear_group` (via `clear_report_group`) to avoid cross-test interference.
 Temporary Test Deferral (additive, non-contradictory)
 
 - HyperEvolution comparison test: Deferred for now to keep CI time stable and avoid flakiness while architecture-search behavior evolves. This does NOT remove or narrow any functionality; it only defers a heavy integration test. Re-enable once stable budgets (pairs/steps/epochs) are agreed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,7 @@ Core Components
   - `run_wanderers_parallel`: orchestrates multiple datasets with thread-based concurrency (process mode intentionally unimplemented).
   - `run_wine_hello_world`: convenience that loads scikit-learn’s Wine dataset, runs training with neuroplasticity active, and writes per-step wanderer logs to a JSONL file.
 
-- Reporter: Global `REPORTER` instance to record structured data. Convenience functions `report`, `report_group`, `report_dir` provide ergonomic logging and querying. Tests and core flows record key metrics and events for auditability.
+- Reporter: Global `REPORTER` instance to record structured data. Convenience functions `report`, `report_group`, `report_dir`, and `clear_report_group` provide ergonomic logging, querying, and cleanup. Tests and core flows record key metrics and events for auditability.
   - Per-step logs: `Wanderer.walk` records detailed step metrics under group `wanderer_steps/logs` including:
     - time, dt_since_last
     - current_loss (per-step), previous_loss, mean_loss (running per-step mean within walk)
@@ -79,7 +79,7 @@ Packaging and Layout
 - Code: primary entry module `marble/marblemain.py` re-exports public APIs from cohesive submodules:
   - `marble/codec.py`: `UniversalTensorCodec`, `TensorLike`.
   - `marble/datapair.py`: `DataPair` and helpers (`make_datapair`, `encode_datapair`, `decode_datapair`).
-  - `marble/reporter.py`: `Reporter`, `REPORTER`, `report`, `report_group`, `report_dir`, `export_wanderer_steps_to_jsonl`.
+  - `marble/reporter.py`: `Reporter`, `REPORTER`, `report`, `report_group`, `report_dir`, `clear_report_group`, `export_wanderer_steps_to_jsonl`.
   - `marble/hf_utils.py`: Hugging Face login and dataset streaming wrappers with auto-encoding.
   - `marble/graph.py`: `_DeviceHelper`, `Neuron`, `Synapse`, and registries (`_NEURON_TYPES`, `_SYNAPSE_TYPES`, register helpers).
   - `marble/training.py`: High-level training flows (`run_wanderer_training`, `create_start_neuron`, `run_training_with_datapairs`, `run_wanderer_epochs_with_datapairs`, `run_wanderers_parallel`, `make_default_codec`, `quick_train_on_pairs`).

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -4987,6 +4987,7 @@ from .reporter import (
     report,
     report_group,
     report_dir,
+    clear_report_group,
     export_wanderer_steps_to_jsonl,
 )
 
@@ -4996,6 +4997,7 @@ __all__ += [
     "report",
     "report_group",
     "report_dir",
+    "clear_report_group",
     "export_wanderer_steps_to_jsonl",
 ]
 

--- a/tests/test_reporter_clear.py
+++ b/tests/test_reporter_clear.py
@@ -1,0 +1,26 @@
+import unittest
+
+from marble.marblemain import REPORTER, report, report_group, clear_report_group
+
+
+class TestReporterClear(unittest.TestCase):
+    def setUp(self):
+        self.reporter = REPORTER
+        self.report = report
+        self.report_group = report_group
+        self.clear = clear_report_group
+
+    def test_clear_group(self):
+        r = self.reporter
+        r.registergroup("temp", "sub")
+        self.report("temp", "val", 42, "sub")
+        before = self.report_group("temp", "sub")
+        self.assertIn("val", before)
+        self.clear("temp", "sub")
+        after = self.report_group("temp", "sub")
+        print("reporter after clear:", after)
+        self.assertEqual(after, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add `Reporter.clear_group` and `clear_report_group` helper for removing reporter groups
- expose helper through `marblemain` and document in architecture
- add unit test and AGENTS rule for clearing reporter state

## Testing
- `python -m pip install -e . --break-system-packages`
- `python -m pip install torch --index-url https://download.pytorch.org/whl/cpu --break-system-packages`
- `python -m pip install numpy --break-system-packages`
- `python -m unittest discover -s tests -p "test*.py" -v`

------
https://chatgpt.com/codex/tasks/task_e_68b00012f23c8327a3fc06c16a134ec2