### PR TITLE
Handle neuron type wiring availability

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -172,7 +172,7 @@ Convenience APIs
     - `record_removed_neuron(neuron)`, `record_removed_synapse(synapse)`: snapshot removals (positions, weights, age, type, and incident synapses for neurons) for restoration.
     - `commit_change()`: finalize the record as the latest change.
     - `rollback_last_change() -> bool`: undo the latest recorded change by removing created objects and restoring removed ones (neurons and synapses). All actions are logged under `selfattention/builder`.
-  - Routine: `findbestneurontype` wraps `Brain.add_neuron` to try all registered neuron types, stepping the Wanderer once with `lr=0` through each candidate and keeping the type with the largest loss improvement.
+  - Routine: `findbestneurontype` wraps `Brain.add_neuron` to try all registered neuron types, stepping the Wanderer once with `lr=0` through each candidate and keeping the type with the largest loss improvement. Types that cannot be wired with existing neurons are skipped; if no type is feasible, a basic neuron is added instead.
   - Analysis: `SelfAttention.history(last_n=None)` reads the last N per-step records directly from the Reporter (`wanderer_steps/logs`), ordered by step number; there is no separate internal buffer. The `history_size` constructor arg is retained for API stability but history is sourced from Reporter.
 
 Module Refactor: SelfAttention

--- a/tests/test_findbestneurontype_fallback.py
+++ b/tests/test_findbestneurontype_fallback.py
@@ -1,0 +1,27 @@
+import unittest
+
+class TestFindBestNeuronTypeFallback(unittest.TestCase):
+    def setUp(self):
+        from marble.marblemain import Brain, Wanderer, SelfAttention, attach_selfattention
+        from marble.plugins.selfattention_findbestneurontype import FindBestNeuronTypeRoutine
+        from marble.reporter import report
+        self.Brain = Brain
+        self.Wanderer = Wanderer
+        self.SelfAttention = SelfAttention
+        self.attach = attach_selfattention
+        self.Routine = FindBestNeuronTypeRoutine
+        self.report = report
+
+    def test_fallback_to_base(self):
+        b = self.Brain(1, size=(3,))
+        w = self.Wanderer(b, seed=1)
+        sa = self.SelfAttention(routines=[self.Routine()])
+        self.attach(w, sa)
+        idx = b.available_indices()[0]
+        n = b.add_neuron(idx, tensor=[0.0])
+        self.report("test", "findbestneurontype_fallback", {"type": n.type_name}, "events")
+        print("fallback neuron type:", n.type_name)
+        self.assertIsNone(n.type_name)
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- skip neuron types in findbestneurontype routine when insufficient existing neurons
- fall back to basic neuron when no candidate types can be wired
- add regression test for fallback logic

## Testing
- `python -m py_compile marble/plugins/selfattention_findbestneurontype.py tests/test_findbestneurontype_fallback.py`
- `python -m unittest -v tests.test_findbestneurontype_fallback`
- `for f in tests/test_*.py; do mod=${f%.py}; mod=${mod//\//.}; python -m unittest -v $mod || break; done`


------
https://chatgpt.com/codex/tasks/task_e_68b062c532fc8327878bcc4110694365