### PR TITLE
Add stepper motor kinematics for 3D printer simulator

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -18,9 +18,9 @@ Step 3: Implement Hardware Emulation Layer
     Substep 3.5: Map Marlin I/O pins to simulated components [complete]
 
 Step 4: Develop Motion and Physics Simulation
-    Substep 4.1: Model kinematics for printer axes
-        Subsubstep 4.1.1: Implement stepper motor behavior
-        Subsubstep 4.1.2: Handle acceleration and jerk limits
+    Substep 4.1: Model kinematics for printer axes [complete]
+        Subsubstep 4.1.1: Implement stepper motor behavior [complete]
+        Subsubstep 4.1.2: Handle acceleration and jerk limits [complete]
     Substep 4.2: Simulate extrusion and material deposition
     Substep 4.3: Compute thermal behavior for hotends and bed
 

--- a/3d_printer_sim/stepper.py
+++ b/3d_printer_sim/stepper.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Simple stepper motor model with kinematic limits.
+
+The model tracks position, velocity and acceleration and exposes a
+``set_target_velocity`` method. On each ``update`` call the internal
+state advances by ``dt`` seconds while respecting maximum acceleration
+and jerk (rate of change of acceleration).
+
+Only the Python standard library is used to keep the module fully
+self‑contained inside ``3d_printer_sim``.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class StepperMotor:
+    """Represents a single stepper motor axis.
+
+    Parameters
+    ----------
+    max_acceleration:
+        Absolute limit for acceleration in steps/s^2.
+    max_jerk:
+        Absolute limit for change in acceleration per second
+        (steps/s^3).
+    """
+
+    max_acceleration: float
+    max_jerk: float
+    position: float = 0.0
+    velocity: float = 0.0
+    acceleration: float = 0.0
+    target_velocity: float = 0.0
+
+    def set_target_velocity(self, velocity: float) -> None:
+        """Set the desired velocity in steps/s."""
+
+        self.target_velocity = float(velocity)
+
+    def update(self, dt: float) -> None:
+        """Advance the motor state by ``dt`` seconds.
+
+        The update first adjusts acceleration towards the required
+        acceleration to reach ``target_velocity``. The change in
+        acceleration is limited by ``max_jerk`` and the resulting
+        acceleration is clamped to ``max_acceleration``. Velocity and
+        position are then integrated using the updated acceleration.
+        """
+
+        if dt <= 0:
+            raise ValueError("dt must be positive")
+
+        # Desired acceleration to hit the target velocity in this step
+        target_accel = (self.target_velocity - self.velocity) / dt
+        delta_accel = target_accel - self.acceleration
+
+        # Limit change in acceleration (jerk)
+        max_delta = self.max_jerk * dt
+        if delta_accel > max_delta:
+            delta_accel = max_delta
+        elif delta_accel < -max_delta:
+            delta_accel = -max_delta
+
+        self.acceleration += delta_accel
+
+        # Clamp acceleration
+        if self.acceleration > self.max_acceleration:
+            self.acceleration = self.max_acceleration
+        elif self.acceleration < -self.max_acceleration:
+            self.acceleration = -self.max_acceleration
+
+        prev_velocity = self.velocity
+
+        # Integrate velocity and position
+        self.velocity += self.acceleration * dt
+
+        # Prevent overshoot beyond target velocity
+        if self.target_velocity > prev_velocity and self.velocity > self.target_velocity:
+            self.velocity = self.target_velocity
+            self.acceleration = 0.0
+        elif self.target_velocity < prev_velocity and self.velocity < self.target_velocity:
+            self.velocity = self.target_velocity
+            self.acceleration = 0.0
+
+        self.position += self.velocity * dt
+
+
+__all__ = ["StepperMotor"]
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -402,3 +402,4 @@ Hugging Face Datasets Policy (additive)
 56. Document analyses of external dependencies in corresponding subdirectories as markdown files to preserve context for future steps.
 57. Modules under `3d_printer_sim` must remain self-contained, using only Python's standard library and other files within that directory.
 58. The microcontroller in `3d_printer_sim` must track pin-to-component mappings so tests can verify attached devices by pin number.
+59. Motion modules in `3d_printer_sim` must update deterministically via time-step `update(dt)` functions and enforce configured acceleration and jerk limits validated by unit tests.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -541,3 +541,4 @@ Helper scripts `clone_or_update.sh` and `clone_or_update.ps1` automate cloning o
 - `3d_printer_sim/sdcard.py` offers an in-memory `VirtualSDCard` with mount/unmount support and basic file operations that the microcontroller can expose to firmware.
 - `3d_printer_sim/sensors.py` adds simple analog sensors; `TemperatureSensor` updates a microcontroller's analog pin as its temperature value changes.
 - `3d_printer_sim/microcontroller.py` now maintains a mapping of Marlin-style I/O pins to the components attached to them, allowing sensors and interfaces like USB or SD cards to be registered and looked up by pin.
+- `3d_printer_sim/stepper.py` introduces a deterministic `StepperMotor` model that advances position over time while enforcing acceleration and jerk limits, forming the foundation of printer-axis kinematics.

--- a/tests/test_3d_printer_sim_stepper.py
+++ b/tests/test_3d_printer_sim_stepper.py
@@ -1,0 +1,53 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, pathlib.Path(filename))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+stepper_mod = load_module("stepper", "3d_printer_sim/stepper.py")
+micro_mod = load_module("microcontroller", "3d_printer_sim/microcontroller.py")
+
+StepperMotor = stepper_mod.StepperMotor
+Microcontroller = micro_mod.Microcontroller
+
+
+class TestStepperMotor(unittest.TestCase):
+    def test_accel_and_jerk_limits(self) -> None:
+        motor = StepperMotor(max_acceleration=10, max_jerk=5)
+        motor.set_target_velocity(100)
+        motor.update(1.0)
+        self.assertAlmostEqual(motor.acceleration, 5)
+        self.assertAlmostEqual(motor.velocity, 5)
+        self.assertAlmostEqual(motor.position, 5)
+        motor.update(1.0)
+        self.assertAlmostEqual(motor.acceleration, 10)
+        self.assertAlmostEqual(motor.velocity, 15)
+        self.assertAlmostEqual(motor.position, 20)
+
+    def test_jerk_limit_progression(self) -> None:
+        motor = StepperMotor(max_acceleration=50, max_jerk=2)
+        motor.set_target_velocity(100)
+        motor.update(1.0)
+        self.assertAlmostEqual(motor.acceleration, 2)
+        motor.update(1.0)
+        self.assertAlmostEqual(motor.acceleration, 4)
+
+    def test_pin_mapping(self) -> None:
+        mcu = Microcontroller()
+        motor = StepperMotor(max_acceleration=10, max_jerk=5)
+        mcu.map_pin(1, motor)
+        self.assertIs(mcu.get_mapped_component(1), motor)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- implement deterministic StepperMotor with acceleration and jerk limits
- document motion module and update development plan
- add unit tests for stepper kinematics and pin mapping

## Testing
- `python -m unittest tests.test_3d_printer_sim_config -v`
- `python -m unittest tests.test_3d_printer_sim_microcontroller -v`
- `python -m unittest tests.test_3d_printer_sim_pinmap -v`
- `python -m unittest tests.test_3d_printer_sim_sdcard -v`
- `python -m unittest tests.test_3d_printer_sim_sensors -v`
- `python -m unittest tests.test_3d_printer_sim_usb -v`
- `python -m unittest tests.test_3d_printer_sim_stepper -v`


------
https://chatgpt.com/codex/tasks/task_e_68b147352f3883279e2ccf30a5f3d3d6