### PR TITLE
Enable brain-train plugins in datapair training

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -89,9 +89,7 @@ def main(epochs: int = 1) -> None:
         codec=codec,
     )
     brain = Brain(2)
-    # Brain-training plugins like "warmup_decay" and "curriculum" apply only to
-    # ``Brain.train`` flows and are not compatible with ``run_training_with_datapairs``.
-    # They are therefore omitted here to keep the example runnable.
+    # Include Brain-training plugins to adjust learning rate and step schedule
     sa = SelfAttention(
         routines=[
             QualityAwareRoutine(window=8),
@@ -129,6 +127,7 @@ def main(epochs: int = 1) -> None:
             steps_per_pair=2,
             lr=1e-3,
             wanderer_type=",".join(wplugins),
+            train_type="warmup_decay,curriculum",
             neuro_config=neuro_cfg,
             selfattention=sa,
             streaming=True,


### PR DESCRIPTION
## Summary
- allow `run_training_with_datapairs` to accept `train_type` and run brain-train plugins
- document and demonstrate new plugin support in `run_hf_image_quality`
- describe `train_type` in `ARCHITECTURE.md`

## Testing
- `python -m py_compile marble/marblemain.py examples/run_hf_image_quality.py`
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_new_paradigms_and_plugins`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`


------
https://chatgpt.com/codex/tasks/task_e_68b05eb7d5188327909b7fa7f9432269