### PR TITLE
Refactor plugin modules to standalone implementations

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -87,6 +87,8 @@ Packaging and Layout
   Additional subsystems will be modularized incrementally (brain, plugins) while preserving public APIs through `marblemain`.
   - Examples: `examples/run_datapair_training.py` demonstrates a small end-to-end datapair training run.
   - Neuron plugins for transpose convolutions (`conv_transpose1d`, `conv_transpose2d`, `conv_transpose3d`) are implemented in dedicated modules under `marble/plugins/`, preparing for future removal of duplicate definitions from `marble/marblemain.py`.
+  - Additional neuron plugins (`maxpool1d/2d/3d`, `unfold2d`, `fold2d`, `maxunpool1d/2d/3d`) now reside in self-contained modules within `marble/plugins/` with full implementations.
+  - Wanderer and brain-training plugin implementations (e.g., L2 penalty, curriculum, warmup-decay) are also hosted in their own modules under `marble/plugins/`.
 
 Operational Policy Update
 

--- a/marble/plugins/brain_train_curriculum.py
+++ b/marble/plugins/brain_train_curriculum.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from ..marblemain import register_brain_train_type
-
 
 class CurriculumTrainPlugin:
     """Brain-train plugin that increases walk max_steps across walks.
@@ -27,11 +25,5 @@ class CurriculumTrainPlugin:
             except Exception:
                 pass
         return {"max_steps": int(ms)}
-
-
-try:
-    register_brain_train_type("curriculum", CurriculumTrainPlugin())
-except Exception:
-    pass
 
 __all__ = ["CurriculumTrainPlugin"]

--- a/marble/plugins/brain_train_warmup_decay.py
+++ b/marble/plugins/brain_train_warmup_decay.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from ..marblemain import register_brain_train_type
 from ..reporter import report
 
 
@@ -59,11 +58,5 @@ class WarmupDecayTrainPlugin:
 
     def on_end(self, brain: "Brain", wanderer: "Wanderer", history: List[Dict[str, Any]]) -> Dict[str, Any]:
         return {"warmup_decay": {"walks": len(history), "final_loss": history[-1].get("loss") if history else None}}
-
-
-try:
-    register_brain_train_type("warmup_decay", WarmupDecayTrainPlugin())
-except Exception:
-    pass
 
 __all__ = ["WarmupDecayTrainPlugin"]

--- a/marble/plugins/fold2d.py
+++ b/marble/plugins/fold2d.py
@@ -1,8 +1,120 @@
 from __future__ import annotations
-from ..marblemain import Fold2DNeuronPlugin as _Base
 
-class Fold2DNeuronPlugin(_Base):
-    pass
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class Fold2DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 6 or len(out) != 1:
+            raise ValueError(
+                f"Fold2D neuron requires exactly 6 incoming PARAM synapses (out_h,out_w,kernel,stride,padding,dilation) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "fold2d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 6:
+            raise ValueError("Fold2D requires 6 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        oh_src, ow_src, k_src, s_src, p_src, d_src = [s.source for s in param_incs[:6]]
+        base_oh = self._first_scalar(getattr(oh_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_ow = self._first_scalar(getattr(ow_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 1.0), default=1.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        base_dl = self._first_scalar(getattr(d_src, "tensor", 1.0), default=1.0, min_val=1.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        def to_int(val, default, minv):
+            try:
+                return int(max(minv, round(float(val.detach().to("cpu").view(-1)[0].item())))) if hasattr(val, "detach") else int(max(minv, round(default)))
+            except Exception:
+                return int(max(minv, round(default)))
+        out_h = to_int(lstore.get("out_h"), base_oh, 1)
+        out_w = to_int(lstore.get("out_w"), base_ow, 1)
+        ksize = to_int(lstore.get("kernel_size"), base_ks, 1)
+        stride = to_int(lstore.get("stride"), base_st, 1)
+        padding = to_int(lstore.get("padding"), base_pd, 0)
+        dilation = to_int(lstore.get("dilation"), base_dl, 1)
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            cols: List[float] = []
+            for s in data_incs:
+                cols += self._to_list1d(getattr(s.source, "tensor", []))
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            cols = self._to_list1d(x)
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        kk = max(1, ksize * ksize)
+        L = len(cols) // kk if len(cols) >= kk else 0
+        if torch is not None and L > 0:
+            try:
+                ct = torch.tensor(cols[: L * kk], dtype=torch.float32, device=device).view(1, 1 * kk, L)
+                y = torch.nn.functional.fold(ct, output_size=(out_h, out_w), kernel_size=(ksize, ksize), dilation=(dilation, dilation), padding=(padding, padding), stride=(stride, stride))
+                y = y.view(-1)
+                try:
+                    report("neuron", "fold2d", {"outHW": [out_h, out_w], "in_cols": L, "k": ksize, "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        if L <= 0:
+            return neuron._ensure_tensor([]) if hasattr(neuron, "_ensure_tensor") else []
+        out = [[0.0 for _ in range(out_w)] for _ in range(out_h)]
+        idx = 0
+        def npos(size):
+            cnt = 0
+            pos = 0
+            span = (ksize - 1) * dilation + 1
+            while pos + span <= size:
+                cnt += 1
+                pos += stride
+            return cnt
+        nh = npos(out_h)
+        nw = npos(out_w)
+        total = nh * nw
+        used = min(L, total)
+        for oy in range(nh):
+            base_y = oy * stride
+            for ox in range(nw):
+                if idx >= used:
+                    break
+                base_x = ox * stride
+                for ky in range(ksize):
+                    for kx in range(ksize):
+                        iy = base_y + ky * dilation
+                        ix = base_x + kx * dilation
+                        if 0 <= iy < out_h and 0 <= ix < out_w:
+                            out[iy][ix] += cols[idx * kk + ky * ksize + kx]
+                idx += 1
+        flat = [v for row in out for v in row]
+        try:
+            report("neuron", "fold2d", {"outHW": [out_h, out_w], "in_cols": used, "k": ksize, "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+        except Exception:
+            pass
+        return neuron._ensure_tensor(flat)
+
 
 __all__ = ["Fold2DNeuronPlugin"]
 

--- a/marble/plugins/maxpool1d.py
+++ b/marble/plugins/maxpool1d.py
@@ -1,8 +1,100 @@
 from __future__ import annotations
-from ..marblemain import MaxPool1DNeuronPlugin as _Base
 
-class MaxPool1DNeuronPlugin(_Base):
-    pass
+from typing import List
+
+from ..reporter import report
+from .conv1d import Conv1DNeuronPlugin
+
+
+class MaxPool1DNeuronPlugin(Conv1DNeuronPlugin):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 3 or len(out) != 1:
+            raise ValueError(
+                f"MaxPool1D neuron requires exactly 3 incoming PARAM synapses (kernel,stride,padding) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "maxpool1d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 3:
+            raise ValueError("MaxPool1D requires 3 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src = [s.source for s in param_incs[:3]]
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        lk = lstore.get("kernel_size")
+        ls = lstore.get("stride")
+        lp = lstore.get("padding")
+        try:
+            ksize = int(max(1, round(float(lk.detach().to("cpu").view(-1)[0].item())))) if hasattr(lk, "detach") else int(max(1, round(base_ks)))
+        except Exception:
+            ksize = int(max(1, round(base_ks)))
+        try:
+            stride = int(max(1, round(float(ls.detach().to("cpu").view(-1)[0].item())))) if hasattr(ls, "detach") else int(max(1, round(base_st)))
+        except Exception:
+            stride = int(max(1, round(base_st)))
+        try:
+            padding = int(max(0, round(float(lp.detach().to("cpu").view(-1)[0].item())))) if hasattr(lp, "detach") else int(max(0, round(base_pd)))
+        except Exception:
+            padding = int(max(0, round(base_pd)))
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            x1: List[float] = []
+            for s in data_incs:
+                x1 += self._to_list1d(getattr(s.source, "tensor", []))
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            x1 = self._to_list1d(x)
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None:
+            try:
+                xt = torch.tensor(x1, dtype=torch.float32, device=device).view(1, 1, -1)
+                y = torch.nn.functional.max_pool1d(xt, kernel_size=ksize, stride=stride, padding=padding)
+                y = y.view(-1)
+                try:
+                    report("neuron", "maxpool1d", {"in": int(xt.numel()), "out": int(y.numel()), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        if padding > 0:
+            x1 = ([float("-inf")] * padding) + x1 + ([float("-inf")] * padding)
+        n = len(x1)
+        out_len = 0 if n < ksize else 1 + (n - ksize) // stride
+        y_list = []
+        for t in range(out_len):
+            base = t * stride
+            y_list.append(max(x1[base: base + ksize]))
+        try:
+            report("neuron", "maxpool1d", {"in": len(x1), "out": len(y_list), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+        except Exception:
+            pass
+        try:
+            return neuron._ensure_tensor(y_list)
+        except Exception:
+            return y_list
+
 
 __all__ = ["MaxPool1DNeuronPlugin"]
 

--- a/marble/plugins/maxpool2d.py
+++ b/marble/plugins/maxpool2d.py
@@ -1,8 +1,136 @@
 from __future__ import annotations
-from ..marblemain import MaxPool2DNeuronPlugin as _Base
 
-class MaxPool2DNeuronPlugin(_Base):
-    pass
+import math
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class MaxPool2DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 3 or len(out) != 1:
+            raise ValueError(
+                f"MaxPool2D neuron requires exactly 3 incoming PARAM synapses (kernel,stride,padding) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "maxpool2d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 3:
+            raise ValueError("MaxPool2D requires 3 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src = [s.source for s in param_incs[:3]]
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        lk = lstore.get("kernel_size")
+        ls = lstore.get("stride")
+        lp = lstore.get("padding")
+        try:
+            ksize = int(max(1, round(float(lk.detach().to("cpu").view(-1)[0].item())))) if hasattr(lk, "detach") else int(max(1, round(base_ks)))
+        except Exception:
+            ksize = int(max(1, round(base_ks)))
+        try:
+            stride = int(max(1, round(float(ls.detach().to("cpu").view(-1)[0].item())))) if hasattr(ls, "detach") else int(max(1, round(base_st)))
+        except Exception:
+            stride = int(max(1, round(base_st)))
+        try:
+            padding = int(max(0, round(float(lp.detach().to("cpu").view(-1)[0].item())))) if hasattr(lp, "detach") else int(max(0, round(base_pd)))
+        except Exception:
+            padding = int(max(0, round(base_pd)))
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            rows = [self._to_list1d(getattr(s.source, "tensor", [])) for s in data_incs]
+            width = min((len(r) for r in rows if r), default=0)
+            if width <= 0:
+                x_vals: List[float] = []
+                H = W = 0
+            else:
+                rows = [r[:width] for r in rows]
+                H = len(rows)
+                W = width
+                x_vals = [v for r in rows for v in r]
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            x_vals = self._to_list1d(x)
+            N = max(1, len(x_vals))
+            rh = int(math.isqrt(N))
+            if rh * rh == N:
+                H = W = rh
+            else:
+                H, W = N, 1
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and H > 0 and W > 0:
+            try:
+                xt = torch.tensor(x_vals, dtype=torch.float32, device=device).view(1, 1, H, W)
+                y = torch.nn.functional.max_pool2d(xt, kernel_size=(ksize, ksize), stride=(stride, stride), padding=(padding, padding))
+                y = y.view(-1)
+                try:
+                    report("neuron", "maxpool2d", {"inHW": [H, W], "out": int(y.numel()), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        if H <= 0 or W <= 0:
+            return neuron._ensure_tensor([]) if hasattr(neuron, "_ensure_tensor") else []
+        if padding > 0:
+            padded: List[List[float]] = []
+            zero_row = [float("-inf")] * (W + 2 * padding)
+            for _ in range(padding):
+                padded.append(list(zero_row))
+            for r_ in range(H):
+                row = [float("-inf")] * padding + x_vals[r_ * W:(r_ + 1) * W] + [float("-inf")] * padding
+                padded.append(row)
+            for _ in range(padding):
+                padded.append(list(zero_row))
+            H2, W2 = len(padded), len(padded[0])
+        else:
+            padded = [x_vals[r_ * W:(r_ + 1) * W] for r_ in range(H)]
+            H2, W2 = H, W
+        out_h = 0 if H2 < ksize else 1 + (H2 - ksize) // stride
+        out_w = 0 if W2 < ksize else 1 + (W2 - ksize) // stride
+        y2 = []
+        for oy in range(out_h):
+            base_y = oy * stride
+            for ox in range(out_w):
+                base_x = ox * stride
+                m = float("-inf")
+                for ky in range(ksize):
+                    for kx in range(ksize):
+                        vy = padded[base_y + ky][base_x + kx]
+                        if vy > m:
+                            m = vy
+                y2.append(m)
+        try:
+            report("neuron", "maxpool2d", {"inHW": [H, W], "out": len(y2), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+        except Exception:
+            pass
+        try:
+            return neuron._ensure_tensor(y2)
+        except Exception:
+            return y2
+
 
 __all__ = ["MaxPool2DNeuronPlugin"]
 

--- a/marble/plugins/maxpool3d.py
+++ b/marble/plugins/maxpool3d.py
@@ -1,8 +1,151 @@
 from __future__ import annotations
-from ..marblemain import MaxPool3DNeuronPlugin as _Base
 
-class MaxPool3DNeuronPlugin(_Base):
-    pass
+import math
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class MaxPool3DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 3 or len(out) != 1:
+            raise ValueError(
+                f"MaxPool3D neuron requires exactly 3 incoming PARAM synapses (kernel,stride,padding) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "maxpool3d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 3:
+            raise ValueError("MaxPool3D requires 3 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src = [s.source for s in param_incs[:3]]
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        lk = lstore.get("kernel_size")
+        ls = lstore.get("stride")
+        lp = lstore.get("padding")
+        try:
+            ksize = int(max(1, round(float(lk.detach().to("cpu").view(-1)[0].item())))) if hasattr(lk, "detach") else int(max(1, round(base_ks)))
+        except Exception:
+            ksize = int(max(1, round(base_ks)))
+        try:
+            stride = int(max(1, round(float(ls.detach().to("cpu").view(-1)[0].item())))) if hasattr(ls, "detach") else int(max(1, round(base_st)))
+        except Exception:
+            stride = int(max(1, round(base_st)))
+        try:
+            padding = int(max(0, round(float(lp.detach().to("cpu").view(-1)[0].item())))) if hasattr(lp, "detach") else int(max(0, round(base_pd)))
+        except Exception:
+            padding = int(max(0, round(base_pd)))
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            slices = []
+            dims = []
+            for s in data_incs:
+                vals = self._to_list1d(getattr(s.source, "tensor", []))
+                N = max(1, len(vals))
+                r = int(math.isqrt(N))
+                if r * r == N:
+                    H = W = r
+                else:
+                    H, W = N, 1
+                dims.append((H, W))
+                slices.append(vals[: H * W])
+            Hmin = min((h for h, _ in dims), default=0)
+            Wmin = min((w for _, w in dims), default=0)
+            x_vals: List[float] = []
+            D = len(slices)
+            for sl, (h, w) in zip(slices, dims):
+                for rr in range(Hmin):
+                    row = sl[rr * w:(rr + 1) * w]
+                    x_vals.extend(row[:Wmin])
+            H, W = Hmin, Wmin
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            vals = self._to_list1d(x)
+            N = max(1, len(vals))
+            r3 = round(N ** (1.0 / 3.0))
+            if r3 > 0 and (r3 * r3 * r3) == N:
+                D = H = W = int(r3)
+                x_vals = vals[: D * H * W]
+            else:
+                D, H, W = N, 1, 1
+                x_vals = vals
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and H > 0 and W > 0:
+            try:
+                xt = torch.tensor(x_vals, dtype=torch.float32, device=device).view(1, 1, D, H, W)
+                y = torch.nn.functional.max_pool3d(xt, kernel_size=(ksize, ksize, ksize), stride=(stride, stride, stride), padding=(padding, padding, padding))
+                y = y.view(-1)
+                try:
+                    report("neuron", "maxpool3d", {"inDHW": [D, H, W], "out": int(y.numel()), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        if padding > 0 and H > 0 and W > 0:
+            D2, H2, W2 = D + 2 * padding, H + 2 * padding, W + 2 * padding
+            padval = float("-inf")
+            padded = [padval] * (D2 * H2 * W2)
+            for dz in range(D):
+                for yy in range(H):
+                    for xx in range(W):
+                        pd = dz + padding
+                        py = yy + padding
+                        px = xx + padding
+                        padded[pd * (H2 * W2) + py * W2 + px] = x_vals[dz * (H * W) + yy * W + xx]
+        else:
+            padded = list(x_vals)
+            D2, H2, W2 = D, H, W
+        out_d = 0 if D2 < ksize else 1 + (D2 - ksize) // stride
+        out_h = 0 if H2 < ksize else 1 + (H2 - ksize) // stride
+        out_w = 0 if W2 < ksize else 1 + (W2 - ksize) // stride
+        y_list = []
+        for od in range(out_d):
+            base_d = od * stride
+            for oy in range(out_h):
+                base_y = oy * stride
+                for ox in range(out_w):
+                    base_x = ox * stride
+                    m = float("-inf")
+                    for kz in range(ksize):
+                        for ky in range(ksize):
+                            for kx in range(ksize):
+                                val = padded[(base_d + kz) * (H2 * W2) + (base_y + ky) * W2 + (base_x + kx)]
+                                if val > m:
+                                    m = val
+                    y_list.append(m)
+        try:
+            report("neuron", "maxpool3d", {"inDHW": [D, H, W], "out": len(y_list), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+        except Exception:
+            pass
+        try:
+            return neuron._ensure_tensor(y_list)
+        except Exception:
+            return y_list
+
 
 __all__ = ["MaxPool3DNeuronPlugin"]
 

--- a/marble/plugins/maxunpool1d.py
+++ b/marble/plugins/maxunpool1d.py
@@ -1,8 +1,72 @@
 from __future__ import annotations
-from ..marblemain import MaxUnpool1DNeuronPlugin as _Base
 
-class MaxUnpool1DNeuronPlugin(_Base):
-    pass
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class MaxUnpool1DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 3 or len(out) != 1:
+            raise ValueError(
+                f"MaxUnpool1D neuron requires exactly 3 incoming PARAM synapses (kernel,stride,padding) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "maxunpool1d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src = [s.source for s in param_incs[:3]]
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        def to_int(val, default, minv):
+            try:
+                return int(max(minv, round(float(val.detach().to("cpu").view(-1)[0].item())))) if hasattr(val, "detach") else int(max(minv, round(default)))
+            except Exception:
+                return int(max(minv, round(default)))
+        ksize = to_int(lstore.get("kernel_size"), base_ks, 1)
+        stride = to_int(lstore.get("stride"), base_st, 1)
+        padding = to_int(lstore.get("padding"), base_pd, 0)
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        data_incs.sort(key=self._key_src)
+        vals = self._to_list1d(getattr(data_incs[0].source, "tensor", [])) if len(data_incs) >= 1 else self._to_list1d(input_value)
+        idxs = self._to_list1d(getattr(data_incs[1].source, "tensor", [])) if len(data_incs) >= 2 else []
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and vals and str(device) == "cuda":
+            try:
+                vt = torch.tensor(vals, dtype=torch.float32, device=device).view(1, 1, -1)
+                it = torch.tensor([int(i) for i in idxs[: len(vals)]], dtype=torch.long, device=device).view(1, 1, -1)
+                out_len = (vt.shape[-1] - 1) * stride - 2 * padding + ksize
+                y = torch.nn.functional.max_unpool1d(vt, it, kernel_size=ksize, stride=stride, padding=padding, output_size=(1, 1, int(out_len)))
+                y = y.view(-1)
+                try:
+                    report("neuron", "maxunpool1d", {"in": int(vt.numel()), "out": int(y.numel()), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+        return neuron._ensure_tensor(vals)
+
 
 __all__ = ["MaxUnpool1DNeuronPlugin"]
 

--- a/marble/plugins/maxunpool2d.py
+++ b/marble/plugins/maxunpool2d.py
@@ -1,8 +1,84 @@
 from __future__ import annotations
-from ..marblemain import MaxUnpool2DNeuronPlugin as _Base
 
-class MaxUnpool2DNeuronPlugin(_Base):
-    pass
+import math
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class MaxUnpool2DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 3 or len(out) != 1:
+            raise ValueError(
+                f"MaxUnpool2D neuron requires exactly 3 incoming PARAM synapses (kernel,stride,padding) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "maxunpool2d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src = [s.source for s in param_incs[:3]]
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        def to_int(val, default, minv):
+            try:
+                return int(max(minv, round(float(val.detach().to("cpu").view(-1)[0].item())))) if hasattr(val, "detach") else int(max(minv, round(default)))
+            except Exception:
+                return int(max(minv, round(default)))
+        ksize = to_int(lstore.get("kernel_size"), base_ks, 1)
+        stride = to_int(lstore.get("stride"), base_st, 1)
+        padding = to_int(lstore.get("padding"), base_pd, 0)
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        data_incs.sort(key=self._key_src)
+        vals: List[float] = []
+        idxs: List[float] = []
+        if len(data_incs) >= 1:
+            vals = self._to_list1d(getattr(data_incs[0].source, "tensor", []))
+        if len(data_incs) >= 2:
+            idxs = self._to_list1d(getattr(data_incs[1].source, "tensor", []))
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and vals and str(device) == "cuda":
+            try:
+                N = len(vals)
+                r = int(math.isqrt(N))
+                if r * r == N:
+                    H = W = r
+                else:
+                    H, W = N, 1
+                vt = torch.tensor(vals, dtype=torch.float32, device=device).view(1, 1, H, W)
+                it = torch.tensor([int(i) for i in idxs[: len(vals)]], dtype=torch.long, device=device).view(1, 1, H, W)
+                out_h = (H - 1) * stride - 2 * padding + ksize
+                out_w = (W - 1) * stride - 2 * padding + ksize
+                y = torch.nn.functional.max_unpool2d(vt, it, kernel_size=(ksize, ksize), stride=(stride, stride), padding=(padding, padding), output_size=(1, 1, int(out_h), int(out_w)))
+                y = y.view(-1)
+                try:
+                    report("neuron", "maxunpool2d", {"inHW": [H, W], "out": int(y.numel()), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+        return neuron._ensure_tensor(vals)
+
 
 __all__ = ["MaxUnpool2DNeuronPlugin"]
 

--- a/marble/plugins/maxunpool3d.py
+++ b/marble/plugins/maxunpool3d.py
@@ -1,8 +1,88 @@
 from __future__ import annotations
-from ..marblemain import MaxUnpool3DNeuronPlugin as _Base
 
-class MaxUnpool3DNeuronPlugin(_Base):
-    pass
+import math
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class MaxUnpool3DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 3 or len(out) != 1:
+            raise ValueError(
+                f"MaxUnpool3D neuron requires exactly 3 incoming PARAM synapses (kernel,stride,padding) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "maxunpool3d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src = [s.source for s in param_incs[:3]]
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        def to_int(val, default, minv):
+            try:
+                return int(max(minv, round(float(val.detach().to("cpu").view(-1)[0].item())))) if hasattr(val, "detach") else int(max(minv, round(default)))
+            except Exception:
+                return int(max(minv, round(default)))
+        ksize = to_int(lstore.get("kernel_size"), base_ks, 1)
+        stride = to_int(lstore.get("stride"), base_st, 1)
+        padding = to_int(lstore.get("padding"), base_pd, 0)
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        data_incs.sort(key=self._key_src)
+        vals: List[float] = []
+        idxs: List[float] = []
+        if len(data_incs) >= 1:
+            vals = self._to_list1d(getattr(data_incs[0].source, "tensor", []))
+        if len(data_incs) >= 2:
+            idxs = self._to_list1d(getattr(data_incs[1].source, "tensor", []))
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and vals:
+            try:
+                N = len(vals)
+                r = int(round(N ** (1.0 / 3.0)))
+                if r > 0 and r * r * r == N:
+                    D = H = W = r
+                else:
+                    D, H, W = N, 1, 1
+                vt = torch.tensor(vals, dtype=torch.float32, device=device).view(1, 1, D, H, W)
+                it = torch.tensor([int(i) for i in idxs[: len(vals)]], dtype=torch.long, device=device).view(1, 1, D, H, W)
+                out_d = (D - 1) * stride - 2 * padding + ksize
+                out_h = (H - 1) * stride - 2 * padding + ksize
+                out_w = (W - 1) * stride - 2 * padding + ksize
+                y = torch.nn.functional.max_unpool3d(
+                    vt, it, kernel_size=(ksize, ksize, ksize), stride=(stride, stride, stride), padding=(padding, padding, padding),
+                    output_size=(1, 1, int(out_d), int(out_h), int(out_w))
+                )
+                y = y.view(-1)
+                try:
+                    report("neuron", "maxunpool3d", {"inDHW": [D, H, W], "out": int(y.numel()), "k": ksize, "stride": stride, "pad": padding}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+        return neuron._ensure_tensor(vals)
+
 
 __all__ = ["MaxUnpool3DNeuronPlugin"]
 

--- a/marble/plugins/unfold2d.py
+++ b/marble/plugins/unfold2d.py
@@ -1,8 +1,130 @@
 from __future__ import annotations
-from ..marblemain import Unfold2DNeuronPlugin as _Base
 
-class Unfold2DNeuronPlugin(_Base):
-    pass
+import math
+from typing import List
+
+from ..reporter import report
+from .conv_common import _ConvNDCommon
+
+
+class Unfold2DNeuronPlugin(_ConvNDCommon):
+    def on_init(self, neuron: "Neuron") -> None:
+        inc = list(getattr(neuron, "incoming", []) or [])
+        out = list(getattr(neuron, "outgoing", []) or [])
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in inc if is_param(s)]
+        if len(param_incs) != 4 or len(out) != 1:
+            raise ValueError(
+                f"Unfold2D neuron requires exactly 4 incoming PARAM synapses (kernel,stride,padding,dilation) and exactly 1 outgoing; got params={len(param_incs)} out={len(out)}"
+            )
+        try:
+            report("neuron", "unfold2d_init", {"incoming_params": len(param_incs), "outgoing": len(out)}, "plugins")
+        except Exception:
+            pass
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        incoming = list(getattr(neuron, "incoming", []))
+        def is_param(s):
+            t = getattr(s, "type_name", None)
+            return isinstance(t, str) and t.startswith("param")
+        param_incs = [s for s in incoming if is_param(s)]
+        if len(param_incs) < 4:
+            raise ValueError("Unfold2D requires 4 incoming PARAM synapses")
+        param_incs.sort(key=self._key_src)
+        k_src, s_src, p_src, d_src = [s.source for s in param_incs[:4]]
+        base_ks = self._first_scalar(getattr(k_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_st = self._first_scalar(getattr(s_src, "tensor", 2.0), default=2.0, min_val=1.0)
+        base_pd = self._first_scalar(getattr(p_src, "tensor", 0.0), default=0.0)
+        base_dl = self._first_scalar(getattr(d_src, "tensor", 1.0), default=1.0, min_val=1.0)
+        lstore = getattr(neuron, "_plugin_state", {}).get("learnable_params", {})
+        lk = lstore.get("kernel_size")
+        ls = lstore.get("stride")
+        lp = lstore.get("padding")
+        ld = lstore.get("dilation")
+        def to_int(val, default, minv):
+            try:
+                return int(max(minv, round(float(val.detach().to("cpu").view(-1)[0].item())))) if hasattr(val, "detach") else int(max(minv, round(default)))
+            except Exception:
+                return int(max(minv, round(default)))
+        ksize = to_int(lk, base_ks, 1)
+        stride = to_int(ls, base_st, 1)
+        padding = to_int(lp, base_pd, 0)
+        dilation = to_int(ld, base_dl, 1)
+
+        data_incs = [s for s in incoming if getattr(s, "type_name", None) == "data"]
+        if data_incs:
+            data_incs.sort(key=self._key_src)
+            rows = [self._to_list1d(getattr(s.source, "tensor", [])) for s in data_incs]
+            width = min((len(r) for r in rows if r), default=0)
+            if width <= 0:
+                x_vals: List[float] = []
+                H = W = 0
+            else:
+                rows = [r[:width] for r in rows]
+                H = len(rows)
+                W = width
+                x_vals = [v for r in rows for v in r]
+        else:
+            x = input_value if input_value is not None else getattr(neuron, "tensor", [])
+            x_vals = self._to_list1d(x)
+            N = max(1, len(x_vals))
+            r = int(math.isqrt(N))
+            if r * r == N:
+                H = W = r
+            else:
+                H, W = N, 1
+
+        torch = getattr(neuron, "_torch", None)
+        device = getattr(neuron, "_device", "cpu")
+        if torch is not None and H > 0 and W > 0:
+            try:
+                xt = torch.tensor(x_vals, dtype=torch.float32, device=device).view(1, 1, H, W)
+                y = torch.nn.functional.unfold(xt, kernel_size=(ksize, ksize), dilation=(dilation, dilation), padding=(padding, padding), stride=(stride, stride))
+                y = y.view(-1)
+                try:
+                    report("neuron", "unfold2d", {"inHW": [H, W], "out": int(y.numel()), "k": ksize, "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+                except Exception:
+                    pass
+                return y
+            except Exception:
+                pass
+
+        if H <= 0 or W <= 0:
+            return neuron._ensure_tensor([]) if hasattr(neuron, "_ensure_tensor") else []
+        if padding > 0:
+            padded = []
+            zero_row = [0.0] * (W + 2 * padding)
+            for _ in range(padding):
+                padded.append(list(zero_row))
+            for r_ in range(H):
+                row = [0.0] * padding + x_vals[r_ * W:(r_ + 1) * W] + [0.0] * padding
+                padded.append(row)
+            for _ in range(padding):
+                padded.append(list(zero_row))
+            H2, W2 = len(padded), len(padded[0])
+        else:
+            padded = [x_vals[r_ * W:(r_ + 1) * W] for r_ in range(H)]
+            H2, W2 = H, W
+        out_h = 0 if H2 < ((ksize - 1) * dilation + 1) else 1 + (H2 - ((ksize - 1) * dilation + 1)) // stride
+        out_w = 0 if W2 < ((ksize - 1) * dilation + 1) else 1 + (W2 - ((ksize - 1) * dilation + 1)) // stride
+        cols: List[float] = []
+        for oy in range(out_h):
+            base_y = oy * stride
+            for ox in range(out_w):
+                base_x = ox * stride
+                for ky in range(ksize):
+                    for kx in range(ksize):
+                        iy = base_y + ky * dilation
+                        ix = base_x + kx * dilation
+                        cols.append(padded[iy][ix])
+        try:
+            report("neuron", "unfold2d", {"inHW": [H, W], "out": len(cols), "k": ksize, "stride": stride, "pad": padding, "dil": dilation}, "plugins")
+        except Exception:
+            pass
+        return neuron._ensure_tensor(cols)
+
 
 __all__ = ["Unfold2DNeuronPlugin"]
 

--- a/marble/plugins/wanderer_altpaths.py
+++ b/marble/plugins/wanderer_altpaths.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, List
 
-from ..wanderer import register_wanderer_type
 from ..reporter import report
 
 
@@ -80,11 +79,5 @@ class AlternatePathsCreatorPlugin:
             wanderer._plugin_state["altpaths_created"] = created + 1
         except Exception:
             pass
-
-
-try:
-    register_wanderer_type("alternatepathscreator", AlternatePathsCreatorPlugin())
-except Exception:
-    pass
 
 __all__ = ["AlternatePathsCreatorPlugin"]

--- a/marble/plugins/wanderer_bestpath.py
+++ b/marble/plugins/wanderer_bestpath.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, List, Tuple
 
-from ..wanderer import register_wanderer_type
 from ..reporter import report
 
 
@@ -86,11 +85,5 @@ class BestLossPathPlugin:
             except Exception:
                 pass
         return None, "forward"
-
-
-try:
-    register_wanderer_type("bestlosspath", BestLossPathPlugin())
-except Exception:
-    pass
 
 __all__ = ["BestLossPathPlugin"]

--- a/marble/plugins/wanderer_contrastive_infonce.py
+++ b/marble/plugins/wanderer_contrastive_infonce.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, List
 
-from ..wanderer import register_wanderer_type
-
 
 class ContrastiveInfoNCEPlugin:
     """Adds an InfoNCE-style contrastive loss across walk outputs.
@@ -52,11 +50,5 @@ class ContrastiveInfoNCEPlugin:
         if not loss_terms:
             return torch.tensor(0.0, device=dev)
         return w * (torch.stack(loss_terms).mean())
-
-
-try:
-    register_wanderer_type("contrastive_infonce", ContrastiveInfoNCEPlugin())
-except Exception:
-    pass
 
 __all__ = ["ContrastiveInfoNCEPlugin"]

--- a/marble/plugins/wanderer_distillation.py
+++ b/marble/plugins/wanderer_distillation.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Optional, List
 
-from ..wanderer import register_wanderer_type
-
 
 class DistillationPlugin:
     """Adds a simple distillation loss to match a moving-average 'teacher' of outputs.
@@ -42,11 +40,5 @@ class DistillationPlugin:
             ema = self._ema
             yv = yt
         return lam * ((yv - ema).pow(2).mean())
-
-
-try:
-    register_wanderer_type("distillation", DistillationPlugin())
-except Exception:
-    pass
 
 __all__ = ["DistillationPlugin"]

--- a/marble/plugins/wanderer_hyperevolution.py
+++ b/marble/plugins/wanderer_hyperevolution.py
@@ -1,17 +1,591 @@
 from __future__ import annotations
 
-from ..marblemain import HyperEvolutionPlugin as _Base
-from ..wanderer import register_wanderer_type
+from typing import Any, Dict, List, Tuple
+
+from ..wanderer import WANDERER_TYPES_REGISTRY as _WANDERER_TYPES, NEURO_TYPES_REGISTRY as _NEURO_TYPES
+from ..marblemain import _PARADIGM_TYPES
 
 
-class HyperEvolutionPlugin(_Base):
-    pass
+class HyperEvolutionPlugin:
+    """Evolutionary architecture search over plugin stacks and parameters without cloning the brain.
+
+    Modes (via `wanderer._neuro_cfg['hyper_evo_mode']`):
+    - "per_walk" (default): before the first training walk, run `hyper_evo_steps` evolution steps
+      using temporary changes and full rollback per step. After finishing, configure the best
+      architecture, deactivate this plugin, and proceed with normal training.
+    - "per_step": at the beginning of each training step, run `hyper_evo_steps` evolution steps,
+      configure the best architecture so far, then continue the step. This lets the search continue
+      during training.
+
+    Config (via `wanderer._neuro_cfg`):
+      - hyper_evo_steps (int, default 50): evolution steps per run
+      - hyper_eval_steps (int, default 3): bounded evaluation walk steps (with lr=0)
+      - hyper_evo_mode (str, default "per_walk"): "per_walk" | "per_step"
+
+    This search mutates across all registered plugin families (wanderer, neuroplasticity, paradigms)
+    and any numeric parameters present in `wanderer._neuro_cfg`. No plugins or parameters are excluded.
+    Each evolution step applies a temporary mutation, performs a short evaluation walk (lr=0) to get
+    loss and speed metrics, and then rolls back every change unless both metrics improved; accepted
+    mutations are accumulated into the current best genome. At the end of the run, the best genome is
+    applied persistently (no temporary stacks), and this plugin deactivates itself in per_walk mode.
+    """
+
+    def on_init(self, wanderer: "Wanderer") -> None:
+        state = getattr(wanderer, "_plugin_state", None)
+        if state is None:
+            wanderer._plugin_state = {}
+            state = wanderer._plugin_state
+        state.setdefault("hyper", {
+            "gen": 0,
+            "pop": [],  # legacy fields retained (not used by new evo loop)
+            "idx": 0,
+            "last_handle": None,
+            "last_paradigms": None,
+            "best": None,
+            "best_score": None,
+            "best_loss": None,
+            "best_speed": None,
+            "done": False,
+            "disabled": False,
+        })
+        if not state["hyper"]["pop"]:
+            self._init_population(wanderer)
+
+    def _init_population(self, wanderer: "Wanderer") -> None:
+        cfg = getattr(wanderer, "_neuro_cfg", {}) or {}
+        pop_size = int(cfg.get("hyper_pop", 8))
+        import random as _r
+        pop = []
+        wnames = list(_WANDERER_TYPES.keys())
+        nnames = list(_NEURO_TYPES.keys())
+        pnames = list(_PARADIGM_TYPES.keys()) if '_PARADIGM_TYPES' in globals() else []
+        for _ in range(pop_size):
+            genome = {
+                "w": _r.sample(wnames, k=min(len(wnames), _r.randint(0, min(3, len(wnames))))) if wnames else [],
+                "n": _r.sample(nnames, k=min(len(nnames), _r.randint(0, min(2, len(nnames))))) if nnames else [],
+                "p": _r.sample(pnames, k=min(len(pnames), _r.randint(0, min(2, len(pnames))))) if pnames else [],
+                "cfg": {},
+                "score": None,
+            }
+            # Ensure at least one wanderer plugin is present to make evolution impactful.
+            if not genome["w"] and wnames:
+                try:
+                    genome["w"] = [_r.choice(wnames)]
+                except Exception:
+                    pass
+            # Encourage at least one paradigm to be active for diversity
+            if not genome["p"] and pnames:
+                try:
+                    genome["p"] = [_r.choice(pnames)]
+                except Exception:
+                    pass
+            pop.append(genome)
+        # Seed population with a strong, commonly useful combination if available
+        try:
+            if wnames and ("bestlosspath" in wnames) and ("wanderalongsynapseweights" in wnames):
+                pop[0] = {
+                    "w": ["bestlosspath", "wanderalongsynapseweights"],
+                    "n": [],
+                    "p": [],
+                    "cfg": {},
+                    "score": None,
+                }
+        except Exception:
+            pass
 
 
-try:
-    register_wanderer_type("hyperEvolution", HyperEvolutionPlugin())
-except Exception:
-    pass
+        wanderer._plugin_state["hyper"]["pop"] = pop
+        wanderer._plugin_state["hyper"]["idx"] = 0
+
+    def before_walk(self, wanderer: "Wanderer", start: "Neuron") -> None:
+        # Run evolution per mode and apply the best architecture if needed
+        st = wanderer._plugin_state["hyper"]
+        if st.get("disabled"):
+            return
+        cfg = getattr(wanderer, "_neuro_cfg", {}) or {}
+        mode = str(cfg.get("hyper_evo_mode", "per_walk")).lower()
+        steps = int(cfg.get("hyper_evo_steps", 50))
+        if mode == "per_walk" and not st.get("done"):
+            self._run_evolution(wanderer, start, steps)
+            self._apply_best_persistently(wanderer)
+            st["done"] = True
+            st["disabled"] = True
+            return
+
+        # Legacy selection/apply path retained for compatibility
+        pop = st["pop"]
+        if not pop:
+            self._init_population(wanderer)
+            pop = st["pop"]
+        # Selection strategy: exploit best-so-far or explore via tournament
+        import random as _r
+        idx = 0
+        try:
+            # Identify scored genomes
+            scored = [(i, float(g.get("score_avg", g.get("score", float("inf"))))) for i, g in enumerate(pop)]
+            scored = [(i, s) for (i, s) in scored if s != float("inf")]
+            best_idx = st.get("best_idx")
+            if scored:
+                # Track current best
+                scored.sort(key=lambda t: t[1])
+                current_best_idx = scored[0][0]
+                st["best_idx"] = current_best_idx
+                # Epsilon-greedy: mostly exploit best, sometimes explore
+                eps = 0.3
+                if best_idx is not None and _r.random() > eps:
+                    idx = int(best_idx)
+                else:
+                    # Tournament among a random subset
+                    k = max(2, min(5, len(pop)))
+                    cand = _r.sample(range(len(pop)), k=k)
+                    # Rank by available scores, unknown treated as mid-rank
+                    def score_of(i):
+                        g = pop[i]
+                        s = g.get("score_avg", g.get("score"))
+                        return float(s) if s is not None else float("inf")
+                    idx = min(cand, key=score_of)
+            else:
+                # No scores yet: random selection
+                idx = _r.randrange(0, len(pop))
+        except Exception:
+            idx = 0
+        st["idx"] = idx
+        genome = pop[idx]
+        # Apply stacks
+        handle = push_temporary_plugins(wanderer, wanderer_types=genome.get("w"), neuro_types=genome.get("n"))
+        st["last_handle"] = handle
+        # Toggle paradigms: enable selected, disable others previously managed
+        prev = st.get("last_paradigms")
+        act = []
+        try:
+            # disable previous
+            if prev:
+                for nm in prev:
+                    try:
+                        wanderer.brain.enable_paradigm(nm, enabled=False)
+                    except Exception:
+                        pass
+            for nm in genome.get("p", []) or []:
+                try:
+                    wanderer.brain.enable_paradigm(nm, enabled=True)
+                    act.append(nm)
+                except Exception:
+                    pass
+            st["last_paradigms"] = act
+        except Exception:
+            pass
+        # Snapshot current neuro config to isolate genome effects
+        try:
+            st["cfg_prev"] = dict(getattr(wanderer, "_neuro_cfg", {}) or {})
+        except Exception:
+            st["cfg_prev"] = None
+        # Snapshot current LR override if any
+        try:
+            st["lr_prev"] = getattr(wanderer, "lr_override", None)
+        except Exception:
+            st["lr_prev"] = None
+        # Merge any genome cfg params into wanderer._neuro_cfg (restored on walk end)
+        try:
+            for k, v in (genome.get("cfg") or {}).items():
+                wanderer._neuro_cfg[k] = v
+        except Exception:
+            pass
+        # If genome proposes an LR override, apply it (treated like any other evolvable param)
+        try:
+            lr_prop = (genome.get("cfg") or {}).get("lr_override", None)
+            if lr_prop is not None:
+                try:
+                    wanderer.lr_override = float(lr_prop)
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+    def on_step(self, wanderer: "Wanderer", current: "Neuron", syn: "Synapse", direction: str, step_index: int, out_value: Any) -> None:
+        # Per-step mode: run micro evolution before continuing the step
+        st = wanderer._plugin_state.get("hyper", {})
+        if st.get("disabled"):
+            return
+        cfg = getattr(wanderer, "_neuro_cfg", {}) or {}
+        mode = str(cfg.get("hyper_evo_mode", "per_walk")).lower()
+        if mode != "per_step":
+            return
+        steps = int(cfg.get("hyper_evo_steps", 50))
+        self._run_evolution(wanderer, current, steps)
+        self._apply_best_persistently(wanderer)
+        return
+
+    def on_walk_end(self, wanderer: "Wanderer", stats: Dict[str, Any]) -> None:
+        # Evaluate fitness
+        st = wanderer._plugin_state.get("hyper", {})
+        pop = st.get("pop", [])
+        idx = st.get("idx", 0) % (len(pop) if pop else 1)
+        if not pop:
+            return
+        genome = pop[idx]
+        # Compute objectives (used only for legacy population mode)
+        loss = float(stats.get("loss", 0.0))
+        steps = int(stats.get("steps", 0))
+        sm = stats.get("step_metrics", []) or []
+        # per-step time
+        dts = [m.get("dt") for m in sm if m.get("dt") is not None]
+        mean_dt = (sum(dts) / len(dts)) if dts else 0.0
+        # loss decrease speed (positive good): use -avg(delta) truncated at 0
+        deltas = [float(m.get("delta", 0.0)) for m in sm]
+        if deltas:
+            avg_delta = sum(deltas) / len(deltas)
+            speed = max(0.0, -avg_delta)
+        else:
+            speed = 0.0
+        # brain size
+        try:
+            brain_size = len(getattr(wanderer.brain, "neurons", {}))
+        except Exception:
+            brain_size = 0
+        # Score: minimize loss, mean_dt, brain_size; maximize speed => use reciprocal
+        score = (loss) + (mean_dt) + (brain_size * 1e-3) + (1.0 / (1e-6 + speed) if speed > 0 else 1.0)
+        # Update instantaneous and running-average scores for the genome
+        genome["score"] = float(score)
+        try:
+            prev_avg = float(genome.get("score_avg", score))
+            trials = int(genome.get("trials", 0)) + 1
+            new_avg = (prev_avg * (trials - 1) + float(score)) / max(1, trials)
+            genome["score_avg"] = float(new_avg)
+            genome["trials"] = trials
+        except Exception:
+            genome["score_avg"] = float(score)
+            genome["trials"] = 1
+        # Restore stacks
+        try:
+            if st.get("last_handle") is not None:
+                pop_handle = st["last_handle"]
+                pop_temporary_plugins(wanderer, pop_handle)
+                st["last_handle"] = None
+        except Exception:
+            pass
+        # Restore neuro config snapshot
+        try:
+            prev = st.get("cfg_prev", None)
+            if prev is not None:
+                wanderer._neuro_cfg = dict(prev)
+                st["cfg_prev"] = None
+        except Exception:
+            pass
+        # Restore LR override
+        try:
+            if "lr_prev" in st:
+                setattr(wanderer, "lr_override", st.get("lr_prev", None))
+                st["lr_prev"] = None
+        except Exception:
+            pass
+        # Harvest observed neuro_cfg keys to expand future mutation search space
+        try:
+            kb = st.setdefault("key_bank", set())
+            for k in (getattr(wanderer, "_neuro_cfg", {}) or {}).keys():
+                try:
+                    kb.add(str(k))
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+        # Advance and evolve at end of a population cycle (count-based, independent of chosen indices)
+        st["eval_count"] = int(st.get("eval_count", 0)) + 1
+        if st["eval_count"] >= max(1, len(pop)):
+            st["eval_count"] = 0
+            self._evolve(wanderer)
+
+    def _evolve(self, wanderer: "Wanderer") -> None:
+        import random as _r
+        cfg = getattr(wanderer, "_neuro_cfg", {}) or {}
+        # Adaptive mutation rate around configured baseline
+        base_mut = float(cfg.get("hyper_mut", 0.3))
+        st = wanderer._plugin_state["hyper"]
+        cur_mut = float(st.get("mut_rate", base_mut))
+        mut_rate = max(0.05, min(0.8, cur_mut))
+        keep = int(cfg.get("hyper_keep", 2))
+        pop = st["pop"]
+        # Sort by running-average score ascending when available (else instantaneous)
+        pop.sort(key=lambda g: float(g.get("score_avg", g.get("score", float("inf")))))
+        keepers = pop[:max(1, min(keep, len(pop)))]
+        # Track best score to adapt mutation rate
+        try:
+            best_now = float(keepers[0].get("score_avg", keepers[0].get("score", float("inf")))) if keepers else float("inf")
+            last_best = float(st.get("last_best", float("inf")))
+            if best_now < last_best:
+                st["mut_rate"] = max(0.05, mut_rate * 0.9)
+            else:
+                st["mut_rate"] = min(0.8, mut_rate * 1.1)
+            st["last_best"] = best_now
+        except Exception:
+            st["mut_rate"] = mut_rate
+        # Refill
+        wnames = list(_WANDERER_TYPES.keys())
+        nnames = list(_NEURO_TYPES.keys())
+        pnames = list(_PARADIGM_TYPES.keys()) if '_PARADIGM_TYPES' in globals() else []
+        new_pop = []
+        for g in keepers:
+            new_pop.append({"w": list(g["w"]), "n": list(g["n"]), "p": list(g["p"]), "cfg": dict(g.get("cfg") or {}), "score": None, "score_avg": g.get("score_avg"), "trials": g.get("trials")})
+        while len(new_pop) < len(pop):
+            # Crossover (pick two parents)
+            a, b = _r.sample(keepers, k=2) if len(keepers) >= 2 else (keepers[0], keepers[0])
+            child = {
+                "w": list(set(_r.sample(a["w"] + b["w"], k=min(len(a["w"] + b["w"]), _r.randint(0, min(3, len(wnames))))))) if (a["w"] or b["w"]) else [],
+                "n": list(set(_r.sample(a["n"] + b["n"], k=min(len(a["n"] + b["n"]), _r.randint(0, min(2, len(nnames))))))) if (a["n"] or b["n"]) else [],
+                "p": list(set(_r.sample(a["p"] + b["p"], k=min(len(a["p"] + b["p"]), _r.randint(0, min(2, len(pnames))))))) if (a["p"] or b["p"]) else [],
+                "cfg": dict(a.get("cfg") or {}),
+                "score": None,
+            }
+            # Mutate types
+            if _r.random() < mut_rate and wnames:
+                # flip one wanderer plugin
+                choice = _r.choice(wnames)
+                if choice in child["w"]:
+                    child["w"].remove(choice)
+                else:
+                    child["w"].append(choice)
+            if _r.random() < mut_rate and nnames:
+                choice = _r.choice(nnames)
+                if choice in child["n"]:
+                    child["n"].remove(choice)
+                else:
+                    child["n"].append(choice)
+            if _r.random() < mut_rate and pnames:
+                choice = _r.choice(pnames)
+                if choice in child["p"]:
+                    child["p"].remove(choice)
+                else:
+                    child["p"].append(choice)
+        # Mutate generic numeric cfg entries over a broad key bank
+        keys = set((child.get("cfg") or {}).keys())
+        try:
+            keys |= set(getattr(wanderer, "_neuro_cfg", {}).keys())
+        except Exception:
+            pass
+        try:
+            kb = st.get("key_bank")
+            if kb:
+                keys |= set(kb)
+        except Exception:
+            pass
+        # Seed known useful numeric keys into the search space without excluding any others
+        keys.add("lr_override")
+        keys = [k for k in set(keys) if isinstance(k, str)]
+        if keys and _r.random() < mut_rate:
+            k = _r.choice(keys)
+            try:
+                base = float((child.get("cfg", {}).get(k) if k in (child.get("cfg") or {}) else getattr(wanderer, "_neuro_cfg", {}).get(k, 0.0)))
+                scale = 1.0 + ((_r.random() * 2.0 - 1.0) * (0.5 + 0.5 * (mut_rate - 0.05)))
+                child["cfg"][k] = base * scale
+            except Exception:
+                pass
+            new_pop.append(child)
+        st["pop"] = new_pop
+        st["gen"] = st.get("gen", 0) + 1
+        st["idx"] = 0
+
+    # ---------------- Evolution helpers (no cloning, full rollback) ----------------
+    def _snapshot_graph(self, brain: "Brain") -> Dict[str, Any]:
+        try:
+            neurons = set(getattr(brain, "neurons", {}).keys())
+        except Exception:
+            neurons = set()
+        try:
+            syns = list(getattr(brain, "synapses", []) or [])
+            syn_ids = set(id(s) for s in syns)
+            syn_weights = {id(s): float(getattr(s, "weight", 1.0)) for s in syns}
+        except Exception:
+            syn_ids = set()
+            syn_weights = {}
+        return {"neurons": neurons, "syn_ids": syn_ids, "syn_w": syn_weights}
+
+    def _restore_graph(self, brain: "Brain", snap: Dict[str, Any]) -> None:
+        try:
+            # Remove newly added synapses
+            current_syns = list(getattr(brain, "synapses", []) or [])
+            before_ids = snap.get("syn_ids", set())
+            for s in current_syns:
+                if id(s) not in before_ids:
+                    try:
+                        brain.remove_synapse(s)
+                    except Exception:
+                        pass
+            # Remove newly added neurons
+            before_neurons = snap.get("neurons", set())
+            for pos, n in list(getattr(brain, "neurons", {}).items()):
+                if pos not in before_neurons:
+                    try:
+                        brain.remove_neuron(n)
+                    except Exception:
+                        pass
+            # Restore original synapse weights
+            for s in list(getattr(brain, "synapses", []) or []):
+                sid = id(s)
+                if sid in snap.get("syn_w", {}):
+                    try:
+                        s.weight = float(snap["syn_w"][sid])
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+
+    def _apply_genome_temp(self, wanderer: "Wanderer", genome: Dict[str, Any]) -> Dict[str, Any]:
+        # Apply stacks and paradigms temporarily; merge cfg; return a handle for rollback
+        handle = push_temporary_plugins(wanderer, wanderer_types=genome.get("w"), neuro_types=genome.get("n"))
+        prev_cfg = dict(getattr(wanderer, "_neuro_cfg", {}) or {})
+        toggled = []
+        try:
+            for nm in genome.get("p", []) or []:
+                wanderer.brain.enable_paradigm(nm, enabled=True)
+                toggled.append(nm)
+        except Exception:
+            pass
+        try:
+            for k, v in (genome.get("cfg") or {}).items():
+                wanderer._neuro_cfg[k] = v
+        except Exception:
+            pass
+        return {"handle": handle, "cfg_prev": prev_cfg, "paradigms": toggled}
+
+    def _rollback_temp(self, wanderer: "Wanderer", temp: Dict[str, Any]) -> None:
+        try:
+            if temp.get("handle") is not None:
+                pop_temporary_plugins(wanderer, temp["handle"])
+        except Exception:
+            pass
+        try:
+            for nm in temp.get("paradigms", []) or []:
+                wanderer.brain.enable_paradigm(nm, enabled=False)
+        except Exception:
+            pass
+        try:
+            wanderer._neuro_cfg = temp.get("cfg_prev", {})
+        except Exception:
+            pass
+
+    def _short_eval(self, wanderer: "Wanderer", start: "Neuron", max_steps: int) -> Dict[str, float]:
+        # Run a short walk with lr=0 to measure loss and speed proxy; rollback handled by caller
+        stats = {"loss": float("inf"), "speed": 0.0}
+        try:
+            res = wanderer.walk(max_steps=max(1, int(max_steps)), start=start, lr=0.0)
+            # Compute speed proxy from res.step_metrics
+            dts = res.get("step_metrics", []) or []
+            deltas = [float(m.get("delta", 0.0)) for m in dts]
+            speed = max(0.0, - (sum(deltas) / max(1, len(deltas)))) if deltas else 0.0
+            stats = {"loss": float(res.get("loss", 0.0)), "speed": float(speed)}
+        except Exception:
+            pass
+        return stats
+
+    def _mutate(self, genome: Dict[str, Any], wanderer: "Wanderer", rate: float) -> Dict[str, Any]:
+        import random as _r
+        g = {"w": list(genome.get("w", [])), "n": list(genome.get("n", [])), "p": list(genome.get("p", [])), "cfg": dict(genome.get("cfg", {}))}
+        wnames = list(_WANDERER_TYPES.keys())
+        nnames = list(_NEURO_TYPES.keys())
+        pnames = list(_PARADIGM_TYPES.keys()) if '_PARADIGM_TYPES' in globals() else []
+        # With rate, add/remove one plugin from each family (no specific selection bias)
+        if wnames and _r.random() < rate:
+            nm = _r.choice(wnames)
+            if nm in g["w"] and _r.random() < 0.5:
+                g["w"].remove(nm)
+            else:
+                if nm not in g["w"]:
+                    g["w"].append(nm)
+        if nnames and _r.random() < rate:
+            nm = _r.choice(nnames)
+            if nm in g["n"] and _r.random() < 0.5:
+                g["n"].remove(nm)
+            else:
+                if nm not in g["n"]:
+                    g["n"].append(nm)
+        if pnames and _r.random() < rate:
+            nm = _r.choice(pnames)
+            if nm in g["p"] and _r.random() < 0.5:
+                g["p"].remove(nm)
+            else:
+                if nm not in g["p"]:
+                    g["p"].append(nm)
+        # Numeric param tweak: pick an observed key or create a neutral one
+        keys = set(g["cfg"].keys())
+        try:
+            keys |= set((getattr(wanderer, "_neuro_cfg", {}) or {}).keys())
+        except Exception:
+            pass
+        if keys and _r.random() < rate:
+            k = _r.choice(list(keys))
+            try:
+                base = float(g["cfg"].get(k, getattr(wanderer, "_neuro_cfg", {}).get(k, 0.0)))
+                scale = 1.0 + ((_r.random() * 2.0 - 1.0) * 0.5)
+                g["cfg"][k] = base * scale
+            except Exception:
+                pass
+        return g
+
+    def _apply_best_persistently(self, wanderer: "Wanderer") -> None:
+        st = wanderer._plugin_state.get("hyper", {})
+        best = st.get("best")
+        if not best:
+            return
+        try:
+            # Replace stacks
+            wanderer._wplugins = []
+            for nm in best.get("w", []) or []:
+                plug = _WANDERER_TYPES.get(str(nm))
+                if plug is not None:
+                    wanderer._wplugins.append(plug)
+            wanderer._neuro_plugins = []
+            for nm in best.get("n", []) or []:
+                nplug = _NEURO_TYPES.get(str(nm))
+                if nplug is not None:
+                    wanderer._neuro_plugins.append(nplug)
+            # Enable paradigms
+            for nm in best.get("p", []) or []:
+                try:
+                    wanderer.brain.enable_paradigm(nm, enabled=True)
+                except Exception:
+                    pass
+            # Merge cfg
+            for k, v in (best.get("cfg") or {}).items():
+                wanderer._neuro_cfg[k] = v
+        except Exception:
+            pass
+
+    def _run_evolution(self, wanderer: "Wanderer", start: "Neuron", steps: int) -> None:
+        cfg = getattr(wanderer, "_neuro_cfg", {}) or {}
+        eval_steps = int(cfg.get("hyper_eval_steps", 3))
+        mut_rate = float(cfg.get("hyper_mut", 0.3))
+        st = wanderer._plugin_state.get("hyper", {})
+        # Initialize best genome from current stacks and cfg
+        base = {"w": [], "n": [], "p": [], "cfg": dict(cfg)}
+        # Evaluate base
+        base_snap = self._snapshot_graph(wanderer.brain)
+        temp = self._apply_genome_temp(wanderer, base)
+        base_stats = self._short_eval(wanderer, start, eval_steps)
+        self._rollback_temp(wanderer, temp)
+        self._restore_graph(wanderer.brain, base_snap)
+        best = base
+        best_loss = float(base_stats.get("loss", float("inf")))
+        best_speed = float(base_stats.get("speed", 0.0))
+        for _ in range(max(1, int(steps))):
+            cand = self._mutate(best, wanderer, rate=mut_rate)
+            snap = self._snapshot_graph(wanderer.brain)
+            temp = self._apply_genome_temp(wanderer, cand)
+            stats = self._short_eval(wanderer, start, eval_steps)
+            self._rollback_temp(wanderer, temp)
+            self._restore_graph(wanderer.brain, snap)
+            cand_loss = float(stats.get("loss", float("inf")))
+            cand_speed = float(stats.get("speed", 0.0))
+            # Accept only if BOTH metrics improve (strict dominance) per user objective
+            if cand_loss < best_loss and cand_speed > best_speed:
+                best = cand
+                best_loss = cand_loss
+                best_speed = cand_speed
+        # Persist best in plugin state
+        try:
+            st["best"] = best
+            st["best_loss"] = best_loss
+            st["best_speed"] = best_speed
+        except Exception:
+            pass
 
 __all__ = ["HyperEvolutionPlugin"]
-

--- a/marble/plugins/wanderer_l2_penalty.py
+++ b/marble/plugins/wanderer_l2_penalty.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any, List
 
-from ..wanderer import register_wanderer_type
-
 
 class L2WeightPenaltyPlugin:
     """Adds L2 penalty over visited neurons' weights and biases to the loss.
@@ -28,11 +26,5 @@ class L2WeightPenaltyPlugin:
         if total is None:
             return torch.tensor(0.0, device=getattr(wanderer, "_device", "cpu"))
         return lam * total
-
-
-try:
-    register_wanderer_type("l2_weight_penalty", L2WeightPenaltyPlugin())
-except Exception:
-    pass
 
 __all__ = ["L2WeightPenaltyPlugin"]

--- a/marble/plugins/wanderer_td_qlearning.py
+++ b/marble/plugins/wanderer_td_qlearning.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Optional, List, Tuple
 
-from ..wanderer import register_wanderer_type
 from ..reporter import report
 
 
@@ -86,11 +85,5 @@ class TDQLearningPlugin:
             pass
         # Reset last_syn only after applying update once; keep it tied to previous transition
         self._last_syn = next_syn
-
-
-try:
-    register_wanderer_type("td_qlearning", TDQLearningPlugin())
-except Exception:
-    pass
 
 __all__ = ["TDQLearningPlugin"]


### PR DESCRIPTION
## Summary
- move pooling, unpooling, unfold, and fold neuron plugins into standalone modules
- relocate wanderer and brain-training plugin code into their own plugin modules
- document plugin module layout in architecture notes

## Testing
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement` *(fails: RuntimeError: torch is required for Wanderer autograd. Please install CPU torch (or GPU if available) and retry.)*


------
https://chatgpt.com/codex/tasks/task_e_68b0327c986c83278a79b5c728e2e759