### PR TITLE
feat: stream datapairs and enhance HF image training

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -369,6 +369,7 @@ Plugin Stacking Policy (additive)
 45. Neuroplasticity: Add new capabilities conservatively with default plugins that are safe and minimally invasive. Hook them into `Wanderer` via plugin registries and ensure all actions are logged via `REPORTER`.
 46. Clear reporter state between tests using `Reporter.clear_group` (via `clear_report_group`) to avoid cross-test interference.
 47. Helper functions that read reporter data must handle missing groups gracefully and return `None` rather than raising exceptions.
+48. `run_training_with_datapairs` defaults to streaming mode, must not materialize full datasets, and must drop each consumed sample while ensuring the Brain stores snapshots during training.
 Temporary Test Deferral (additive, non-contradictory)
 
 - HyperEvolution comparison test: Deferred for now to keep CI time stable and avoid flakiness while architecture-search behavior evolves. This does NOT remove or narrow any functionality; it only defers a heavy integration test. Re-enable once stable budgets (pairs/steps/epochs) are agreed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,9 @@ Core Components
 
 - Training Helpers: High-level flows to run Wanderer training:
   - `run_wanderer_training`: single-wanderer multi-walk loop.
-  - `run_training_with_datapairs`: iterates over `DataPair`s; encodes left/right, injects left into start neuron, and trains against right via a target provider.
+  - `run_training_with_datapairs`: iterates over `DataPair`s; encodes left/right, injects left into a start neuron, and trains against right via a target provider.
+    - Supports a **streaming** mode (enabled by default) that never materializes the full dataset and drops consumed samples from memory immediately.
+    - Automatically enables brain snapshots during training, writing snapshots every walk to the configured `snapshot_path`.
   - `run_wanderer_epochs_with_datapairs`: repeats dataset for multiple epochs, recording per-epoch deltas.
   - `quick_train_on_pairs`: builds a minimal 2D `Brain` with configurable `grid_size`, creates a default codec if not provided, and calls `run_training_with_datapairs` with the supplied hyperparameters (`steps_per_pair`, `lr`, `seed`, `wanderer_type`, `neuro_config`, `gradient_clip`, optional `selfattention`). Logs summary under `training/quick`.
   - `run_wanderers_parallel`: orchestrates multiple datasets with thread-based concurrency (process mode intentionally unimplemented).
@@ -323,7 +325,7 @@ SelfAttention Integration
   - Neuron-type selection + wiring: SelfAttention exposes `list_neuron_types()` so routines can choose from available neuron types (currently `base` and `conv1d`). Routines MUST perform all wiring themselves when creating special neurons. The framework provides validation only:
     - `validate_neuron_wiring(neuron)`: returns `{ok, reason}`; for `conv1d` it checks exactly 5 incoming synapses and exactly 1 outgoing synapse. Unknown types are considered OK but are logged for visibility. No automatic neuron creation or connection is performed by the framework.
 - Training: `run_wanderer_training`, `run_training_with_datapairs`, `run_wanderer_epochs_with_datapairs`, `run_wanderers_parallel`, `create_start_neuron`.
-- Datasets/Examples: `run_wine_hello_world`, `export_wanderer_steps_to_jsonl`, `examples/run_wine_with_selfattention.py` (adaptive LR via SelfAttention), `examples/run_hf_image_quality.py` (streamed HF prompt-image quality training).
+- Datasets/Examples: `run_wine_hello_world`, `export_wanderer_steps_to_jsonl`, `examples/run_wine_with_selfattention.py` (adaptive LR via SelfAttention), `examples/run_hf_image_quality.py` (streamed HF prompt-image quality training with stacked Wanderer plugins).
   - `run_training_with_datapairs` accepts `selfattention` to attach step-wise control to the shared Wanderer.
   - Training helpers accept `gradient_clip` and pass it to the shared `Wanderer`.
 - Reporting: `REPORTER`, `report`, `report_group`, `report_dir`.

--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -93,14 +93,25 @@ def main(epochs: int = 1) -> None:
     sa = SelfAttention(
         routines=[QualityAwareRoutine(window=8), AdaptiveGradClipRoutine(threshold_ratio=1.3, max_norm=1.0)]
     )
-    wplugins = (
-        "epsilongreedy,td_qlearning,bestlosspath,alternatepathscreator,l2_weight_penalty,distillation,wanderalongsynapseweights"
-    )
+    wplugins = [
+        "epsilongreedy",
+        "td_qlearning",
+        "bestlosspath",
+        "alternatepathscreator",
+        "l2_weight_penalty",
+        "distillation",
+        "wanderalongsynapseweights",
+    ]
     neuro_cfg = {
         "grow_on_step_when_stuck": True,
         "max_new_per_walk": 1,
         "enable_prune": True,
         "prune_if_outgoing_gt": 3,
+        "epsilongreedy_epsilon": 0.15,
+        "rl_epsilon": 0.1,
+        "rl_alpha": 0.05,
+        "rl_gamma": 0.95,
+        "l2_lambda": 1e-4,
     }
     for _ in range(int(epochs)):
         pairs = _sample_pairs(ds)
@@ -110,9 +121,10 @@ def main(epochs: int = 1) -> None:
             codec,
             steps_per_pair=2,
             lr=1e-3,
-            wanderer_type=wplugins,
+            wanderer_type=",".join(wplugins),
             neuro_config=neuro_cfg,
             selfattention=sa,
+            streaming=True,
         )
     print("streamed quality training complete")
 


### PR DESCRIPTION
## Summary
- add streaming mode with auto brain snapshots to `run_training_with_datapairs`
- stack specialized Wanderer plugins in `run_hf_image_quality` example and enable streaming
- document streaming training flow and plugin usage

## Testing
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`


------
https://chatgpt.com/codex/tasks/task_e_68b0479ae3948327b2a813e53b4c410d