### PR TITLE
docs: plan for visualization fidelity

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -1313,3 +1313,17 @@ Step 13: Filament Material Physics
         Subsubstep 13.5.1: Ensure extrusion behavior changes with viscosity inputs
         Subsubstep 13.5.2: Confirm thermal simulations reflect material heat properties
         Subsubstep 13.5.3: Verify warping or elasticity effects manifest per filament type
+
+Step 14: Visualization Fidelity Assurance
+    Substep 14.1: Enumerate all simulation outputs that require visual representation
+        Subsubstep 14.1.1: List motion, thermal, material, and sensor states to display
+        Subsubstep 14.1.2: Define corresponding visual cues or overlays for each state
+    Substep 14.2: Bind physics simulation data to the live 3D model
+        Subsubstep 14.2.1: Update rendering so positions, temperatures, and material properties mirror simulation values
+        Subsubstep 14.2.2: Reflect dynamic effects such as cooling, adhesion, or collisions in real time
+    Substep 14.3: Implement synchronization checks between simulation and visualization
+        Subsubstep 14.3.1: Add hooks that update visual elements every simulation tick
+        Subsubstep 14.3.2: Validate through logs that no simulated variable lacks a visual counterpart
+    Substep 14.4: Add tests verifying full coverage of simulated physics in the 3D view
+        Subsubstep 14.4.1: Render sample frames and assert positional and thermal accuracy
+        Subsubstep 14.4.2: Ensure newly added physics features introduce matching visual indicators


### PR DESCRIPTION
## Summary
- specify visualization fidelity step ensuring all simulated physics are mirrored in the 3D view

## Testing
- `python -m unittest tests.test_3d_printer_sim_config -v`
- `python -m unittest tests.test_3d_printer_sim_extrusion -v`
- `python -m unittest tests.test_3d_printer_sim_microcontroller -v`
- `python -m unittest tests.test_3d_printer_sim_pinmap -v`
- `python -m unittest tests.test_3d_printer_sim_sdcard -v`
- `python -m unittest tests.test_3d_printer_sim_sensors -v`
- `python -m unittest tests.test_3d_printer_sim_stepper -v`
- `python -m unittest tests.test_3d_printer_sim_thermal -v`
- `python -m unittest tests.test_3d_printer_sim_usb -v`


------
https://chatgpt.com/codex/tasks/task_e_68b1572fdd4c8327ba9da662f691a2fa