### PR TITLE
test: expand config parser tests

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -40,7 +40,12 @@ Step 6: Integrate with Marlin [complete]
     Substep 6.4: Feed simulated sensor data to firmware [complete]
 
 Step 7: Testing Framework
-    Substep 7.1: Create unit tests for configuration parser
+    Substep 7.1: Create unit tests for configuration parser [complete]
+        Subsubstep 7.1.1: Verify successful parse of valid configuration [complete]
+        Subsubstep 7.1.2: Ensure missing sections raise ValueError [complete]
+        Subsubstep 7.1.3: Ensure empty extruder list raises ValueError [complete]
+        Subsubstep 7.1.4: Ensure negative axis values raise ValueError [complete]
+        Subsubstep 7.1.5: Test parse_simple_yaml handles scalar and list values [complete]
     Substep 7.2: Create integration tests for firmware communication [complete]
     Substep 7.3: Validate physics simulation against known printer behavior
 

--- a/tests/test_3d_printer_sim_config.py
+++ b/tests/test_3d_printer_sim_config.py
@@ -1,5 +1,6 @@
 import importlib.util
 import pathlib
+import tempfile
 import unittest
 
 import sys
@@ -12,6 +13,7 @@ assert spec.loader is not None
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 load_config = module.load_config
+parse_simple_yaml = module.parse_simple_yaml
 
 
 class TestPrinterConfig(unittest.TestCase):
@@ -22,6 +24,51 @@ class TestPrinterConfig(unittest.TestCase):
         self.assertIn("PETG", cfg.filament_types)
         self.assertEqual(cfg.extruders[1].filament, "PETG")
         self.assertAlmostEqual(cfg.heater_targets["hotend"], 200)
+
+    def test_missing_section_raises(self) -> None:
+        text = (
+            "build_volume:\n  x: 1\n  y: 1\n  z: 1\n"
+            "bed_size:\n  x: 1\n  y: 1\n"
+            "max_print_dimensions:\n  x: 1\n  y: 1\n  z: 1\n"
+            "filament_types: {}\n"
+        )
+        with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
+            tmp.write(text)
+            tmp.flush()
+            with self.assertRaises(ValueError):
+                load_config(tmp.name)
+
+    def test_empty_extruders_list(self) -> None:
+        text = (
+            "build_volume:\n  x: 1\n  y: 1\n  z: 1\n"
+            "bed_size:\n  x: 1\n  y: 1\n"
+            "max_print_dimensions:\n  x: 1\n  y: 1\n  z: 1\n"
+            "extruders: []\n"
+            "filament_types: {}\n"
+        )
+        with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
+            tmp.write(text)
+            tmp.flush()
+            with self.assertRaises(ValueError):
+                load_config(tmp.name)
+
+    def test_negative_axis_value(self) -> None:
+        text = (
+            "build_volume:\n  x: -1\n  y: 1\n  z: 1\n"
+            "bed_size:\n  x: 1\n  y: 1\n"
+            "max_print_dimensions:\n  x: 1\n  y: 1\n  z: 1\n"
+            "extruders:\n  - id: 0\n    type: direct\n    hotend: e3d_v6\n    filament: PLA\n"
+            "filament_types:\n  PLA:\n    hotend_temp:\n      - 190\n      - 220\n    bed_temp:\n      - 0\n      - 60\n"
+        )
+        with tempfile.NamedTemporaryFile("w+", delete=False) as tmp:
+            tmp.write(text)
+            tmp.flush()
+            with self.assertRaises(ValueError):
+                load_config(tmp.name)
+
+    def test_parse_simple_yaml_basic(self) -> None:
+        data = parse_simple_yaml("a: 1\nb:\n  - 2\n  - 3\n")
+        self.assertEqual(data, {"a": 1, "b": [2, 3]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add thorough unit tests for config parser, including error conditions and YAML parsing
- document completion of config tests in development plan

## Testing
- `python -m py_compile tests/test_3d_printer_sim_config.py 3d_printer_sim/config.py`
- `python -m unittest tests.test_3d_printer_sim_config -v`


------
https://chatgpt.com/codex/tasks/task_e_68b166d9dfb48327adabb025a7f6bb4d