### PR TITLE
Add triple contrast wanderer plugin

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,6 +232,7 @@ Additional Paradigms and Plugins
   - `contrastive_infonce`: InfoNCE-style contrastive objective across outputs in a walk; positives are adjacent pairs; all others are negatives. Temperature `contrastive_tau`, weight `contrastive_lambda`.
   - `td_qlearning`: Tabular TD(0) with per-synapse Q values stored in `synapse._plugin_state['q']`; `choose_next` is epsilon-greedy.
   - `distillation`: Teacher-student MSE loss to a moving-average teacher of past outputs; controlled by `distill_lambda` and `teacher_momentum`.
+  - `triple_contrast`: spawns two auxiliary wanderers per loss call and averages pairwise MSE across the three final outputs for a contrastive signal.
 
 These additions are fully additive; they do not remove or narrow any existing APIs or calculations. All changes continue to respect the single-file import rule and CUDA preference policy.
 

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -551,15 +551,18 @@ try:
     from .plugins.wanderer_contrastive_infonce import ContrastiveInfoNCEPlugin
     from .plugins.wanderer_td_qlearning import TDQLearningPlugin
     from .plugins.wanderer_distillation import DistillationPlugin
+    from .plugins.wanderer_triple_contrast import TripleWanderersContrastPlugin
     register_wanderer_type("l2_weight_penalty", L2WeightPenaltyPlugin())
     register_wanderer_type("contrastive_infonce", ContrastiveInfoNCEPlugin())
     register_wanderer_type("td_qlearning", TDQLearningPlugin())
     register_wanderer_type("distillation", DistillationPlugin())
+    register_wanderer_type("triple_contrast", TripleWanderersContrastPlugin())
     __all__ += [
         "L2WeightPenaltyPlugin",
         "ContrastiveInfoNCEPlugin",
         "TDQLearningPlugin",
         "DistillationPlugin",
+        "TripleWanderersContrastPlugin",
     ]
 except Exception:
     pass

--- a/marble/plugins/wanderer_triple_contrast.py
+++ b/marble/plugins/wanderer_triple_contrast.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+from ..reporter import report
+
+
+class TripleWanderersContrastPlugin:
+    """Runs two auxiliary wanderers and contrasts outputs of three walks.
+
+    Upon each loss computation, spawns two additional Wanderer instances that
+    perform walks on the same Brain. The final outputs of all three walks are
+    compared pairwise using mean squared error, and the averaged value is
+    returned as an auxiliary loss term.
+    """
+
+    def loss(self, wanderer: "Wanderer", outputs: List[Any]):  # noqa: D401
+        torch = getattr(wanderer, "_torch", None)
+        if torch is None:
+            return 0.0
+        dev = getattr(wanderer, "_device", "cpu")
+        main_out = outputs[-1] if outputs else torch.tensor(0.0, device=dev)
+        brain = wanderer.brain
+        steps = int(wanderer._walk_ctx.get("steps", len(outputs) or 1))
+        lr = float(getattr(wanderer, "current_lr", 1e-2))
+        # Gather outputs from two additional walks using fresh Wanderer instances
+        extra_outs = []
+        try:
+            from ..marblemain import Wanderer as _Wanderer
+            for _ in range(2):
+                seed = wanderer.rng.randint(0, 2**31 - 1)
+                w2 = _Wanderer(brain, seed=seed, mixedprecision=False)
+                w2.walk(max_steps=steps, lr=lr)
+                o2 = w2._walk_ctx.get("outputs", [])
+                extra_outs.append(o2[-1] if o2 else torch.tensor(0.0, device=dev))
+        except Exception:
+            return torch.tensor(0.0, device=dev)
+        all_outs = [main_out] + extra_outs
+        losses = []
+        for i in range(3):
+            for j in range(i + 1, 3):
+                a, b = all_outs[i], all_outs[j]
+                if hasattr(a, "detach") and hasattr(b, "detach"):
+                    diff = a.detach().to(dev) - b.detach().to(dev)
+                    losses.append((diff.view(-1) ** 2).mean())
+                else:
+                    at = torch.tensor([float(v) for v in (a if isinstance(a, (list, tuple)) else [a])], dtype=torch.float32, device=dev)
+                    bt = torch.tensor([float(v) for v in (b if isinstance(b, (list, tuple)) else [b])], dtype=torch.float32, device=dev)
+                    diff = at - bt
+                    losses.append((diff.view(-1) ** 2).mean())
+        if not losses:
+            return torch.tensor(0.0, device=dev)
+        loss = sum(losses) / len(losses)
+        try:
+            report("wanderer", "triple_contrast_loss", {"loss": float(loss.detach().to("cpu").item())}, "events")
+        except Exception:
+            pass
+        return loss
+
+__all__ = ["TripleWanderersContrastPlugin"]

--- a/tests/test_triple_contrast_plugin.py
+++ b/tests/test_triple_contrast_plugin.py
@@ -1,0 +1,17 @@
+import unittest
+
+
+class TestTripleContrastPlugin(unittest.TestCase):
+    def test_triple_contrast_runs(self):
+        from marble.marblemain import Brain, Wanderer, report, clear_report_group
+        clear_report_group("tests/triple")
+        b = Brain(2, size=(3, 3))
+        w = Wanderer(b, type_name="triple_contrast", mixedprecision=False)
+        stats = w.walk(max_steps=2, lr=0.01)
+        report("tests", "triple_contrast_loss", {"loss": stats.get("loss", 0.0)}, "triple")
+        print("triple contrast loss:", stats.get("loss", 0.0))
+        self.assertIn("loss", stats)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add TripleWanderersContrastPlugin that spawns two auxiliary wanderers and averages pairwise MSE across three walks
- register the plugin under the name `triple_contrast`
- document and test the new wanderer plugin

## Testing
- `python -m unittest -v tests.test_batch_training_plugin`
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_earlystop_plugin`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_findbestneurontype_fallback`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_new_paradigms_and_plugins`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`
- `python -m unittest -v tests.test_triple_contrast_plugin`


------
https://chatgpt.com/codex/tasks/task_e_68b0b7cc644483279abd19bd3ce64f3c