### PR TITLE
feat: map microcontroller pins to components

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -15,7 +15,7 @@ Step 3: Implement Hardware Emulation Layer
     Substep 3.2: Provide virtual USB interface [complete]
     Substep 3.3: Provide virtual SD card storage [complete]
     Substep 3.4: Simulate temperature and other sensors [complete]
-    Substep 3.5: Map Marlin I/O pins to simulated components
+    Substep 3.5: Map Marlin I/O pins to simulated components [complete]
 
 Step 4: Develop Motion and Physics Simulation
     Substep 4.1: Model kinematics for printer axes

--- a/3d_printer_sim/sensors.py
+++ b/3d_printer_sim/sensors.py
@@ -14,6 +14,8 @@ class AnalogSensor:
 
     def __post_init__(self) -> None:
         self.mc.set_analog(self.pin, self.value)
+        if hasattr(self.mc, "map_pin"):
+            self.mc.map_pin(self.pin, self)
 
     def set_value(self, value: float) -> None:
         self.value = float(value)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,3 +401,4 @@ Hugging Face Datasets Policy (additive)
 55. Development plan directories must contain a `developmentplan.md` with Step/Substep/Subsubstep structure so new modules can be executed sequentially.
 56. Document analyses of external dependencies in corresponding subdirectories as markdown files to preserve context for future steps.
 57. Modules under `3d_printer_sim` must remain self-contained, using only Python's standard library and other files within that directory.
+58. The microcontroller in `3d_printer_sim` must track pin-to-component mappings so tests can verify attached devices by pin number.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -540,3 +540,4 @@ Helper scripts `clone_or_update.sh` and `clone_or_update.ps1` automate cloning o
 - `3d_printer_sim/usb.py` implements a `VirtualUSB` class with host and device buffers. A microcontroller can attach to this interface to exchange bytes with a host, enabling a virtual USB link for future Marlin communication.
 - `3d_printer_sim/sdcard.py` offers an in-memory `VirtualSDCard` with mount/unmount support and basic file operations that the microcontroller can expose to firmware.
 - `3d_printer_sim/sensors.py` adds simple analog sensors; `TemperatureSensor` updates a microcontroller's analog pin as its temperature value changes.
+- `3d_printer_sim/microcontroller.py` now maintains a mapping of Marlin-style I/O pins to the components attached to them, allowing sensors and interfaces like USB or SD cards to be registered and looked up by pin.

--- a/tests/test_3d_printer_sim_pinmap.py
+++ b/tests/test_3d_printer_sim_pinmap.py
@@ -1,0 +1,69 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+# Load modules from 3d_printer_sim
+spec_mc = importlib.util.spec_from_file_location(
+    "microcontroller", pathlib.Path("3d_printer_sim/microcontroller.py")
+)
+mc_module = importlib.util.module_from_spec(spec_mc)
+assert spec_mc.loader is not None
+sys.modules[spec_mc.name] = mc_module
+spec_mc.loader.exec_module(mc_module)
+Microcontroller = mc_module.Microcontroller
+
+spec_usb = importlib.util.spec_from_file_location(
+    "usb", pathlib.Path("3d_printer_sim/usb.py")
+)
+usb_module = importlib.util.module_from_spec(spec_usb)
+assert spec_usb.loader is not None
+sys.modules[spec_usb.name] = usb_module
+spec_usb.loader.exec_module(usb_module)
+VirtualUSB = usb_module.VirtualUSB
+
+spec_sd = importlib.util.spec_from_file_location(
+    "sdcard", pathlib.Path("3d_printer_sim/sdcard.py")
+)
+sd_module = importlib.util.module_from_spec(spec_sd)
+assert spec_sd.loader is not None
+sys.modules[spec_sd.name] = sd_module
+spec_sd.loader.exec_module(sd_module)
+VirtualSDCard = sd_module.VirtualSDCard
+
+spec_sensors = importlib.util.spec_from_file_location(
+    "sensors", pathlib.Path("3d_printer_sim/sensors.py")
+)
+sensors_module = importlib.util.module_from_spec(spec_sensors)
+assert spec_sensors.loader is not None
+sys.modules[spec_sensors.name] = sensors_module
+spec_sensors.loader.exec_module(sensors_module)
+TemperatureSensor = sensors_module.TemperatureSensor
+
+
+class TestPinMapping(unittest.TestCase):
+    def test_sensor_auto_maps(self) -> None:
+        mc = Microcontroller()
+        sensor = TemperatureSensor(mc=mc, pin=0, value=25.0)
+        self.assertIs(mc.get_mapped_component(0), sensor)
+
+    def test_manual_and_interface_mapping(self) -> None:
+        mc = Microcontroller()
+        mc.map_pin(13, "led")
+        self.assertEqual(mc.get_mapped_component(13), "led")
+        mc.unmap_pin(13)
+        self.assertIsNone(mc.get_mapped_component(13))
+
+        usb = VirtualUSB()
+        usb.connect()
+        mc.attach_usb(usb, pins=[1, 2])
+        self.assertIs(mc.get_mapped_component(1), usb)
+
+        card = VirtualSDCard()
+        card.mount()
+        mc.attach_sd_card(card, pins=[10])
+        self.assertIs(mc.get_mapped_component(10), card)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- track pin-to-component connections in microcontroller and allow optional pin mapping when attaching USB or SD interfaces
- sensors automatically register their pins with the microcontroller
- test pin mapping logic with new unit tests

## Testing
- `python -m unittest tests.test_3d_printer_sim_config -v`
- `python -m unittest tests.test_3d_printer_sim_microcontroller -v`
- `python -m unittest tests.test_3d_printer_sim_sdcard -v`
- `python -m unittest tests.test_3d_printer_sim_sensors -v`
- `python -m unittest tests.test_3d_printer_sim_usb -v`
- `python -m unittest tests.test_3d_printer_sim_pinmap -v`


------
https://chatgpt.com/codex/tasks/task_e_68b14647b53c832790300dccce4836d7