### PR TITLE
Remove unsupported paradigms from HF image quality example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,3 +394,4 @@ Hugging Face Datasets Policy (additive)
 - Example scripts fetching Hugging Face datasets must use `load_hf_streaming_dataset` and comment which dataset fields are consumed.
 
 50. Utility scripts for repository setup (e.g., `clone_or_update.sh` and `.ps1`) must remain in the repo root, use `git -C` for pulls, and perform editable installs via `pip install -e .`.
+51. Example scripts must reference only existing plugins and paradigms so they run without missing-component errors.

--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -89,8 +89,9 @@ def main(epochs: int = 1) -> None:
         codec=codec,
     )
     brain = Brain(2)
-    brain.load_paradigm("warmup_decay", {"warmup_steps": 5})
-    brain.load_paradigm("curriculum", {"start_steps": 1, "step_increment": 1})
+    # Brain-training plugins like "warmup_decay" and "curriculum" apply only to
+    # ``Brain.train`` flows and are not compatible with ``run_training_with_datapairs``.
+    # They are therefore omitted here to keep the example runnable.
     sa = SelfAttention(
         routines=[
             QualityAwareRoutine(window=8),


### PR DESCRIPTION
## Summary
- drop warmup_decay and curriculum paradigm calls from `run_hf_image_quality.py`
- clarify in comments that these brain-training plugins apply only to `Brain.train`
- add AGENTS rule ensuring examples only reference existing components

## Testing
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_new_paradigms_and_plugins`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`


------
https://chatgpt.com/codex/tasks/task_e_68b05b9d30b08327b2d537b43ae1ac1f