### PR TITLE
feat: add global learnable parameter hooks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,6 +167,10 @@ Convenience APIs
     - `ensure_learnable_param(neuron, name, init_value, requires_grad=True, lr=None)` registers a tensor under `neuron._plugin_state['learnable_params'][name]` and in SelfAttention’s registry.
     - `set_param_optimization(neuron, name, enabled=True, lr=None)` toggles optimization per param.
     - During `Wanderer.walk`, after `loss.backward()`, attached SelfAttentions update any enabled learnables via simple SGD using per‑param or current LR. Plugins prefer learnables when present; otherwise they use values from existing PARAM neurons.
+  - Global learnable parameters: higher level components can expose their own tunables.
+    - `Wanderer.ensure_learnable_param(name, init_value, requires_grad=True, lr=None)` registers Wanderer-wide tensors; `set_param_optimization` enables SGD updates. Decorator `expose_learnable_params` automatically registers function parameters as Wanderer learnables.
+    - `Brain.ensure_learnable_param(name, init_value, requires_grad=True, lr=None)` mirrors the API for Brain-level plugins.
+    - `SelfAttention.ensure_global_learnable_param(name, init_value, requires_grad=True, lr=None)` allows routines to maintain global tensors alongside per-neuron learnables.
   - SelfAttention rollback API: Routines can bracket graph mutations and roll them back entirely (including topology changes) using:
     - `start_change(tag: Optional[str]) -> int`: begin a new change record (kept on a stack per SelfAttention instance).
     - `record_created_neuron(neuron)`, `record_created_synapse(synapse)`: mark creations.

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -4,11 +4,11 @@
 Move remaining plugin classes out of `marble/marblemain.py` into dedicated modules under `marble/plugins` with direct implementations (no wrappers) and adjust imports.
 
 ## Steps
-1. For each neuron plugin still defined in `marble/marblemain.py` (ConvTranspose1D/2D/3D, MaxPool1D/2D/3D, Unfold2D, Fold2D, MaxUnpool1D/2D/3D), copy the full class implementation into the corresponding module in `marble/plugins/` and remove the class definition from `marble/marblemain.py`.
-2. Update these plugin modules to include all necessary imports (typing, math, reporter helpers, and base mixins) so they are self-contained.
-3. Replace wrapper modules for `wanderer_hyperevolution.py` and ensure the `HyperEvolutionPlugin` implementation lives entirely inside that file.
-4. Remove duplicate plugin class definitions from `marble/marblemain.py` for wanderer and brain-training plugins (`L2WeightPenaltyPlugin`, `ContrastiveInfoNCEPlugin`, `TDQLearningPlugin`, `DistillationPlugin`, `WarmupDecayTrainPlugin`, `CurriculumTrainPlugin`, `BestLossPathPlugin`, `AlternatePathsCreatorPlugin`, `HyperEvolutionPlugin`, `BaseNeuroplasticityPlugin`). Import their classes from the plugin modules instead and keep registration calls where necessary.
-5. After each removal, adjust `__all__` and registration logic so that plugin classes remain accessible via `marble.marblemain`.
-6. Create a new plugin module for `BaseNeuroplasticityPlugin` (e.g., `marble/plugins/neuroplasticity_base.py`) and move its implementation there with a `register_neuroplasticity_type` call.
-7. Run the full test suite (`py -3 -m unittest -v tests.<module>`) to ensure all functionality remains intact, focusing on tests covering convolution, pooling, unpooling, and wanderer plugins.
-8. Update `ARCHITECTURE.md` to document that plugin implementations now reside in their own modules rather than in `marble/marblemain.py`.
+1. For each neuron plugin still defined in `marble/marblemain.py` (ConvTranspose1D/2D/3D, MaxPool1D/2D/3D, Unfold2D, Fold2D, MaxUnpool1D/2D/3D), copy the full class implementation into the corresponding module in `marble/plugins/` and remove the class definition from `marble/marblemain.py`. [complete]
+2. Update these plugin modules to include all necessary imports (typing, math, reporter helpers, and base mixins) so they are self-contained. [complete]
+3. Replace wrapper modules for `wanderer_hyperevolution.py` and ensure the `HyperEvolutionPlugin` implementation lives entirely inside that file. [complete]
+4. Remove duplicate plugin class definitions from `marble/marblemain.py` for wanderer and brain-training plugins (`L2WeightPenaltyPlugin`, `ContrastiveInfoNCEPlugin`, `TDQLearningPlugin`, `DistillationPlugin`, `WarmupDecayTrainPlugin`, `CurriculumTrainPlugin`, `BestLossPathPlugin`, `AlternatePathsCreatorPlugin`, `HyperEvolutionPlugin`, `BaseNeuroplasticityPlugin`). Import their classes from the plugin modules instead and keep registration calls where necessary. [complete]
+5. After each removal, adjust `__all__` and registration logic so that plugin classes remain accessible via `marble.marblemain`. [complete]
+6. Create a new plugin module for `BaseNeuroplasticityPlugin` (e.g., `marble/plugins/neuroplasticity_base.py`) and move its implementation there with a `register_neuroplasticity_type` call. [complete]
+7. Run the full test suite (`py -3 -m unittest -v tests.<module>`) to ensure all functionality remains intact, focusing on tests covering convolution, pooling, unpooling, and wanderer plugins. [complete]
+8. Update `ARCHITECTURE.md` to document that plugin implementations now reside in their own modules rather than in `marble/marblemain.py`. [complete]

--- a/tests/test_learnable_params.py
+++ b/tests/test_learnable_params.py
@@ -1,0 +1,65 @@
+import unittest
+
+
+class LearnableParamTests(unittest.TestCase):
+    def test_global_learnables_and_decorator(self):
+        from marble.marblemain import (
+            Brain,
+            Wanderer,
+            SelfAttention,
+            expose_learnable_params,
+        )
+
+        brain = Brain(1, size=1)
+        w = Wanderer(brain)
+        sa = SelfAttention()
+        sa._bind(w)
+        w._selfattentions.append(sa)
+
+        # Wanderer learnable
+        w.ensure_learnable_param("wp", 0.5)
+        w.set_param_optimization("wp", enabled=True, lr=0.1)
+
+        # Brain learnable
+        brain.ensure_learnable_param("bp", 1.0)
+        brain.set_param_optimization("bp", enabled=True, lr=0.1)
+
+        # SelfAttention global learnable
+        sa.ensure_global_learnable_param("sp", 2.0)
+        sa.set_global_param_optimization("sp", enabled=True, lr=0.1)
+
+        @expose_learnable_params
+        def foo(wanderer, a: float = 1.0):
+            torch = wanderer._torch  # type: ignore[attr-defined]
+            return (
+                a
+                + wanderer.get_learnable_param_tensor("wp")
+                + brain.get_learnable_param_tensor("bp")
+                + sa.get_global_param_tensor("sp")
+            )
+
+        foo(w)  # register parameter 'a'
+        w.set_param_optimization("a", enabled=True, lr=0.1)
+
+        # Record previous values
+        torch = w._torch  # type: ignore[attr-defined]
+        a_before = w.get_learnable_param_tensor("a").clone()
+        bp_before = brain.get_learnable_param_tensor("bp").clone()
+        sp_before = sa.get_global_param_tensor("sp").clone()
+        wp_before = w.get_learnable_param_tensor("wp").clone()
+
+        loss = foo(w)
+        loss.backward()
+        w._update_learnables()
+        brain._update_learnables()
+        sa._update_learnables(w)
+
+        self.assertFalse(torch.equal(a_before, w.get_learnable_param_tensor("a")))
+        self.assertFalse(torch.equal(wp_before, w.get_learnable_param_tensor("wp")))
+        self.assertFalse(torch.equal(bp_before, brain.get_learnable_param_tensor("bp")))
+        self.assertFalse(torch.equal(sp_before, sa.get_global_param_tensor("sp")))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- allow functions to register wanderer-level learnables via `expose_learnable_params`
- let Wanderer, Brain, and SelfAttention plugins manage their own global learnable parameters
- document global learnables and add coverage tests

## Testing
- `python -m py_compile marble/wanderer.py marble/marblemain.py marble/selfattention.py tests/test_learnable_params.py`
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m pip install -e .`
- `python -m unittest -v tests.test_batch_training_plugin`
- `python -m unittest -v tests.test_brain`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_earlystop_plugin`
- `python -m unittest -v tests.test_epochs`
- `python -m unittest -v tests.test_findbestneurontype_fallback`
- `python -m unittest -v tests.test_graph`
- `python -m unittest -v tests.test_learning_paradigm`
- `python -m unittest -v tests.test_learning_paradigm_helpers`
- `python -m unittest -v tests.test_learning_paradigm_stacking`
- `python -m unittest -v tests.test_learning_paradigm_toggle_and_growth`
- `python -m unittest -v tests.test_maxpool_improvement`
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_triple_contrast_plugin`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_walk_summary`
- `python -m unittest -v tests.test_new_paradigms_and_plugins`
- `python -m unittest -v tests.test_learnable_params`


------
https://chatgpt.com/codex/tasks/task_e_68b0e13b3fd88327aff53020d5f0285c