### PR TITLE
Add extrusion and thermal simulation to 3d printer sim

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -21,8 +21,8 @@ Step 4: Develop Motion and Physics Simulation
     Substep 4.1: Model kinematics for printer axes [complete]
         Subsubstep 4.1.1: Implement stepper motor behavior [complete]
         Subsubstep 4.1.2: Handle acceleration and jerk limits [complete]
-    Substep 4.2: Simulate extrusion and material deposition
-    Substep 4.3: Compute thermal behavior for hotends and bed
+    Substep 4.2: Simulate extrusion and material deposition [complete]
+    Substep 4.3: Compute thermal behavior for hotends and bed [complete]
 
 Step 5: Create 3D Visualization Module
     Substep 5.1: Render isometric view of printer and prints

--- a/3d_printer_sim/extruder.py
+++ b/3d_printer_sim/extruder.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Extrusion and material deposition model.
+
+The :class:`Extruder` couples a stepper motor with basic filament
+geometry to track how much material has been extruded.  It remains
+self‑contained inside ``3d_printer_sim`` and only relies on modules in
+this directory.
+"""
+
+from dataclasses import dataclass
+import importlib.util
+import math
+import pathlib
+import sys
+
+_spec = importlib.util.spec_from_file_location(
+    "stepper", pathlib.Path(__file__).with_name("stepper.py")
+)
+_module = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules[_spec.name] = _module
+_spec.loader.exec_module(_module)
+StepperMotor = _module.StepperMotor
+
+
+@dataclass
+class Extruder:
+    """Represents a filament extruder.
+
+    Parameters
+    ----------
+    stepper:
+        Stepper motor driving the filament.
+    steps_per_mm:
+        Number of motor steps that move one millimetre of filament.
+    filament_diameter:
+        Diameter of the filament in millimetres used to compute volume.
+    """
+
+    stepper: StepperMotor
+    steps_per_mm: float
+    filament_diameter: float
+    extruded_length: float = 0.0
+    deposited_volume: float = 0.0
+
+    def set_target_velocity(self, velocity: float) -> None:
+        """Proxy to the stepper's ``set_target_velocity``."""
+
+        self.stepper.set_target_velocity(velocity)
+
+    def update(self, dt: float) -> None:
+        """Advance simulation by ``dt`` seconds.
+
+        The stepper state is updated and the resulting change in
+        position is converted into extruded filament length and volume.
+        """
+
+        prev_pos = self.stepper.position
+        self.stepper.update(dt)
+        delta_steps = self.stepper.position - prev_pos
+        length_mm = delta_steps / self.steps_per_mm
+        if length_mm <= 0:
+            return
+        self.extruded_length += length_mm
+        area = math.pi * (self.filament_diameter / 2) ** 2
+        self.deposited_volume += area * length_mm
+
+    def reset(self) -> None:
+        """Reset accumulated extrusion metrics."""
+
+        self.extruded_length = 0.0
+        self.deposited_volume = 0.0
+
+
+__all__ = ["Extruder"]
+

--- a/3d_printer_sim/thermal.py
+++ b/3d_printer_sim/thermal.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Thermal component models for hotends and heated beds."""
+
+from dataclasses import dataclass
+import importlib.util
+import pathlib
+import sys
+
+_spec = importlib.util.spec_from_file_location(
+    "sensors", pathlib.Path(__file__).with_name("sensors.py")
+)
+_module = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+sys.modules[_spec.name] = _module
+_spec.loader.exec_module(_module)
+TemperatureSensor = _module.TemperatureSensor
+
+
+@dataclass
+class Heater:
+    """Base class for temperature controlled components."""
+
+    sensor: TemperatureSensor
+    heating_rate: float  # degrees per second while heating
+    cooling_rate: float  # degrees per second while cooling
+    target_temperature: float = 25.0
+
+    def set_target_temperature(self, temp: float) -> None:
+        self.target_temperature = float(temp)
+
+    def update(self, dt: float) -> None:
+        """Advance the thermal simulation by ``dt`` seconds."""
+
+        if dt <= 0:
+            raise ValueError("dt must be positive")
+        current = self.sensor.read_temperature()
+        if current < self.target_temperature:
+            current += self.heating_rate * dt
+            if current > self.target_temperature:
+                current = self.target_temperature
+        elif current > self.target_temperature:
+            current -= self.cooling_rate * dt
+            if current < self.target_temperature:
+                current = self.target_temperature
+        self.sensor.set_temperature(current)
+
+
+class Hotend(Heater):
+    """Hotend heater."""
+
+
+class HeatedBed(Heater):
+    """Heated bed controller."""
+
+
+__all__ = ["Heater", "Hotend", "HeatedBed"]
+

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -542,3 +542,5 @@ Helper scripts `clone_or_update.sh` and `clone_or_update.ps1` automate cloning o
 - `3d_printer_sim/sensors.py` adds simple analog sensors; `TemperatureSensor` updates a microcontroller's analog pin as its temperature value changes.
 - `3d_printer_sim/microcontroller.py` now maintains a mapping of Marlin-style I/O pins to the components attached to them, allowing sensors and interfaces like USB or SD cards to be registered and looked up by pin.
 - `3d_printer_sim/stepper.py` introduces a deterministic `StepperMotor` model that advances position over time while enforcing acceleration and jerk limits, forming the foundation of printer-axis kinematics.
+- `3d_printer_sim/extruder.py` couples a stepper motor with filament geometry to track extruded length and deposited volume.
+- `3d_printer_sim/thermal.py` provides `Heater` implementations for hotends and heated beds, updating `TemperatureSensor` readings while respecting configurable heating and cooling rates.

--- a/tests/test_3d_printer_sim_extrusion.py
+++ b/tests/test_3d_printer_sim_extrusion.py
@@ -1,0 +1,37 @@
+import importlib.util
+import math
+import pathlib
+import sys
+import unittest
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, pathlib.Path(filename))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+stepper_mod = load_module("stepper", "3d_printer_sim/stepper.py")
+extruder_mod = load_module("extruder", "3d_printer_sim/extruder.py")
+
+StepperMotor = stepper_mod.StepperMotor
+Extruder = extruder_mod.Extruder
+
+
+class TestExtruder(unittest.TestCase):
+    def test_extrusion_volume(self) -> None:
+        motor = StepperMotor(max_acceleration=1000, max_jerk=1000)
+        extruder = Extruder(motor, steps_per_mm=100, filament_diameter=1.75)
+        extruder.set_target_velocity(100)  # steps per second
+        extruder.update(1.0)
+        self.assertAlmostEqual(extruder.extruded_length, 1.0)
+        expected_volume = math.pi * (1.75 / 2) ** 2 * 1.0
+        self.assertAlmostEqual(extruder.deposited_volume, expected_volume)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_3d_printer_sim_thermal.py
+++ b/tests/test_3d_printer_sim_thermal.py
@@ -1,0 +1,43 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, pathlib.Path(filename))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+thermal_mod = load_module("thermal", "3d_printer_sim/thermal.py")
+sensors_mod = load_module("sensors", "3d_printer_sim/sensors.py")
+micro_mod = load_module("microcontroller", "3d_printer_sim/microcontroller.py")
+
+HeatedBed = thermal_mod.HeatedBed
+TemperatureSensor = sensors_mod.TemperatureSensor
+Microcontroller = micro_mod.Microcontroller
+
+
+class TestThermal(unittest.TestCase):
+    def test_heating_and_cooling(self) -> None:
+        mc = Microcontroller()
+        sensor = TemperatureSensor(mc, pin=1, value=25.0)
+        bed = HeatedBed(sensor, heating_rate=100, cooling_rate=50)
+        bed.set_target_temperature(200)
+        bed.update(1.0)
+        self.assertAlmostEqual(sensor.read_temperature(), 125)
+        self.assertAlmostEqual(mc.read_analog(1), 125)
+        bed.update(1.0)
+        self.assertAlmostEqual(sensor.read_temperature(), 200)
+        bed.set_target_temperature(50)
+        bed.update(1.0)
+        self.assertAlmostEqual(sensor.read_temperature(), 150)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- model filament extrusion volume using stepper-driven Extruder
- simulate heating elements with Heater base, Hotend and HeatedBed
- mark development plan steps for extrusion and thermal systems complete

## Testing
- `python -m unittest -v tests.test_3d_printer_sim_config`
- `python -m unittest -v tests.test_3d_printer_sim_microcontroller`
- `python -m unittest -v tests.test_3d_printer_sim_pinmap`
- `python -m unittest -v tests.test_3d_printer_sim_sdcard`
- `python -m unittest -v tests.test_3d_printer_sim_sensors`
- `python -m unittest -v tests.test_3d_printer_sim_stepper`
- `python -m unittest -v tests.test_3d_printer_sim_usb`
- `python -m unittest -v tests.test_3d_printer_sim_extrusion`
- `python -m unittest -v tests.test_3d_printer_sim_thermal`


------
https://chatgpt.com/codex/tasks/task_e_68b14a1c5b508327b835608dfbaa5422