### PR TITLE
Add dynamic brain sizing and progress reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,7 @@ Plugin Stacking Policy (additive)
 46. Clear reporter state between tests using `Reporter.clear_group` (via `clear_report_group`) to avoid cross-test interference.
 47. Helper functions that read reporter data must handle missing groups gracefully and return `None` rather than raising exceptions.
 48. `run_training_with_datapairs` defaults to streaming mode, must not materialize full datasets, and must drop each consumed sample while ensuring the Brain stores snapshots during training.
+49. Progress reporting must use `tqdm`, automatically choosing `tqdm.notebook` when running inside IPython environments.
 Temporary Test Deferral (additive, non-contradictory)
 
 - HyperEvolution comparison test: Deferred for now to keep CI time stable and avoid flakiness while architecture-search behavior evolves. This does NOT remove or narrow any functionality; it only defers a heavy integration test. Re-enable once stable budgets (pairs/steps/epochs) are agreed.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,7 @@ Core Components
 - `Neuron` and `Synapse`: Fundamental graph units. Neurons store a tensor-like value and scalar `weight`/`bias` with an `age` counter. Synapses connect neurons with `direction` (uni/bi) and `weight`, and apply scaling on transmitted values. Plugin registries (`register_neuron_type`, `register_synapse_type`) allow custom behaviors (`on_init`, `forward`, `receive`, `transmit`).
 
 - `Brain`: n-dimensional space that can be either:
-  - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`).
+  - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`). Omitting the `size` parameter enables a fully dynamic grid that expands as neurons are added; capacity becomes unbounded.
   - Sparse mode: only track explicit world coordinates within per-dimension bounds supporting open-ended maxima via `None`.
   Provides neuron placement, connections, coordinate mapping, bulk add, and JSON export/import for sparse brains. Includes basic cross-process file-based locks (Windows-friendly) for neurons and synapses. The brain can persist and restore its entire state via single-file snapshots (`save_snapshot`/`load_snapshot`) using the `.marble` extension. When constructed with `store_snapshots=True`, snapshots are automatically written every `snapshot_freq` wanderer walks into `snapshot_path`.
 
@@ -36,6 +36,7 @@ Core Components
 
 - `Wanderer`: Autograd-based traversal across the graph. At each step, computes outputs from visited neurons using their (learnable) `weight`/`bias` (via temporary autograd parameters), accumulates loss, and performs SGD-style updates. Plugin registry (`register_wanderer_type`) allows custom step choice and loss definitions. Neuroplasticity registry (`register_neuroplasticity_type`) includes a default `BaseNeuroplasticityPlugin` that can grow/prune graph edges and adjust neuron parameters based on walk outcomes.
   - Gradient clipping: configurable per `Wanderer` via `gradient_clip` dict (`method`: `norm` or `value`, with `max_norm`/`norm_type` or `clip_value`). Applied after `loss.backward()` and before parameter updates.
+  - Progress reporting: `Wanderer.walk` now emits a `tqdm` progress bar (or `tqdm.notebook` in IPython) updated each step with epoch/walk counts, neuron and synapse totals, brain size, step speed, path count, and loss metrics.
 
 - Training Helpers: High-level flows to run Wanderer training:
   - `run_wanderer_training`: single-wanderer multi-walk loop.

--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -24,6 +24,7 @@ from marble.marblemain import (
     SelfAttention,
 )
 from marble.plugins.selfattention_adaptive_grad_clip import AdaptiveGradClipRoutine
+from marble.plugins.selfattention_findbestneurontype import FindBestNeuronTypeRoutine
 
 
 def _img_to_bytes(img) -> bytes:
@@ -87,11 +88,15 @@ def main(epochs: int = 1) -> None:
         trust_remote_code=True,
         codec=codec,
     )
-    brain = Brain(2, size=(8, 8))
+    brain = Brain(2)
     brain.load_paradigm("warmup_decay", {"warmup_steps": 5})
     brain.load_paradigm("curriculum", {"start_steps": 1, "step_increment": 1})
     sa = SelfAttention(
-        routines=[QualityAwareRoutine(window=8), AdaptiveGradClipRoutine(threshold_ratio=1.3, max_norm=1.0)]
+        routines=[
+            QualityAwareRoutine(window=8),
+            AdaptiveGradClipRoutine(threshold_ratio=1.3, max_norm=1.0),
+            FindBestNeuronTypeRoutine(),
+        ]
     )
     wplugins = [
         "epsilongreedy",

--- a/marble/training.py
+++ b/marble/training.py
@@ -28,7 +28,11 @@ def run_wanderer_training(
 
     w = Wanderer(brain, type_name=wanderer_type, seed=seed, loss=loss, target_provider=target_provider)
     history: List[Dict[str, Any]] = []
+    brain._progress_total_epochs = 1  # type: ignore[attr-defined]
+    brain._progress_epoch = 0  # type: ignore[attr-defined]
+    brain._progress_total_walks = num_walks  # type: ignore[attr-defined]
     for i in range(num_walks):
+        brain._progress_walk = i  # type: ignore[attr-defined]
         start = start_selector(brain) if start_selector is not None else None
         stats = w.walk(max_steps=max_steps, start=start, lr=lr)
         history.append(stats)
@@ -85,6 +89,10 @@ def run_training_with_datapairs(
 
     history: List[Dict[str, Any]] = []
     count = 0
+    try:
+        brain._progress_total_walks = len(datapairs)  # type: ignore[attr-defined]
+    except Exception:
+        brain._progress_total_walks = 0  # type: ignore[attr-defined]
 
     def _normalize_pair(p: Union[DataPair, Tuple[Any, Any], Tuple[Union[TensorLike, Sequence[int]], Union[TensorLike, Sequence[int]]]]) -> DataPair:
         if isinstance(p, DataPair):
@@ -147,6 +155,7 @@ def run_training_with_datapairs(
             pass
 
     for item in datapairs:
+        brain._progress_walk = count  # type: ignore[attr-defined]
         dp = _normalize_pair(item)
         enc_l, enc_r = dp.encode(codec)
         # Create/choose start neuron
@@ -198,7 +207,10 @@ def run_wanderer_epochs_with_datapairs(
 
     prev_final = None
     epochs: List[Dict[str, Any]] = []
+    brain._progress_total_epochs = num_epochs  # type: ignore[attr-defined]
     for e in range(num_epochs):
+        brain._progress_epoch = e  # type: ignore[attr-defined]
+        brain._progress_total_walks = len(dataset)  # type: ignore[attr-defined]
         res = run_training_with_datapairs(
             brain,
             dataset,


### PR DESCRIPTION
## Summary
- allow Brain to grow dynamically when size is omitted
- show detailed tqdm progress for Wanderer walks with loss and graph stats
- update HF image quality example to use dynamic Brain and findbestneurontype plugin

## Testing
- `for t in tests/test_*.py; do m=${t%.py}; m=${m//\//.}; python -m unittest $m; if [ $? -ne 0 ]; then break; fi; done`


------
https://chatgpt.com/codex/tasks/task_e_68b04fb158a08327b9582e32b55a407e