### PR TITLE
Make 3d printer sim self-contained and extend plan

### DIFF
--- a/3d_printer_sim/config.py
+++ b/3d_printer_sim/config.py
@@ -1,8 +1,74 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
-import yaml
+from typing import Any, List
+
+
+def _parse_value(token: str) -> Any:
+    token = token.strip()
+    if token.lower() in {"true", "false"}:
+        return token.lower() == "true"
+    try:
+        if "." in token:
+            return float(token)
+        return int(token)
+    except ValueError:
+        return token
+
+
+def _parse_yaml(lines: list[str], index: int, indent: int) -> tuple[Any, int]:
+    result: dict[str, Any] = {}
+    items: list[Any] = []
+    is_list = False
+    i = index
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip() or line.lstrip().startswith("#"):
+            i += 1
+            continue
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent < indent:
+            break
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            is_list = True
+            stripped = stripped[2:]
+            i += 1
+            # Scalar list item with no following block
+            if ":" not in stripped and (i >= len(lines) or len(lines[i]) - len(lines[i].lstrip(" ")) <= current_indent):
+                items.append(_parse_value(stripped))
+                continue
+            item_lines: list[str] = []
+            if stripped:
+                item_lines.append(" " * (current_indent + 2) + stripped)
+            while i < len(lines):
+                next_line = lines[i]
+                next_indent = len(next_line) - len(next_line.lstrip(" "))
+                if next_indent <= current_indent:
+                    break
+                item_lines.append(next_line)
+                i += 1
+            value, _ = _parse_yaml(item_lines, 0, current_indent + 2)
+            items.append(value)
+            continue
+        else:
+            key, _, rest = stripped.partition(":")
+            key = key.strip()
+            rest = rest.strip()
+            if rest:
+                result[key] = _parse_value(rest)
+                i += 1
+            else:
+                i += 1
+                value, i = _parse_yaml(lines, i, current_indent + 2)
+                result[key] = value
+    return (items if is_list else result), i
+
+
+def parse_simple_yaml(text: str) -> Any:
+    lines = [line.rstrip("\n") for line in text.splitlines()]
+    data, _ = _parse_yaml(lines, 0, 0)
+    return data
 
 
 @dataclass
@@ -59,7 +125,7 @@ class PrinterConfig:
 
 def load_config(path: str) -> PrinterConfig:
     with open(path, "r", encoding="utf-8") as fh:
-        data = yaml.safe_load(fh) or {}
+        data = parse_simple_yaml(fh.read()) or {}
     if "build_volume" not in data or "bed_size" not in data or "max_print_dimensions" not in data or "extruders" not in data:
         raise ValueError("config missing required sections")
     build_volume = Volume.from_dict(data["build_volume"], "build_volume")

--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -74,7 +74,7 @@ Step 9: Advanced Physics and Failure Modes
         Subsubstep 9.4.4: Adjust support failure probability based on overhang angle and cooling efficiency
     Substep 9.5: Model print errors such as filament not sticking and spaghetti failures
         Subsubstep 9.5.1: Detect scenarios with insufficient bed or layer adhesion
-        Subsubstep 9.5.2: Produce tangled filament paths when extrusion continues without adhesion
+        Subsubstep 9.5.2: Produce tangled filament paths ("spaghetti") when extrusion continues without adhesion
         Subsubstep 9.5.3: Simulate layer collapse or shifting due to partial adhesion loss
         Subsubstep 9.5.4: Represent layer shifts from skipped steps or mechanical backlash
     Substep 9.6: Simulate fan influences, including print cooling fan, on thermal gradients and print quality
@@ -117,6 +117,7 @@ Step 9: Advanced Physics and Failure Modes
         Subsubstep 9.11.4: Evaluate defects such as ringing, ghosting, and resonance
         Subsubstep 9.11.5: Quantify warping, cracking, and other thermally induced defects
         Subsubstep 9.11.6: Provide a composite quality score combining multiple metrics
+        Subsubstep 9.11.7: Account for belt tension, frame rigidity, and stepper calibration on final print fidelity
 
 Step 10: Comprehensive Marlin Configuration Coverage
     Substep 10.1: Parse Marlin Configuration.h and Configuration_adv.h to enumerate all configuration items
@@ -1282,4 +1283,5 @@ Step 10: Comprehensive Marlin Configuration Coverage
 Step 11: Code Isolation and Dependency Audit
     Substep 11.1: Confirm all modules rely only on Python's standard library or files within 3d_printer_sim
     Substep 11.2: Remove or refactor any code importing modules outside this directory
+        Subsubstep 11.2.1: Replace external YAML dependency with an internal minimal parser in config.py
     Substep 11.3: Add tests verifying absence of external dependencies

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -535,7 +535,7 @@ Helper scripts `clone_or_update.sh` and `clone_or_update.ps1` automate cloning o
 - Directory `3d_printer_sim` holds a development plan for a future 3D printer simulator.
 - The plan targets full compatibility with unmodified Marlin firmware, including virtual USB/SD interfaces, configurable build volumes, and complete sensor and physics emulation.
 - Initial Marlin firmware study is recorded in `3d_printer_sim/marlin_analysis.md`, outlining HAL structure, required interfaces, and key configuration parameters.
-- A YAML-based configuration system (`3d_printer_sim/config.yaml`) defines build volume, bed size, maximum print dimensions, and extruder/hotend setups. A typed parser (`3d_printer_sim/config.py`) validates these parameters for use in later simulator stages.
+- A YAML-based configuration system (`3d_printer_sim/config.yaml`) defines build volume, bed size, maximum print dimensions, and extruder/hotend setups. A self-contained parser (`3d_printer_sim/config.py`) reads this file without external dependencies and validates parameters for later simulator stages.
 - `3d_printer_sim/microcontroller.py` introduces a minimal microcontroller emulator. It tracks digital and analog pin states via dictionaries and provides read/write helpers, forming the foundation for later hardware emulation compatible with Marlin firmware.
 - `3d_printer_sim/usb.py` implements a `VirtualUSB` class with host and device buffers. A microcontroller can attach to this interface to exchange bytes with a host, enabling a virtual USB link for future Marlin communication.
 - `3d_printer_sim/sdcard.py` offers an in-memory `VirtualSDCard` with mount/unmount support and basic file operations that the microcontroller can expose to firmware.


### PR DESCRIPTION
## Summary
- Remove external PyYAML dependency by adding a minimal YAML parser in 3d_printer_sim
- Expand development plan with explicit spaghetti failure modeling, mechanical quality factors, and dependency cleanup steps
- Document self-contained config parsing in architecture overview

## Testing
- `python -m unittest tests.test_3d_printer_sim_config -v`
- `python -m unittest tests.test_3d_printer_sim_extrusion -v`
- `python -m unittest tests.test_3d_printer_sim_microcontroller -v`
- `python -m unittest tests.test_3d_printer_sim_pinmap -v`
- `python -m unittest tests.test_3d_printer_sim_sdcard -v`
- `python -m unittest tests.test_3d_printer_sim_sensors -v`
- `python -m unittest tests.test_3d_printer_sim_stepper -v`
- `python -m unittest tests.test_3d_printer_sim_thermal -v`
- `python -m unittest tests.test_3d_printer_sim_usb -v`


------
https://chatgpt.com/codex/tasks/task_e_68b152ca37a48327bc873a272f6724c7