### PR TITLE
Add freeze control for Wanderer plugins

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,6 +37,7 @@ Core Components
 
   - `Wanderer`: Autograd-based traversal across the graph. At each step, computes outputs from visited neurons using their (learnable) `weight`/`bias` (via temporary autograd parameters), accumulates loss, and performs SGD-style updates. Plugin registry (`register_wanderer_type`) allows custom step choice and loss definitions. Neuroplasticity registry (`register_neuroplasticity_type`) includes a default `BaseNeuroplasticityPlugin` that can grow/prune graph edges and adjust neuron parameters based on walk outcomes.
     - `dynamicdimensions` plugin periodically adds a new dimension to the `Brain`, observes neuron growth, and removes the dimension if it doesn't improve loss.
+    - Plugins can freeze neurons or synapses via `freeze_neuron`, `freeze_neurons`, `freeze_synapse`, or `freeze_path`. Frozen neurons skip parameter updates; frozen synapses are excluded from traversal choices.
   - Gradient clipping: configurable per `Wanderer` via `gradient_clip` dict (`method`: `norm` or `value`, with `max_norm`/`norm_type` or `clip_value`). Applied after `loss.backward()` and before parameter updates.
   - Progress reporting: `Wanderer.walk` now emits a `tqdm` progress bar (or `tqdm.notebook` in IPython) updated each step with epoch/walk counts, neuron and synapse totals, brain size, step speed, path count, and loss metrics.
 

--- a/tests/test_wanderer_freeze.py
+++ b/tests/test_wanderer_freeze.py
@@ -1,0 +1,53 @@
+import unittest
+
+
+class TestWandererFreeze(unittest.TestCase):
+    def setUp(self):
+        from marble.marblemain import Brain, Wanderer, register_wanderer_type, report
+
+        self.Brain = Brain
+        self.Wanderer = Wanderer
+        self.register = register_wanderer_type
+        self.report = report
+
+    def test_freeze_single_neuron(self):
+        b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        n1 = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        n2 = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
+
+        class FreezePlugin:
+            def before_walk(self, wanderer, start):
+                wanderer.freeze_neuron(n2)
+
+        self.register("freeze_neuron", FreezePlugin())
+
+        w = self.Wanderer(b, type_name="freeze_neuron", seed=1)
+        orig = (n2.weight, n2.bias)
+        self.report("test", "freeze_single_neuron_start", {"w": orig[0], "b": orig[1]}, "events")
+        w.walk(max_steps=3, lr=1e-2)
+        self.report("test", "freeze_single_neuron_end", {"w": n2.weight, "b": n2.bias}, "events")
+        self.assertEqual((n2.weight, n2.bias), orig)
+
+    def test_freeze_path(self):
+        b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        n1 = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        n2 = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        s = b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
+
+        class PathFreezePlugin:
+            def before_walk(self, wanderer, start):
+                wanderer.freeze_path([s])
+
+        self.register("freeze_path", PathFreezePlugin())
+
+        w = self.Wanderer(b, type_name="freeze_path", seed=2)
+        stats = w.walk(max_steps=3, lr=1e-2)
+        self.report("test", "freeze_path_stats", stats, "events")
+        self.assertEqual(stats["steps"], 0)
+        self.assertEqual(len(w._visited), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- allow Wanderer plugins to freeze neurons or synapses via new APIs
- skip updates and traversal for frozen elements
- document and test freeze capabilities

## Testing
- `python -m py_compile marble/wanderer.py tests/test_wanderer_freeze.py`
- `python -m unittest -v tests.test_batch_training_plugin`
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_earlystop_plugin`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_findbestneurontype_fallback`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_new_paradigms_and_plugins`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_freeze`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`


------
https://chatgpt.com/codex/tasks/task_e_68b094036eb48327929bb56f79d16e71