### PR TITLE
Add SD card and sensor support to 3D printer sim

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -13,8 +13,8 @@ Step 2: Define Simulation Configuration System
 Step 3: Implement Hardware Emulation Layer
     Substep 3.1: Emulate microcontroller architecture compatible with Marlin [complete]
     Substep 3.2: Provide virtual USB interface [complete]
-    Substep 3.3: Provide virtual SD card storage
-    Substep 3.4: Simulate temperature and other sensors
+    Substep 3.3: Provide virtual SD card storage [complete]
+    Substep 3.4: Simulate temperature and other sensors [complete]
     Substep 3.5: Map Marlin I/O pins to simulated components
 
 Step 4: Develop Motion and Physics Simulation

--- a/3d_printer_sim/sdcard.py
+++ b/3d_printer_sim/sdcard.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class VirtualSDCard:
+    """In-memory representation of an SD card."""
+
+    mounted: bool = False
+    files: Dict[str, bytes] = field(default_factory=dict)
+
+    def mount(self) -> None:
+        self.mounted = True
+
+    def unmount(self) -> None:
+        self.mounted = False
+        self.files.clear()
+
+    def write_file(self, path: str, data: bytes) -> None:
+        if not self.mounted:
+            raise RuntimeError("SD card not mounted")
+        self.files[path] = bytes(data)
+
+    def read_file(self, path: str) -> Optional[bytes]:
+        if not self.mounted:
+            raise RuntimeError("SD card not mounted")
+        return self.files.get(path)
+
+    def list_files(self) -> List[str]:
+        if not self.mounted:
+            raise RuntimeError("SD card not mounted")
+        return sorted(self.files.keys())
+
+    def delete_file(self, path: str) -> None:
+        if not self.mounted:
+            raise RuntimeError("SD card not mounted")
+        self.files.pop(path, None)

--- a/3d_printer_sim/sensors.py
+++ b/3d_printer_sim/sensors.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class AnalogSensor:
+    """Basic analog sensor updating a microcontroller pin."""
+
+    mc: Any
+    pin: int
+    value: float = 0.0
+
+    def __post_init__(self) -> None:
+        self.mc.set_analog(self.pin, self.value)
+
+    def set_value(self, value: float) -> None:
+        self.value = float(value)
+        self.mc.set_analog(self.pin, self.value)
+
+    def read_value(self) -> float:
+        return self.value
+
+
+@dataclass
+class TemperatureSensor(AnalogSensor):
+    """Temperature sensor that stores degrees Celsius."""
+
+    def set_temperature(self, temp: float) -> None:
+        self.set_value(temp)
+
+    def read_temperature(self) -> float:
+        return self.read_value()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,3 +400,4 @@ Hugging Face Datasets Policy (additive)
 54. Dynamic neuron types like `AutoNeuron` must revert to the previous type on errors and expose selection parameters via `expose_learnable_params` to keep gradients intact.
 55. Development plan directories must contain a `developmentplan.md` with Step/Substep/Subsubstep structure so new modules can be executed sequentially.
 56. Document analyses of external dependencies in corresponding subdirectories as markdown files to preserve context for future steps.
+57. Modules under `3d_printer_sim` must remain self-contained, using only Python's standard library and other files within that directory.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -538,3 +538,5 @@ Helper scripts `clone_or_update.sh` and `clone_or_update.ps1` automate cloning o
 - A YAML-based configuration system (`3d_printer_sim/config.yaml`) defines build volume, bed size, maximum print dimensions, and extruder/hotend setups. A typed parser (`3d_printer_sim/config.py`) validates these parameters for use in later simulator stages.
 - `3d_printer_sim/microcontroller.py` introduces a minimal microcontroller emulator. It tracks digital and analog pin states via dictionaries and provides read/write helpers, forming the foundation for later hardware emulation compatible with Marlin firmware.
 - `3d_printer_sim/usb.py` implements a `VirtualUSB` class with host and device buffers. A microcontroller can attach to this interface to exchange bytes with a host, enabling a virtual USB link for future Marlin communication.
+- `3d_printer_sim/sdcard.py` offers an in-memory `VirtualSDCard` with mount/unmount support and basic file operations that the microcontroller can expose to firmware.
+- `3d_printer_sim/sensors.py` adds simple analog sensors; `TemperatureSensor` updates a microcontroller's analog pin as its temperature value changes.

--- a/tests/test_3d_printer_sim_sdcard.py
+++ b/tests/test_3d_printer_sim_sdcard.py
@@ -1,0 +1,46 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+spec_sd = importlib.util.spec_from_file_location(
+    "sdcard", pathlib.Path("3d_printer_sim/sdcard.py")
+)
+module_sd = importlib.util.module_from_spec(spec_sd)
+assert spec_sd.loader is not None
+sys.modules[spec_sd.name] = module_sd
+spec_sd.loader.exec_module(module_sd)
+VirtualSDCard = module_sd.VirtualSDCard
+
+spec_mc = importlib.util.spec_from_file_location(
+    "microcontroller", pathlib.Path("3d_printer_sim/microcontroller.py")
+)
+module_mc = importlib.util.module_from_spec(spec_mc)
+assert spec_mc.loader is not None
+sys.modules[spec_mc.name] = module_mc
+spec_mc.loader.exec_module(module_mc)
+Microcontroller = module_mc.Microcontroller
+
+
+class TestSDCard(unittest.TestCase):
+    def test_basic_file_ops(self) -> None:
+        card = VirtualSDCard()
+        card.mount()
+        card.write_file("test.gcode", b"G1 X10")
+        self.assertEqual(card.read_file("test.gcode"), b"G1 X10")
+        self.assertEqual(card.list_files(), ["test.gcode"])
+        card.delete_file("test.gcode")
+        self.assertEqual(card.list_files(), [])
+
+    def test_microcontroller_sd_interface(self) -> None:
+        mc = Microcontroller()
+        card = VirtualSDCard()
+        card.mount()
+        mc.attach_sd_card(card)
+        mc.sd_write_file("a.txt", b"abc")
+        self.assertEqual(mc.sd_read_file("a.txt"), b"abc")
+        self.assertEqual(mc.sd_list_files(), ["a.txt"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_3d_printer_sim_sensors.py
+++ b/tests/test_3d_printer_sim_sensors.py
@@ -1,0 +1,35 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+spec_mc = importlib.util.spec_from_file_location(
+    "microcontroller", pathlib.Path("3d_printer_sim/microcontroller.py")
+)
+module_mc = importlib.util.module_from_spec(spec_mc)
+assert spec_mc.loader is not None
+sys.modules[spec_mc.name] = module_mc
+spec_mc.loader.exec_module(module_mc)
+Microcontroller = module_mc.Microcontroller
+
+spec_sensors = importlib.util.spec_from_file_location(
+    "sensors", pathlib.Path("3d_printer_sim/sensors.py")
+)
+module_sensors = importlib.util.module_from_spec(spec_sensors)
+assert spec_sensors.loader is not None
+sys.modules[spec_sensors.name] = module_sensors
+spec_sensors.loader.exec_module(module_sensors)
+TemperatureSensor = module_sensors.TemperatureSensor
+
+
+class TestSensors(unittest.TestCase):
+    def test_temperature_sensor_updates_pin(self) -> None:
+        mc = Microcontroller()
+        sensor = TemperatureSensor(mc=mc, pin=0, value=25.0)
+        self.assertAlmostEqual(mc.read_analog(0), 25.0)
+        sensor.set_temperature(200.0)
+        self.assertAlmostEqual(mc.read_analog(0), 200.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement in-memory VirtualSDCard with microcontroller hooks
- add AnalogSensor and TemperatureSensor abstractions
- document and mark development plan steps 3.3-3.4 as complete

## Testing
- `python -m unittest tests.test_3d_printer_sim_config -v`
- `python -m unittest tests.test_3d_printer_sim_microcontroller -v`
- `python -m unittest tests.test_3d_printer_sim_usb -v`
- `python -m unittest tests.test_3d_printer_sim_sdcard -v`
- `python -m unittest tests.test_3d_printer_sim_sensors -v`


------
https://chatgpt.com/codex/tasks/task_e_68b13b7963e88327bca6c95da533da45