### PR TITLE
Add configuration system for 3D printer simulator

### DIFF
--- a/3d_printer_sim/config.py
+++ b/3d_printer_sim/config.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+import yaml
+
+
+@dataclass
+class Volume:
+    x: float
+    y: float
+    z: float
+
+    @staticmethod
+    def from_dict(d: dict, name: str) -> "Volume":
+        for axis in ("x", "y", "z"):
+            if axis not in d:
+                raise ValueError(f"{name} missing axis {axis}")
+            if d[axis] <= 0:
+                raise ValueError(f"{name}.{axis} must be positive")
+        return Volume(float(d["x"]), float(d["y"]), float(d["z"]))
+
+
+@dataclass
+class BedSize:
+    x: float
+    y: float
+
+    @staticmethod
+    def from_dict(d: dict) -> "BedSize":
+        for axis in ("x", "y"):
+            if axis not in d:
+                raise ValueError(f"bed_size missing axis {axis}")
+            if d[axis] <= 0:
+                raise ValueError(f"bed_size.{axis} must be positive")
+        return BedSize(float(d["x"]), float(d["y"]))
+
+
+@dataclass
+class Extruder:
+    id: int
+    type: str
+    hotend: str
+
+    @staticmethod
+    def from_dict(d: dict) -> "Extruder":
+        if "id" not in d or "type" not in d or "hotend" not in d:
+            raise ValueError("extruder requires id, type and hotend")
+        return Extruder(int(d["id"]), str(d["type"]), str(d["hotend"]))
+
+
+@dataclass
+class PrinterConfig:
+    build_volume: Volume
+    bed_size: BedSize
+    max_print_dimensions: Volume
+    extruders: List[Extruder]
+
+
+def load_config(path: str) -> PrinterConfig:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if "build_volume" not in data or "bed_size" not in data or "max_print_dimensions" not in data or "extruders" not in data:
+        raise ValueError("config missing required sections")
+    build_volume = Volume.from_dict(data["build_volume"], "build_volume")
+    bed_size = BedSize.from_dict(data["bed_size"])
+    max_print = Volume.from_dict(data["max_print_dimensions"], "max_print_dimensions")
+    if not isinstance(data["extruders"], list) or not data["extruders"]:
+        raise ValueError("extruders must be a non-empty list")
+    extruders = [Extruder.from_dict(e) for e in data["extruders"]]
+    return PrinterConfig(
+        build_volume=build_volume,
+        bed_size=bed_size,
+        max_print_dimensions=max_print,
+        extruders=extruders,
+    )
+

--- a/3d_printer_sim/config.yaml
+++ b/3d_printer_sim/config.yaml
@@ -1,0 +1,18 @@
+build_volume:
+  x: 220
+  y: 220
+  z: 250
+bed_size:
+  x: 220
+  y: 220
+max_print_dimensions:
+  x: 200
+  y: 200
+  z: 200
+extruders:
+  - id: 0
+    type: direct
+    hotend: e3d_v6
+  - id: 1
+    type: bowden
+    hotend: volcano

--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -4,11 +4,11 @@ Step 1: Analyse Marlin Firmware [complete]
     Substep 1.3: Document Marlin's configuration options relevant to simulation [complete]
 
 Step 2: Define Simulation Configuration System
-    Substep 2.1: Create config file structure
-        Subsubstep 2.1.1: Parameters for build volume and bed size
-        Subsubstep 2.1.2: Parameters for maximum print dimensions
-        Subsubstep 2.1.3: Parameters for extruder/hotend count and types
-    Substep 2.2: Implement parser and validation for configuration
+    Substep 2.1: Create config file structure [complete]
+        Subsubstep 2.1.1: Parameters for build volume and bed size [complete]
+        Subsubstep 2.1.2: Parameters for maximum print dimensions [complete]
+        Subsubstep 2.1.3: Parameters for extruder/hotend count and types [complete]
+    Substep 2.2: Implement parser and validation for configuration [complete]
 
 Step 3: Implement Hardware Emulation Layer
     Substep 3.1: Emulate microcontroller architecture compatible with Marlin

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -534,4 +534,5 @@ Helper scripts `clone_or_update.sh` and `clone_or_update.ps1` automate cloning o
 
 - Directory `3d_printer_sim` holds a development plan for a future 3D printer simulator.
 - The plan targets full compatibility with unmodified Marlin firmware, including virtual USB/SD interfaces, configurable build volumes, and complete sensor and physics emulation.
- - Initial Marlin firmware study is recorded in `3d_printer_sim/marlin_analysis.md`, outlining HAL structure, required interfaces, and key configuration parameters.
+- Initial Marlin firmware study is recorded in `3d_printer_sim/marlin_analysis.md`, outlining HAL structure, required interfaces, and key configuration parameters.
+- A YAML-based configuration system (`3d_printer_sim/config.yaml`) defines build volume, bed size, maximum print dimensions, and extruder/hotend setups. A typed parser (`3d_printer_sim/config.py`) validates these parameters for use in later simulator stages.

--- a/tests/test_3d_printer_sim_config.py
+++ b/tests/test_3d_printer_sim_config.py
@@ -1,0 +1,36 @@
+import importlib.util
+import pathlib
+import unittest
+
+import sys
+
+from marble.reporter import report, clear_report_group, report_group
+
+spec = importlib.util.spec_from_file_location(
+    "printer_config", pathlib.Path("3d_printer_sim/config.py")
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+load_config = module.load_config
+
+
+class TestPrinterConfig(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_report_group("3d_printer_sim")
+
+    def tearDown(self) -> None:
+        clear_report_group("3d_printer_sim")
+
+    def test_load_config(self) -> None:
+        cfg = load_config("3d_printer_sim/config.yaml")
+        report("3d_printer_sim", "extruder_count", len(cfg.extruders))
+        self.assertEqual(len(cfg.extruders), 2)
+        self.assertEqual(cfg.build_volume.z, 250)
+        logged = report_group("3d_printer_sim")
+        self.assertIn("extruder_count", logged)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add YAML config defining build volume, bed size, max print dimensions, and extruders
- implement typed parser with validation for simulator configuration
- document configuration system in development plan and architecture
- add unit test logging via REPORTER

## Testing
- `python -m py_compile 3d_printer_sim/config.py tests/test_3d_printer_sim_config.py`
- `python -m unittest tests.test_3d_printer_sim_config -v`


------
https://chatgpt.com/codex/tasks/task_e_68b137c8341c8327a81f1ece5e2e5b27