### PR TITLE
Add AutoNeuron dynamic neuron type with fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,3 +397,4 @@ Hugging Face Datasets Policy (additive)
 51. Example scripts must reference only existing plugins and paradigms so they run without missing-component errors.
 52. Before running any tests, explicitly install the CPU-only version of torch via `pip install --index-url https://download.pytorch.org/whl/cpu torch`.
 53. Example scripts that enable batching must load the `batchtrainer` Wanderer plugin and set `batch_size` consistently in both `neuro_config` and helper arguments.
+54. Dynamic neuron types like `AutoNeuron` must revert to the previous type on errors and expose selection parameters via `expose_learnable_params` to keep gradients intact.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,8 @@ Core Components
 - `Neuron` and `Synapse`: Fundamental graph units. Neurons store a tensor-like value and scalar `weight`/`bias` with an `age` counter. Synapses connect neurons with `direction` (uni/bi) and `weight`, and apply scaling on transmitted values. Plugin registries (`register_neuron_type`, `register_synapse_type`) allow custom behaviors (`on_init`, `forward`, `receive`, `transmit`).
   Synapses may also connect directly to other synapses; transmission recursively traverses until a neuron endpoint is reached. When a neuron is removed, its adjacent synapses are bridged to maintain path continuity.
 
+  - `AutoNeuron` plugin: Learns via `expose_learnable_params` to delegate each forward pass to the most promising neuron type. On failures (e.g., wiring errors), it reverts to the previous successful type and retries, preserving gradient flow.
+
 - `Brain`: n-dimensional space that can be either:
   - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`). Omitting the `size` parameter enables a fully dynamic grid that expands as neurons are added; capacity becomes unbounded.
   - Sparse mode: only track explicit world coordinates within per-dimension bounds supporting open-ended maxima via `None`.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -369,6 +369,17 @@ except Exception:
     pass
 
 # -----------------------------
+# Neuron Plugin: AutoNeuron
+# -----------------------------
+
+try:
+    from .plugins.autoneuron import AutoNeuronPlugin
+    register_neuron_type("autoneuron", AutoNeuronPlugin())
+    __all__ += ["AutoNeuronPlugin"]
+except Exception:
+    pass
+
+# -----------------------------
 # Learning Paradigm Plugins (Brain-level orchestration) (Brain-level orchestration)
 # -----------------------------
 

--- a/marble/plugins/autoneuron.py
+++ b/marble/plugins/autoneuron.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+"""Neuron plugin that learns to delegate to other neuron types.
+
+`AutoNeuronPlugin` acts as a meta neuron type. For every forward pass it
+chooses a concrete neuron type via learnable scores exposed through
+``expose_learnable_params`` and delegates execution to that type. If the
+chosen type raises an exception (for example due to unmet wiring
+requirements), the plugin rolls back to the previously successful type and
+retries the step so training can continue without breaking gradients.
+"""
+
+from typing import Any, List, Optional
+
+from ..wanderer import expose_learnable_params
+from ..graph import _NEURON_TYPES
+
+
+class AutoNeuronPlugin:
+    """Meta neuron type that dynamically selects other neuron plugins."""
+
+    def __init__(self) -> None:
+        self._current_neuron_id = 0
+
+    # ---- Selection -----------------------------------------------------
+    def _candidate_types(self) -> List[Optional[str]]:
+        names: List[Optional[str]] = [None]
+        names += [n for n in _NEURON_TYPES.keys() if n != "autoneuron"]
+        return names
+
+    def _select_type(self, wanderer: "Wanderer", neuron: "Neuron") -> Optional[str]:
+        torch = getattr(wanderer, "_torch", None)
+        device = getattr(wanderer, "_device", "cpu")
+        names = self._candidate_types()
+        scores: List[Any] = []
+        for nm in names:
+            bias_name = f"autoneuron_bias_{nm or 'base'}"
+            try:
+                wanderer.ensure_learnable_param(bias_name, 0.0)
+                bias = wanderer.get_learnable_param_tensor(bias_name)
+            except Exception:
+                bias = 0.0
+            try:
+                score = self._raw_score(wanderer) + bias
+            except Exception:
+                score = bias
+            scores.append(score)
+        if torch is None:
+            return names[0]
+        try:
+            stacked = torch.stack(
+                [
+                    s if hasattr(s, "to") else torch.tensor(float(s), device=device)
+                    for s in scores
+                ]
+            )
+            idx = int(torch.argmax(stacked).detach().to("cpu").item())
+            return names[idx]
+        except Exception:
+            return names[0]
+
+    @expose_learnable_params
+    def _raw_score(
+        self,
+        wanderer: "Wanderer",
+        *,
+        base: float = 0.0,
+        step_weight: float = 0.0,
+        neuron_weight: float = 0.0,
+    ):
+        """Compute a score using walk step and neuron id."""
+
+        torch = getattr(wanderer, "_torch", None)
+        if torch is None:
+            return base
+        step = getattr(wanderer, "_walk_step_count", 0)
+        nid = getattr(self, "_current_neuron_id", 0)
+        return base + step_weight * step + neuron_weight * nid
+
+    # ---- Core operations -----------------------------------------------
+    def _base_forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(
+            neuron.tensor if input_value is None else input_value
+        )
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            return x * neuron.weight + neuron.bias
+        xl = x if isinstance(x, list) else list(x)  # type: ignore[arg-type]
+        return [neuron.weight * float(v) + neuron.bias for v in xl]
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        wanderer = neuron._plugin_state.get("wanderer")
+        prev = neuron._plugin_state.get("prev_type")
+        chosen = prev
+        if wanderer is not None:
+            self._current_neuron_id = id(neuron)
+            chosen = self._select_type(wanderer, neuron)
+        plugin = _NEURON_TYPES.get(chosen) if chosen else None
+        try:
+            neuron.type_name = chosen
+            if plugin is None:
+                out = self._base_forward(neuron, input_value)
+            else:
+                out = plugin.forward(neuron, input_value)
+            neuron._plugin_state["prev_type"] = chosen
+            return out
+        except Exception:
+            neuron.type_name = prev
+            plugin_prev = _NEURON_TYPES.get(prev) if prev else None
+            if plugin_prev is None:
+                out = self._base_forward(neuron, input_value)
+            else:
+                out = plugin_prev.forward(neuron, input_value)
+            neuron._plugin_state["prev_type"] = prev
+            return out
+        finally:
+            neuron.type_name = "autoneuron"
+
+    def receive(self, neuron: "Neuron", value):
+        prev = neuron._plugin_state.get("prev_type")
+        plugin = _NEURON_TYPES.get(prev) if prev else None
+        try:
+            neuron.type_name = prev
+            if plugin is not None and hasattr(plugin, "receive"):
+                plugin.receive(neuron, value)
+            else:
+                neuron.tensor = neuron._ensure_tensor(value)
+        finally:
+            neuron.type_name = "autoneuron"
+
+
+__all__ = ["AutoNeuronPlugin"]
+

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -396,6 +396,10 @@ class Wanderer(_DeviceHelper):
             current.weight = w_param  # type: ignore[assignment]
             current.bias = b_param  # type: ignore[assignment]
             try:
+                current._plugin_state["wanderer"] = self
+            except Exception:
+                pass
+            try:
                 with (torch.autocast(device_type=amp_device, dtype=amp_dtype) if amp_enabled else contextlib.nullcontext()):
                     out = current.forward(carried_value)
             finally:
@@ -580,6 +584,10 @@ class Wanderer(_DeviceHelper):
 
         try:
             if moved_last and current is not None:
+                try:
+                    current._plugin_state["wanderer"] = self
+                except Exception:
+                    pass
                 out_tail = current.forward(None)
                 outputs.append(out_tail)
         except Exception:

--- a/tests/test_autoneuron.py
+++ b/tests/test_autoneuron.py
@@ -1,0 +1,31 @@
+import unittest
+
+
+class TestAutoNeuron(unittest.TestCase):
+    def setUp(self):
+        from marble.marblemain import Brain, Wanderer, register_neuron_type
+
+        class FailingPlugin:
+            def forward(self, neuron, input_value=None):
+                raise RuntimeError("boom")
+
+        self.Brain = Brain
+        self.Wanderer = Wanderer
+        self.register_neuron_type = register_neuron_type
+        self.register_neuron_type("fail", FailingPlugin())
+
+    def test_fallback_on_error(self):
+        b = self.Brain(1, size=(1,))
+        idx = b.available_indices()[0]
+        n = b.add_neuron(idx, tensor=[1.0], type_name="autoneuron")
+        w = self.Wanderer(b, seed=0)
+        w.ensure_learnable_param("autoneuron_bias_fail", 10.0)
+        w.ensure_learnable_param("autoneuron_bias_base", -10.0)
+        res = w.walk(max_steps=1, start=n, lr=0.0)
+        self.assertIn("loss", res)
+        self.assertEqual(n.type_name, "autoneuron")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add AutoNeuron neuron plugin that learns to delegate to other types and falls back on error
- register AutoNeuron in marblemain and pass Wanderer context to neurons
- document AutoNeuron and add regression test

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m pip install -e .`
- `python -m unittest -v tests.test_autoneuron`
- `for t in tests/test_*.py; do mod=${t%.py}; mod=${mod//\//.}; python -m unittest -v $mod >/tmp/unit.log && tail -n 20 /tmp/unit.log; done`


------
https://chatgpt.com/codex/tasks/task_e_68b1272fb5fc83279a6e95fccb0a44d8