### PR TITLE
Add HF streaming quality training example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -389,3 +389,4 @@ Hugging Face Datasets Policy (additive)
 - Auto-encoding fields: Any field accessed from a Hugging Face dataset example returned by project helpers is automatically encoded through `UniversalTensorCodec` before being returned, honoring CUDA preference when available.
 - Token sourcing: `hf_login` reads the token from the explicit parameter or from `HF_TOKEN`/`HUGGINGFACE_TOKEN` environment variables. No interactive prompts are used in tests.
 - Lazy imports: Hugging Face libraries are imported lazily inside helpers in `marble/marblemain.py` to keep import-time requirements minimal; missing dependencies are reported clearly when a helper is used.
+- Example scripts fetching Hugging Face datasets must use `load_hf_streaming_dataset` and comment which dataset fields are consumed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -323,7 +323,7 @@ SelfAttention Integration
   - Neuron-type selection + wiring: SelfAttention exposes `list_neuron_types()` so routines can choose from available neuron types (currently `base` and `conv1d`). Routines MUST perform all wiring themselves when creating special neurons. The framework provides validation only:
     - `validate_neuron_wiring(neuron)`: returns `{ok, reason}`; for `conv1d` it checks exactly 5 incoming synapses and exactly 1 outgoing synapse. Unknown types are considered OK but are logged for visibility. No automatic neuron creation or connection is performed by the framework.
 - Training: `run_wanderer_training`, `run_training_with_datapairs`, `run_wanderer_epochs_with_datapairs`, `run_wanderers_parallel`, `create_start_neuron`.
-- Datasets/Examples: `run_wine_hello_world`, `export_wanderer_steps_to_jsonl`, `examples/run_wine_with_selfattention.py` (adaptive LR via SelfAttention).
+- Datasets/Examples: `run_wine_hello_world`, `export_wanderer_steps_to_jsonl`, `examples/run_wine_with_selfattention.py` (adaptive LR via SelfAttention), `examples/run_hf_image_quality.py` (streamed HF prompt-image quality training).
   - `run_training_with_datapairs` accepts `selfattention` to attach step-wise control to the shared Wanderer.
   - Training helpers accept `gradient_clip` and pass it to the shared `Wanderer`.
 - Reporting: `REPORTER`, `report`, `report_group`, `report_dir`.

--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -1,0 +1,122 @@
+"""Example: Streamed quality training on a Hugging Face dataset.
+
+This script demonstrates how to:
+- Load the Rapidata Imagen preference dataset in streaming mode
+- Derive quality quotients from human preference and alignment scores
+- Train a small Brain with stacked Wanderer plugins and neuroplasticity
+- Employ a custom SelfAttention routine combined with adaptive grad clipping
+
+Usage:
+    py -3 examples/run_hf_image_quality.py
+"""
+
+from __future__ import annotations
+
+import io
+from typing import Iterator
+
+from marble.marblemain import (
+    Brain,
+    UniversalTensorCodec,
+    make_datapair,
+    run_training_with_datapairs,
+    load_hf_streaming_dataset,
+    SelfAttention,
+)
+from marble.plugins.selfattention_adaptive_grad_clip import AdaptiveGradClipRoutine
+
+
+def _img_to_bytes(img) -> bytes:
+    buf = io.BytesIO()
+    try:
+        img.save(buf, format="PNG")
+    except Exception:
+        return b""
+    return buf.getvalue()
+
+
+class QualityAwareRoutine:
+    """Adjust LR based on recent loss trend for stability."""
+
+    def __init__(self, window: int = 8, decay: float = 0.9, grow: float = 1.1) -> None:
+        self.window = int(window)
+        self.decay = float(decay)
+        self.grow = float(grow)
+
+    def after_step(self, sa: SelfAttention, ro, wanderer, step_idx: int, ctx):
+        hist = sa.history(self.window)
+        if len(hist) < 2:
+            return None
+        losses = [h.get("current_loss") for h in hist if isinstance(h.get("current_loss"), (int, float))]
+        if len(losses) < 2:
+            return None
+        prev, cur = losses[-2], losses[-1]
+        base_lr = sa.get_param("lr_override") or sa.get_param("current_lr") or 1e-3
+        try:
+            base_lr = float(base_lr)
+        except Exception:
+            base_lr = 1e-3
+        if cur > prev:
+            new_lr = max(1e-5, base_lr * self.decay)
+        else:
+            new_lr = min(5e-3, base_lr * self.grow)
+        return {"lr_override": float(new_lr)}
+
+
+def _sample_pairs(ds) -> Iterator:
+    for ex in ds:
+        prompt = ex.get_raw("prompt")
+        img1 = _img_to_bytes(ex.get_raw("image1"))
+        img2 = _img_to_bytes(ex.get_raw("image2"))
+        pref1 = float(ex.get_raw("weighted_results_image1_preference"))
+        pref2 = float(ex.get_raw("weighted_results_image2_preference"))
+        al1 = float(ex.get_raw("weighted_results_image1_alignment"))
+        al2 = float(ex.get_raw("weighted_results_image2_alignment"))
+        q1 = (pref1 + al1) / 2.0
+        q2 = (pref2 + al2) / 2.0
+        yield make_datapair({"prompt": prompt, "image": img1}, q1)
+        yield make_datapair({"prompt": prompt, "image": img2}, q2)
+
+
+def main(epochs: int = 1) -> None:
+    codec = UniversalTensorCodec()
+    ds = load_hf_streaming_dataset(
+        "Rapidata/Imagen-4-ultra-24-7-25_t2i_human_preference",
+        split="train",
+        streaming=True,
+        trust_remote_code=True,
+        codec=codec,
+    )
+    brain = Brain(2, size=(8, 8))
+    brain.load_paradigm("warmup_decay", {"warmup_steps": 5})
+    brain.load_paradigm("curriculum", {"start_steps": 1, "step_increment": 1})
+    sa = SelfAttention(
+        routines=[QualityAwareRoutine(window=8), AdaptiveGradClipRoutine(threshold_ratio=1.3, max_norm=1.0)]
+    )
+    wplugins = (
+        "epsilongreedy,td_qlearning,bestlosspath,alternatepathscreator,l2_weight_penalty,distillation,wanderalongsynapseweights"
+    )
+    neuro_cfg = {
+        "grow_on_step_when_stuck": True,
+        "max_new_per_walk": 1,
+        "enable_prune": True,
+        "prune_if_outgoing_gt": 3,
+    }
+    for _ in range(int(epochs)):
+        pairs = _sample_pairs(ds)
+        run_training_with_datapairs(
+            brain,
+            pairs,
+            codec,
+            steps_per_pair=2,
+            lr=1e-3,
+            wanderer_type=wplugins,
+            neuro_config=neuro_cfg,
+            selfattention=sa,
+        )
+    print("streamed quality training complete")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add example script streaming Hugging Face Rapidata dataset and training quality predictor
- document new example in architecture and add rule for HF dataset usage

## Testing
- `python -m py_compile examples/run_hf_image_quality.py`
- `for t in tests/test_*.py; do python -m unittest -v $(echo ${t%.py} | tr '/' '.'); done`


------
https://chatgpt.com/codex/tasks/task_e_68b03f850f148327b69f41721365f2e4