### PR TITLE
Add walk summary helper and test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,7 @@ Plugin Stacking Policy (additive)
 44. Test runner policy: Treat `pytest` as unavailable/unstable in this environment; the agent SHALL run tests using `unittest` modules by default (leveraging rule 26’s fallback). Only use `pytest` if the user explicitly requests it and stability is verified.
 45. Neuroplasticity: Add new capabilities conservatively with default plugins that are safe and minimally invasive. Hook them into `Wanderer` via plugin registries and ensure all actions are logged via `REPORTER`.
 46. Clear reporter state between tests using `Reporter.clear_group` (via `clear_report_group`) to avoid cross-test interference.
+47. Helper functions that read reporter data must handle missing groups gracefully and return `None` rather than raising exceptions.
 Temporary Test Deferral (additive, non-contradictory)
 
 - HyperEvolution comparison test: Deferred for now to keep CI time stable and avoid flakiness while architecture-search behavior evolves. This does NOT remove or narrow any functionality; it only defers a heavy integration test. Re-enable once stable budgets (pairs/steps/epochs) are agreed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,7 @@ Core Components
     - applied_settings (dict applied at step start), current_lr (effective LR used for update)
   - Export: `export_wanderer_steps_to_jsonl(path)` writes collected step records to JSON Lines.
   - Per-walk summaries: After each walk, Wanderer reports `{final_loss, mean_step_loss, steps, visited, timestamp}` under `training/walks`.
+  - Convenience: `get_last_walk_summary()` retrieves the latest record from `training/walks` for quick access in tests or tools.
 
 Device and CUDA Policy
 

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -5001,6 +5001,34 @@ __all__ += [
     "export_wanderer_steps_to_jsonl",
 ]
 
+
+def get_last_walk_summary() -> Optional[Dict[str, Any]]:
+    """Return the most recent walk summary recorded under training/walks.
+
+    Reads the global REPORTER's ``training/walks`` group and selects the
+    entry with the highest numeric suffix. Returns ``None`` when the group
+    is empty or missing.
+    """
+
+    try:
+        walks = REPORTER.group("training", "walks")
+    except Exception:
+        return None
+    if not walks:
+        return None
+
+    def _idx(k: str) -> int:
+        try:
+            return int(k.split("_")[-1])
+        except Exception:
+            return -1
+
+    last_key = max(walks.keys(), key=_idx)
+    return walks.get(last_key)
+
+
+__all__ += ["get_last_walk_summary"]
+
 # High-level training helpers (moved)
 from .training import (
     run_training_with_datapairs,

--- a/tests/test_wanderer_walk_summary.py
+++ b/tests/test_wanderer_walk_summary.py
@@ -1,0 +1,41 @@
+import unittest
+
+
+class TestWandererWalkSummary(unittest.TestCase):
+    def setUp(self):
+        from marble.marblemain import (
+            Brain,
+            Wanderer,
+            get_last_walk_summary,
+            clear_report_group,
+            report,
+        )
+        self.Brain = Brain
+        self.Wanderer = Wanderer
+        self.get_last_walk_summary = get_last_walk_summary
+        self.clear_report_group = clear_report_group
+        self.report = report
+
+    def test_walk_summary_recorded(self):
+        # Ensure clean reporter state
+        self.clear_report_group("training")
+
+        b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
+
+        w = self.Wanderer(b, seed=123)
+        w.walk(max_steps=2, lr=1e-2)
+
+        summary = self.get_last_walk_summary()
+        print("latest walk summary:", summary)
+        self.report("tests", "walk_summary", summary)
+        self.assertIsNotNone(summary)
+        self.assertIn("final_loss", summary)
+        self.assertIn("steps", summary)
+        self.assertGreaterEqual(summary["steps"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add `get_last_walk_summary` helper to quickly access latest `training/walks` report
- test that `Wanderer.walk` records per-walk summaries and expose via helper
- document helper in architecture and operating rules

## Testing
- `python3 -m py_compile marble/marblemain.py tests/test_wanderer_walk_summary.py`
- `python3 -m unittest discover -s tests -p "test*.py" -v`

------
https://chatgpt.com/codex/tasks/task_e_68b0055f491483278612ee2dec0eaa51