### PR TITLE
Add 3D printer simulator development plan

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -1,0 +1,47 @@
+Step 1: Analyse Marlin Firmware
+    Substep 1.1: Clone Marlin repository and review hardware abstraction layers
+    Substep 1.2: Identify required interfaces (USB, SD, sensors, motion control)
+    Substep 1.3: Document Marlin's configuration options relevant to simulation
+
+Step 2: Define Simulation Configuration System
+    Substep 2.1: Create config file structure
+        Subsubstep 2.1.1: Parameters for build volume and bed size
+        Subsubstep 2.1.2: Parameters for maximum print dimensions
+        Subsubstep 2.1.3: Parameters for extruder/hotend count and types
+    Substep 2.2: Implement parser and validation for configuration
+
+Step 3: Implement Hardware Emulation Layer
+    Substep 3.1: Emulate microcontroller architecture compatible with Marlin
+    Substep 3.2: Provide virtual USB interface
+    Substep 3.3: Provide virtual SD card storage
+    Substep 3.4: Simulate temperature and other sensors
+    Substep 3.5: Map Marlin I/O pins to simulated components
+
+Step 4: Develop Motion and Physics Simulation
+    Substep 4.1: Model kinematics for printer axes
+        Subsubstep 4.1.1: Implement stepper motor behavior
+        Subsubstep 4.1.2: Handle acceleration and jerk limits
+    Substep 4.2: Simulate extrusion and material deposition
+    Substep 4.3: Compute thermal behavior for hotends and bed
+
+Step 5: Create 3D Visualization Module
+    Substep 5.1: Render isometric view of printer and prints
+    Substep 5.2: Render side view focusing on motion
+    Substep 5.3: Render bed-only top-down view
+    Substep 5.4: Synchronize visualization with physics simulation
+
+Step 6: Integrate with Marlin
+    Substep 6.1: Compile unmodified Marlin to run on emulation layer
+    Substep 6.2: Forward G-code commands through virtual USB
+    Substep 6.3: Expose virtual SD card to Marlin for file operations
+    Substep 6.4: Feed simulated sensor data to firmware
+
+Step 7: Testing Framework
+    Substep 7.1: Create unit tests for configuration parser
+    Substep 7.2: Create integration tests for firmware communication
+    Substep 7.3: Validate physics simulation against known printer behavior
+
+Step 8: Documentation and Examples
+    Substep 8.1: Write setup guide for configuring printers
+    Substep 8.2: Provide example configurations for common printers
+    Substep 8.3: Document API for extending hardware components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,3 +398,4 @@ Hugging Face Datasets Policy (additive)
 52. Before running any tests, explicitly install the CPU-only version of torch via `pip install --index-url https://download.pytorch.org/whl/cpu torch`.
 53. Example scripts that enable batching must load the `batchtrainer` Wanderer plugin and set `batch_size` consistently in both `neuro_config` and helper arguments.
 54. Dynamic neuron types like `AutoNeuron` must revert to the previous type on errors and expose selection parameters via `expose_learnable_params` to keep gradients intact.
+55. Development plan directories must contain a `developmentplan.md` with Step/Substep/Subsubstep structure so new modules can be executed sequentially.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -529,3 +529,8 @@ All additions remain fully additive; existing behavior and APIs are preserved. E
 Utility Scripts
 
 Helper scripts `clone_or_update.sh` and `clone_or_update.ps1` automate cloning or updating the repository and perform an editable install via `pip install -e .`.
+
+## 3D Printer Simulator Plan
+
+- Directory `3d_printer_sim` holds a development plan for a future 3D printer simulator.
+- The plan targets full compatibility with unmodified Marlin firmware, including virtual USB/SD interfaces, configurable build volumes, and complete sensor and physics emulation.


### PR DESCRIPTION
## Summary
- Document a stepwise development plan for a 3D printer simulator compatible with Marlin firmware
- Note new plan directory in the architecture overview
- Clarify in AGENTS that all plan directories must include a structured developmentplan.md

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m pip install -e .`
- `for t in tests/test_*.py; do module=$(echo ${t%.py} | tr '/' '.'); python -m unittest -v $module || break; done`


------
https://chatgpt.com/codex/tasks/task_e_68b132dd5afc8327b60125706879ef5e