### PR TITLE
Add quality-aware HF image training example with batching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,3 +396,4 @@ Hugging Face Datasets Policy (additive)
 50. Utility scripts for repository setup (e.g., `clone_or_update.sh` and `.ps1`) must remain in the repo root, use `git -C` for pulls, and perform editable installs via `pip install -e .`.
 51. Example scripts must reference only existing plugins and paradigms so they run without missing-component errors.
 52. Before running any tests, explicitly install the CPU-only version of torch via `pip install --index-url https://download.pytorch.org/whl/cpu torch`.
+53. Example scripts that enable batching must load the `batchtrainer` Wanderer plugin and set `batch_size` consistently in both `neuro_config` and helper arguments.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,7 @@ Packaging and Layout
   - Examples: `examples/run_datapair_training.py` demonstrates a small end-to-end datapair training run.
   - Neuron plugins for transpose convolutions (`conv_transpose1d`, `conv_transpose2d`, `conv_transpose3d`) are implemented in dedicated modules under `marble/plugins/`.
   - Additional neuron plugins (`maxpool1d/2d/3d`, `unfold2d`, `fold2d`, `maxunpool1d/2d/3d`) live entirely in `marble/plugins/` and are imported into `marble/marblemain.py` for registration.
-  - Wanderer plugins (`l2_weight_penalty`, `contrastive_infonce`, `td_qlearning`, `distillation`, `bestlosspath`, `alternatepathscreator`, `hyperEvolution`, `batchtrainer`) and brain-training plugins (`warmup_decay`, `curriculum`) are implemented in their own modules under `marble/plugins/` and registered on import.
+  - Wanderer plugins (`l2_weight_penalty`, `contrastive_infonce`, `td_qlearning`, `distillation`, `bestlosspath`, `alternatepathscreator`, `hyperEvolution`, `batchtrainer`, `qualityweightedloss`) and brain-training plugins (`warmup_decay`, `curriculum`, `qualityaware`) are implemented in their own modules under `marble/plugins/` and registered on import.
   - The default `BaseNeuroplasticityPlugin` resides in `marble/plugins/neuroplasticity_base.py` and self-registers under type name `base`.
   - Wanderer and brain-training plugin implementations (e.g., L2 penalty, curriculum, warmup-decay) are also hosted in their own modules under `marble/plugins/`.
 
@@ -330,7 +330,7 @@ SelfAttention Integration
   - Neuron-type selection + wiring: SelfAttention exposes `list_neuron_types()` so routines can choose from available neuron types (currently `base` and `conv1d`). Routines MUST perform all wiring themselves when creating special neurons. The framework provides validation only:
     - `validate_neuron_wiring(neuron)`: returns `{ok, reason}`; for `conv1d` it checks exactly 5 incoming synapses and exactly 1 outgoing synapse. Unknown types are considered OK but are logged for visibility. No automatic neuron creation or connection is performed by the framework.
 - Training: `run_wanderer_training`, `run_training_with_datapairs`, `run_wanderer_epochs_with_datapairs`, `run_wanderers_parallel`, `create_start_neuron`.
-- Datasets/Examples: `run_wine_hello_world`, `export_wanderer_steps_to_jsonl`, `examples/run_wine_with_selfattention.py` (adaptive LR via SelfAttention), `examples/run_hf_image_quality.py` (streamed HF prompt-image quality training with stacked Wanderer plugins; saves brain snapshots every 100 iterations, keeping the latest 10 in the working directory).
+  - Datasets/Examples: `run_wine_hello_world`, `export_wanderer_steps_to_jsonl`, `examples/run_wine_with_selfattention.py` (adaptive LR via SelfAttention), `examples/run_hf_image_quality.py` (streamed HF prompt-image quality training with stacked Wanderer plugins, custom quality-aware plugins, diagonal-band initialization formula, and batches of five; saves brain snapshots every 100 iterations, keeping the latest 10 in the working directory).
   - `run_training_with_datapairs` accepts `selfattention` to attach step-wise control to the shared Wanderer and `train_type` to apply Brain-training plugins during datapair training.
   - Training helpers accept `gradient_clip` and pass it to the shared `Wanderer`.
 - Reporting: `REPORTER`, `report`, `report_group`, `report_dir`.

--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -90,6 +90,9 @@ def main(epochs: int = 1) -> None:
     )
     brain = Brain(
         2,
+        size=32,
+        bounds=((0, 31), (0, 31)),
+        formula="abs(n1 - n2) <= 2",
         store_snapshots=True,
         snapshot_path=".",
         snapshot_freq=100,
@@ -104,6 +107,8 @@ def main(epochs: int = 1) -> None:
         ]
     )
     wplugins = [
+        "batchtrainer",
+        "qualityweightedloss",
         "epsilongreedy",
         "td_qlearning",
         "bestlosspath",
@@ -123,6 +128,7 @@ def main(epochs: int = 1) -> None:
         "rl_alpha": 0.05,
         "rl_gamma": 0.95,
         "l2_lambda": 1e-4,
+        "batch_size": 5,
     }
     for _ in range(int(epochs)):
         pairs = _sample_pairs(ds)
@@ -133,10 +139,11 @@ def main(epochs: int = 1) -> None:
             steps_per_pair=2,
             lr=1e-3,
             wanderer_type=",".join(wplugins),
-            train_type="warmup_decay,curriculum",
+            train_type="warmup_decay,curriculum,qualityaware",
             neuro_config=neuro_cfg,
             selfattention=sa,
             streaming=True,
+            batch_size=5,
         )
     print("streamed quality training complete")
 

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -1893,8 +1893,15 @@ def register_brain_train_type(name: str, plugin: Any) -> None:
 try:
     from .plugins.brain_train_curriculum import CurriculumTrainPlugin
     register_brain_train_type("curriculum", CurriculumTrainPlugin())
+    __all__ += ["CurriculumTrainPlugin"]
 except Exception:
     pass
+
+try:
+    from .plugins.brain_train_qualityaware import QualityAwareTrainPlugin
+    register_brain_train_type("qualityaware", QualityAwareTrainPlugin())
+    __all__ += ["QualityAwareTrainPlugin"]
+except Exception:
     pass
 
 
@@ -2103,6 +2110,13 @@ try:
     from .plugins.wanderer_batchtrainer import BatchTrainingPlugin
     register_wanderer_type("batchtrainer", BatchTrainingPlugin())
     __all__ += ["BatchTrainingPlugin"]
+except Exception:
+    pass
+
+try:
+    from .plugins.wanderer_qualityweightedloss import QualityWeightedLossPlugin
+    register_wanderer_type("qualityweightedloss", QualityWeightedLossPlugin())
+    __all__ += ["QualityWeightedLossPlugin"]
 except Exception:
     pass
 

--- a/marble/plugins/brain_train_qualityaware.py
+++ b/marble/plugins/brain_train_qualityaware.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..reporter import report
+
+
+class QualityAwareTrainPlugin:
+    """Adjust learning rate each walk based on current target quality."""
+
+    def on_init(self, brain: "Brain", wanderer: "Wanderer", config: Dict[str, Any]) -> None:  # noqa: D401
+        pass
+
+    def before_walk(self, brain: "Brain", wanderer: "Wanderer", i: int) -> Dict[str, Any]:
+        try:
+            tgt = float(wanderer._target_provider(None))  # type: ignore[call-arg]
+        except Exception:
+            tgt = 0.0
+        lr = 1e-3 + max(0.0, min(1.0, tgt)) * 5e-4
+        try:
+            report("training", "qualityaware_before", {"walk": i, "lr": lr, "target": tgt}, "brain")
+        except Exception:
+            pass
+        return {"lr": float(lr)}
+
+
+__all__ = ["QualityAwareTrainPlugin"]
+

--- a/marble/plugins/wanderer_qualityweightedloss.py
+++ b/marble/plugins/wanderer_qualityweightedloss.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import torch
+from typing import Any, List
+
+from ..wanderer import register_wanderer_type
+
+
+class QualityWeightedLossPlugin:
+    """Scale loss by target quality so higher-quality samples influence updates more."""
+
+    def loss(self, wanderer: "Wanderer", outputs: List[Any]):  # noqa: D401
+        torch_device = getattr(wanderer, "_device", "cpu")
+        target_provider = getattr(wanderer, "_target_provider", None)
+        if not outputs or target_provider is None:
+            return torch.tensor(0.0, device=torch_device)
+        y = outputs[-1].float()
+        tgt = target_provider(outputs[-1])  # type: ignore[call-arg]
+        if not hasattr(tgt, "float"):
+            tgt = torch.tensor(tgt, dtype=torch.float32, device=torch_device)
+        tgt = tgt.view_as(y)
+        weight = tgt.clamp(min=0.0)
+        return (weight * (y - tgt) ** 2).mean()
+
+
+try:
+    register_wanderer_type("qualityweightedloss", QualityWeightedLossPlugin())
+except Exception:
+    pass
+
+
+__all__ = ["QualityWeightedLossPlugin"]
+


### PR DESCRIPTION
## Summary
- add QualityWeightedLoss wanderer plugin that scales loss by human quality score
- add QualityAware brain-train plugin to adjust learning rate by quality
- update HF image quality example to use batch size 5, diagonal-band brain formula, and new plugins
- document plugins and batching policy

## Testing
- `python -m unittest -v tests.test_batch_training_plugin`
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_findbestneurontype_fallback`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_new_paradigms_and_plugins`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`


------
https://chatgpt.com/codex/tasks/task_e_68b0773b31448327819891ac207d58e9