### PR TITLE
Refactor conv transpose neuron plugins into dedicated modules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -85,7 +85,8 @@ Packaging and Layout
   - `marble/graph.py`: `_DeviceHelper`, `Neuron`, `Synapse`, and registries (`_NEURON_TYPES`, `_SYNAPSE_TYPES`, register helpers).
   - `marble/training.py`: High-level training flows (`run_wanderer_training`, `create_start_neuron`, `run_training_with_datapairs`, `run_wanderer_epochs_with_datapairs`, `run_wanderers_parallel`, `make_default_codec`, `quick_train_on_pairs`).
   Additional subsystems will be modularized incrementally (brain, plugins) while preserving public APIs through `marblemain`.
-- Examples: `examples/run_datapair_training.py` demonstrates a small end-to-end datapair training run.
+  - Examples: `examples/run_datapair_training.py` demonstrates a small end-to-end datapair training run.
+  - Neuron plugins for transpose convolutions (`conv_transpose1d`, `conv_transpose2d`, `conv_transpose3d`) are implemented in dedicated modules under `marble/plugins/`, preparing for future removal of duplicate definitions from `marble/marblemain.py`.
 
 Operational Policy Update
 

--- a/marble/plugins/conv_transpose1d.py
+++ b/marble/plugins/conv_transpose1d.py
@@ -1,8 +1,111 @@
 from __future__ import annotations
-from ..marblemain import ConvTranspose1DNeuronPlugin as _Base
 
-class ConvTranspose1DNeuronPlugin(_Base):
-    pass
+from typing import List
+
+from ..reporter import report
+from .conv1d import Conv1DNeuronPlugin
+
+
+class ConvTranspose1DNeuronPlugin(Conv1DNeuronPlugin):
+    def on_init(self, neuron: "Neuron") -> None:
+        # Reuse strict rule: 5 PARAM + 1 outgoing
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 5 or len(out) != 1:
+            raise ValueError(
+                f"ConvTranspose1D neuron requires exactly 5 incoming PARAM synapses and exactly 1 outgoing synapse; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "convtranspose1d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        # Gather params and data using Conv1D helpers
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 5:
+            raise ValueError("ConvTranspose1D requires 5 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src, d_src, b_src = [s.source for s in param_incs[:5]]
+        kernel = self._to_list1d(getattr(k_src, "tensor", [])) or [1.0]
+        stride = int(self._first_scalar(getattr(s_src, "tensor", 1.0), default=1.0, min_val=1.0))
+        padding = int(max(0.0, self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)))
+        dilation = int(self._first_scalar(getattr(d_src, "tensor", 1.0), default=1.0, min_val=1.0))
+        bias = float(self._first_scalar(getattr(b_src, "tensor", 0.0), default=0.0))
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        learn_kernel = lstore.get("kernel")
+        learn_bias = lstore.get("conv_bias")
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            x1: List[float] = []
+            for s in data_incs:
+                x1 += self._to_list1d(getattr(s.source, "tensor", []))
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            x1 = self._to_list1d(x)
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and str(device) == "cuda":
+            try:
+                xt = torch.tensor(x1, dtype=torch.float32, device=device).view(1, 1, -1)
+                wt = (learn_kernel.to(device) if hasattr(learn_kernel, "to") else torch.tensor(kernel, dtype=torch.float32, device=device)).view(1, 1, -1)
+                bt = (learn_bias.to(device).view(-1) if hasattr(learn_bias, "to") else torch.tensor([bias], dtype=torch.float32, device=device))
+                y = torch.nn.functional.conv_transpose1d(xt, wt, bias=bt, stride=stride, padding=padding, dilation=dilation)
+                y = y.view(-1)
+                try:
+                    report("neuron", "convtranspose1d", {"in": int(xt.numel()), "out": int(y.numel()), "k": int(wt.numel()), "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        # Pure-Python fallback
+        n = len(x1)
+        klen = len(kernel)
+        out_len = (n - 1) * stride - 2 * padding + (klen - 1) * dilation + 1
+        y_list = [0.0] * max(0, out_len)
+        if hasattr(learn_kernel, "detach"):
+            try:
+                kernel = list(learn_kernel.detach().to("cpu").view(-1).tolist())
+                klen = len(kernel)
+            except Exception:
+                pass
+        if hasattr(learn_bias, "detach"):
+            try:
+                bias = float(learn_bias.detach().to("cpu").view(-1)[0].item())
+            except Exception:
+                try:
+                    bias = float(learn_bias)
+                except Exception:
+                    pass
+        for t in range(n):
+            base = t * stride
+            for i in range(klen):
+                oi = base + i * dilation - padding
+                if 0 <= oi < len(y_list):
+                    y_list[oi] += kernel[i] * x1[t]
+        y_list = [v + bias for v in y_list]
+        try:
+            report("neuron", "convtranspose1d", {"in": n, "out": len(y_list), "k": klen, "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+        except Exception:
+            pass
+        try:
+            return neuron._ensure_tensor(y_list)
+        except Exception:
+            return y_list
+
 
 __all__ = ["ConvTranspose1DNeuronPlugin"]
 

--- a/marble/plugins/conv_transpose2d.py
+++ b/marble/plugins/conv_transpose2d.py
@@ -1,8 +1,142 @@
 from __future__ import annotations
-from ..marblemain import ConvTranspose2DNeuronPlugin as _Base
 
-class ConvTranspose2DNeuronPlugin(_Base):
-    pass
+import math
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class ConvTranspose2DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 5 or len(out) != 1:
+            raise ValueError(
+                f"ConvTranspose2D neuron requires exactly 5 incoming PARAM synapses and exactly 1 outgoing synapse; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "convtranspose2d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 5:
+            raise ValueError("ConvTranspose2D requires 5 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src, d_src, b_src = [s.source for s in param_incs[:5]]
+        kernel_1d = self._to_list1d(getattr(k_src, "tensor", [])) or [1.0]
+        stride = int(self._first_scalar(getattr(s_src, "tensor", 1.0), default=1.0, min_val=1.0))
+        padding = int(max(0.0, self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)))
+        dilation = int(self._first_scalar(getattr(d_src, "tensor", 1.0), default=1.0, min_val=1.0))
+        bias = float(self._first_scalar(getattr(b_src, "tensor", 0.0), default=0.0))
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        learn_kernel = lstore.get("kernel")
+        learn_bias = lstore.get("conv_bias")
+
+        # Build 2D input from DATA rows
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            rows = [self._to_list1d(getattr(s.source, "tensor", [])) for s in data_incs]
+            width = min((len(r) for r in rows if r), default=0)
+            if width <= 0:
+                x_vals: List[float] = []
+                H = W = 0
+            else:
+                rows = [r[:width] for r in rows]
+                H = len(rows)
+                W = width
+                x_vals = [v for r in rows for v in r]
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            x_vals = self._to_list1d(x)
+            N = max(1, len(x_vals))
+            rh = int(math.isqrt(N))
+            if rh * rh == N:
+                H = W = rh
+            else:
+                H, W = N, 1
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and H > 0 and W > 0 and str(device) == "cuda":
+            try:
+                xt = torch.tensor(x_vals, dtype=torch.float32, device=device).view(1, 1, H, W)
+                L = max(1, len(kernel_1d))
+                r = int(math.isqrt(L))
+                if r * r == L:
+                    kh = kw = r
+                else:
+                    kh, kw = L, 1
+                base_w = (learn_kernel.to(device) if hasattr(learn_kernel, "to") else torch.tensor(kernel_1d, dtype=torch.float32, device=device))
+                wt = base_w.view(1, 1, kh, kw)
+                bt = (learn_bias.to(device).view(-1) if hasattr(learn_bias, "to") else torch.tensor([bias], dtype=torch.float32, device=device))
+                y = torch.nn.functional.conv_transpose2d(
+                    xt, wt, bias=bt, stride=(stride, stride), padding=(padding, padding), dilation=(dilation, dilation)
+                )
+                y = y.view(-1)
+                try:
+                    report("neuron", "convtranspose2d", {"inHW": [H, W], "out": int(y.numel()), "kHW": [kh, kw], "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        # Pure Python fallback (simplified)
+        if hasattr(learn_kernel, "detach"):
+            try:
+                kernel_1d = list(learn_kernel.detach().to("cpu").view(-1).tolist())
+            except Exception:
+                pass
+        if hasattr(learn_bias, "detach"):
+            try:
+                bias = float(learn_bias.detach().to("cpu").view(-1)[0].item())
+            except Exception:
+                try:
+                    bias = float(learn_bias)
+                except Exception:
+                    pass
+        L = max(1, len(kernel_1d))
+        r = int(math.isqrt(L))
+        if r * r == L:
+            kh = kw = r
+        else:
+            kh, kw = L, 1
+        out_h = (H - 1) * stride - 2 * padding + (kh - 1) * dilation + 1
+        out_w = (W - 1) * stride - 2 * padding + (kw - 1) * dilation + 1
+        y2 = [[0.0 for _ in range(max(0, out_w))] for _ in range(max(0, out_h))]
+        for iy in range(H):
+            for ix in range(W):
+                base_y = iy * stride
+                base_x = ix * stride
+                val = x_vals[iy * W + ix]
+                for ky in range(kh):
+                    for kx in range(kw):
+                        oy = base_y + ky * dilation - padding
+                        ox = base_x + kx * dilation - padding
+                        if 0 <= oy < len(y2) and 0 <= ox < len(y2[0]):
+                            y2[oy][ox] += kernel_1d[ky * kw + kx] * val
+        y_list = [v + bias for row in y2 for v in row]
+        try:
+            report("neuron", "convtranspose2d", {"inHW": [H, W], "out": len(y_list), "kHW": [kh, kw], "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+        except Exception:
+            pass
+        try:
+            return neuron._ensure_tensor(y_list)
+        except Exception:
+            return y_list
+
 
 __all__ = ["ConvTranspose2DNeuronPlugin"]
 

--- a/marble/plugins/conv_transpose3d.py
+++ b/marble/plugins/conv_transpose3d.py
@@ -1,8 +1,149 @@
 from __future__ import annotations
-from ..marblemain import ConvTranspose3DNeuronPlugin as _Base
 
-class ConvTranspose3DNeuronPlugin(_Base):
-    pass
+import math
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class ConvTranspose3DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 5 or len(out) != 1:
+            raise ValueError(
+                f"ConvTranspose3D neuron requires exactly 5 incoming PARAM synapses and exactly 1 outgoing synapse; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "convtranspose3d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 5:
+            raise ValueError("ConvTranspose3D requires 5 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src, d_src, b_src = [s.source for s in param_incs[:5]]
+        kernel_1d = self._to_list1d(getattr(k_src, "tensor", [])) or [1.0]
+        stride = int(self._first_scalar(getattr(s_src, "tensor", 1.0), default=1.0, min_val=1.0))
+        padding = int(max(0.0, self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)))
+        dilation = int(self._first_scalar(getattr(d_src, "tensor", 1.0), default=1.0, min_val=1.0))
+        bias = float(self._first_scalar(getattr(b_src, "tensor", 0.0), default=0.0))
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        learn_kernel = lstore.get("kernel")
+        learn_bias = lstore.get("conv_bias")
+
+        # Build 3D input from DATA slices
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            slices = []
+            dims = []
+            for s in data_incs:
+                vals = self._to_list1d(getattr(s.source, "tensor", []))
+                N = max(1, len(vals))
+                r = int(math.isqrt(N))
+                if r * r == N:
+                    H = W = r
+                else:
+                    H, W = N, 1
+                dims.append((H, W))
+                slices.append(vals[: H * W])
+            Hmin = min((h for h, _ in dims), default=0)
+            Wmin = min((w for _, w in dims), default=0)
+            x_vals: List[float] = []
+            D = len(slices)
+            for sl, (h, w) in zip(slices, dims):
+                for rr in range(Hmin):
+                    row = sl[rr * w:(rr + 1) * w]
+                    x_vals.extend(row[:Wmin])
+            H, W = Hmin, Wmin
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            vals = self._to_list1d(x)
+            N = max(1, len(vals))
+            r3 = round(N ** (1.0 / 3.0))
+            if r3 > 0 and (r3 * r3 * r3) == N:
+                D = H = W = int(r3)
+                x_vals = vals[: D * H * W]
+            else:
+                D, H, W = N, 1, 1
+                x_vals = vals
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and H > 0 and W > 0 and str(device) == "cuda":
+            try:
+                xt = torch.tensor(x_vals, dtype=torch.float32, device=device).view(1, 1, D, H, W)
+                L = max(1, len(kernel_1d))
+                r = round(L ** (1.0 / 3.0))
+                if r > 0 and (r * r * r) == L:
+                    kd = kh = kw = int(r)
+                else:
+                    kd, kh, kw = L, 1, 1
+                base_w = (learn_kernel.to(device) if hasattr(learn_kernel, "to") else torch.tensor(kernel_1d, dtype=torch.float32, device=device))
+                wt = base_w.view(1, 1, kd, kh, kw)
+                bt = (learn_bias.to(device).view(-1) if hasattr(learn_bias, "to") else torch.tensor([bias], dtype=torch.float32, device=device))
+                y = torch.nn.functional.conv_transpose3d(
+                    xt, wt, bias=bt, stride=(stride, stride, stride), padding=(padding, padding, padding), dilation=(dilation, dilation, dilation)
+                )
+                y = y.view(-1)
+                try:
+                    report("neuron", "convtranspose3d", {"inDHW": [D, H, W], "out": int(y.numel()), "kDHW": [kd, kh, kw], "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        # Pure Python fallback
+        L = max(1, len(kernel_1d))
+        r = round(L ** (1.0 / 3.0))
+        if r > 0 and (r * r * r) == L:
+            kd = kh = kw = int(r)
+        else:
+            kd, kh, kw = L, 1, 1
+        out_d = (D - 1) * stride - 2 * padding + (kd - 1) * dilation + 1
+        out_h = (H - 1) * stride - 2 * padding + (kh - 1) * dilation + 1
+        out_w = (W - 1) * stride - 2 * padding + (kw - 1) * dilation + 1
+        y = [0.0] * max(0, out_d * out_h * out_w)
+        def idx3(a, d, h, w, H_, W_):
+            return d * (H_ * W_) + h * W_ + w
+        for iz in range(D):
+            for iy in range(H):
+                for ix in range(W):
+                    base_d = iz * stride
+                    base_y = iy * stride
+                    base_x = ix * stride
+                    val = x_vals[iz * (H * W) + iy * W + ix]
+                    for kz in range(kd):
+                        for ky in range(kh):
+                            for kx in range(kw):
+                                od = base_d + kz * dilation - padding
+                                oh = base_y + ky * dilation - padding
+                                ow = base_x + kx * dilation - padding
+                                if 0 <= od < out_d and 0 <= oh < out_h and 0 <= ow < out_w:
+                                    y[idx3(y, od, oh, ow, out_h, out_w)] += kernel_1d[(kz * kh + ky) * kw + kx] * val
+        y = [v + bias for v in y]
+        try:
+            report("neuron", "convtranspose3d", {"inDHW": [D, H, W], "out": len(y), "kDHW": [kd, kh, kw], "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+        except Exception:
+            pass
+        try:
+            return neuron._ensure_tensor(y)
+        except Exception:
+            return y
+
 
 __all__ = ["ConvTranspose3DNeuronPlugin"]
 


### PR DESCRIPTION
## Summary
- implement ConvTranspose1D/2D/3D neuron plugins directly in `marble/plugins`
- document plugin modularization in ARCHITECTURE

## Testing
- `python -m py_compile marble/plugins/conv_transpose1d.py marble/plugins/conv_transpose2d.py marble/plugins/conv_transpose3d.py`
- `python -m pip install -e .`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_wanderer_walk_summary`

------
https://chatgpt.com/codex/tasks/task_e_68b0272010308327ab07c7e683a066c1