### PR TITLE
Add brain snapshot persistence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ Core Components
 - `Brain`: n-dimensional space that can be either:
   - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`).
   - Sparse mode: only track explicit world coordinates within per-dimension bounds supporting open-ended maxima via `None`.
-  Provides neuron placement, connections, coordinate mapping, bulk add, and JSON export/import for sparse brains. Includes basic cross-process file-based locks (Windows-friendly) for neurons and synapses.
+  Provides neuron placement, connections, coordinate mapping, bulk add, and JSON export/import for sparse brains. Includes basic cross-process file-based locks (Windows-friendly) for neurons and synapses. The brain can persist and restore its entire state via single-file snapshots (`save_snapshot`/`load_snapshot`) using the `.marble` extension. When constructed with `store_snapshots=True`, snapshots are automatically written every `snapshot_freq` wanderer walks into `snapshot_path`.
 
 - Brain Training Plugins: Registry (`register_brain_train_type`) and the `Brain.train` method (bound at runtime) to orchestrate multiple wanderer walks with plugin hooks for start selection and per-walk adjustments. Stacking is supported via comma-separated or list `type_name`:
   - `on_init` executed for all trainers in order.

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -193,6 +193,13 @@ class Wanderer(_DeviceHelper):
                             },
                             "walks",
                         )
+                        if getattr(self.brain, "store_snapshots", False):
+                            freq = getattr(self.brain, "snapshot_freq", None)
+                            if freq and self._walk_counter % int(freq) == 0:
+                                try:
+                                    self.brain.save_snapshot()
+                                except Exception:
+                                    pass
                 except Exception:
                     pass
                 return res if isinstance(res, dict) else {"loss": 0.0, "steps": 0, "visited": 0}
@@ -554,6 +561,13 @@ class Wanderer(_DeviceHelper):
                 },
                 "walks",
             )
+            if getattr(self.brain, "store_snapshots", False):
+                freq = getattr(self.brain, "snapshot_freq", None)
+                if freq and self._walk_counter % int(freq) == 0:
+                    try:
+                        self.brain.save_snapshot()
+                    except Exception:
+                        pass
         except Exception:
             pass
 

--- a/tests/test_brain_snapshot.py
+++ b/tests/test_brain_snapshot.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+import unittest
+
+from marble.marblemain import Brain
+from marble.wanderer import Wanderer
+from marble.reporter import clear_report_group
+
+
+class TestBrainSnapshot(unittest.TestCase):
+    def test_snapshot_save_and_load(self):
+        clear_report_group("brain")
+        tmp = tempfile.mkdtemp()
+        b = Brain(1, size=3, store_snapshots=True, snapshot_path=tmp, snapshot_freq=1)
+        b.add_neuron((0,), tensor=[1.0])
+        b.add_neuron((1,), tensor=[0.0])
+        b.connect((0,), (1,))
+        w = Wanderer(b)
+        w.walk(max_steps=1)
+        files = [f for f in os.listdir(tmp) if f.endswith(".marble")]
+        print("snapshot files count:", len(files))
+        self.assertTrue(files)
+        loaded = Brain.load_snapshot(os.path.join(tmp, files[0]))
+        print("loaded brain neurons:", len(loaded.neurons))
+        self.assertEqual(len(loaded.neurons), len(b.neurons))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- allow Brain to persist/load full state as .marble snapshots
- trigger automatic snapshots during Wanderer walks
- document snapshot support and add coverage test

## Testing
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_new_paradigms_and_plugins`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`


------
https://chatgpt.com/codex/tasks/task_e_68b0434bb8308327adacee3e1013b206