### PR TITLE
Expose wanderer learnable parameters to plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,3 +397,4 @@ Hugging Face Datasets Policy (additive)
 51. Example scripts must reference only existing plugins and paradigms so they run without missing-component errors.
 52. Before running any tests, explicitly install the CPU-only version of torch via `pip install --index-url https://download.pytorch.org/whl/cpu torch`.
 53. Example scripts that enable batching must load the `batchtrainer` Wanderer plugin and set `batch_size` consistently in both `neuro_config` and helper arguments.
+54. Wanderer exposes ten global learnable parameters under `wanderer.learnable_params`; plugins interacting with Wanderer-level learnables should read/write via this mapping.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -199,7 +199,8 @@ Module Refactor: Wanderer (Phase 2)
   - `wanderer_epsgreedy.py` → `EpsilonGreedyChooserPlugin` (self‑registers `epsilongreedy`)
 - `marble/marblemain.py` imports these modules to ensure they register on import and continues to act as the single aggregation point.
 - Behavior, algorithms, and registration names remain unchanged.
- - Removed duplicate in-file plugin class definitions from `marble/marblemain.py` to avoid drift; single sources of truth now live in `marble/plugins/wanderer_*.py`.
+- Removed duplicate in-file plugin class definitions from `marble/marblemain.py` to avoid drift; single sources of truth now live in `marble/plugins/wanderer_*.py`.
+- Wanderer now allocates ten global learnable tensors (`param_0`–`param_9`) exposed via `wanderer.learnable_params` (also mirrored under `_plugin_state['learnable_params']`). These parameters participate in SGD updates each walk and are available for custom wanderer plugins.
 
 GUI
 

--- a/marble/plugins/wanderer_mixedprecision.py
+++ b/marble/plugins/wanderer_mixedprecision.py
@@ -10,10 +10,14 @@ class MixedPrecisionPlugin:
     """Enable mixed precision training for Wanderer walks."""
 
     def before_walk(self, wanderer: "Wanderer", start: "Neuron") -> None:  # noqa: D401
+        if not torch.cuda.is_available():
+            setattr(wanderer, "_use_mixed_precision", False)
+            setattr(wanderer, "_amp_scaler", None)
+            return
         setattr(wanderer, "_use_mixed_precision", True)
         if not hasattr(wanderer, "_amp_scaler") or getattr(wanderer, "_amp_scaler", None) is None:
             try:
-                scaler = torch.cuda.amp.GradScaler()
+                scaler = torch.amp.GradScaler("cuda")
             except Exception:
                 scaler = None
             setattr(wanderer, "_amp_scaler", scaler)


### PR DESCRIPTION
## Summary
- add ten global learnable tensors to Wanderer and expose them via `learnable_params`
- include these tensors in gradient scaling/clipping/updates and fix loss shape alignment
- guard mixed-precision plugin against missing CUDA and use new GradScaler API
- document new parameters and plugin access

## Testing
- `python -m py_compile marble/wanderer.py marble/plugins/wanderer_mixedprecision.py tests/test_wanderer.py`
- `pip install --index-url https://download.pytorch.org/whl/cpu torch -q`
- `python -m pip install -e . -q`
- `python -m unittest -v tests.test_wanderer`


------
https://chatgpt.com/codex/tasks/task_e_68b0dd8fff50832793bd2f313d8895ee