### PR TITLE
Simulate nozzle-bed clearance effects

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -61,13 +61,13 @@ Step 9: Advanced Physics and Failure Modes
         Subsubstep 9.1.2: Adjust gravity and nozzle coordinates for bed orientation [complete]
         Subsubstep 9.1.3: Ensure material deposition and movement calculations respect tilt [complete]
         Subsubstep 9.1.4: Simulate individual bed screw adjustments and compute resulting tilt from uneven tension [complete]
-    Substep 9.2: Model nozzle-to-bed distance effects on filament deposition and dragging
-        Subsubstep 9.2.1: Compute real-time nozzle height relative to the tilted bed
-        Subsubstep 9.2.2: Alter extrusion width and adhesion based on clearance
-        Subsubstep 9.2.3: Simulate nozzle dragging, scratching, or collisions when clearance is too low
-        Subsubstep 9.2.4: Reflect layer height errors caused by incorrect leveling
-        Subsubstep 9.2.5: Capture surface deformation and delamination when the nozzle scrapes deposited material
-        Subsubstep 9.2.6: Model part displacement or detachment when nozzle contact exerts excessive force
+    Substep 9.2: Model nozzle-to-bed distance effects on filament deposition and dragging [complete]
+        Subsubstep 9.2.1: Compute real-time nozzle height relative to the tilted bed [complete]
+        Subsubstep 9.2.2: Alter extrusion width and adhesion based on clearance [complete]
+        Subsubstep 9.2.3: Simulate nozzle dragging, scratching, or collisions when clearance is too low [complete]
+        Subsubstep 9.2.4: Reflect layer height errors caused by incorrect leveling [complete]
+        Subsubstep 9.2.5: Capture surface deformation and delamination when the nozzle scrapes deposited material [complete]
+        Subsubstep 9.2.6: Model part displacement or detachment when nozzle contact exerts excessive force [complete]
     Substep 9.3: Implement realistic molten filament behavior including adherence, stickiness, cooling, and layer bonding
         Subsubstep 9.3.1: Model temperature-dependent viscosity and flow characteristics
         Subsubstep 9.3.2: Simulate adhesion to the bed and existing layers

--- a/tests/test_3d_printer_sim_nozzle_distance.py
+++ b/tests/test_3d_printer_sim_nozzle_distance.py
@@ -1,0 +1,50 @@
+
+import importlib.util
+import pathlib
+import unittest
+import sys
+
+spec = importlib.util.spec_from_file_location(
+    "printer_sim", pathlib.Path("3d_printer_sim/simulation.py")
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+PrinterSimulation = module.PrinterSimulation
+
+
+class TestNozzleDistance(unittest.TestCase):
+    def test_width_and_adhesion(self) -> None:
+        sim = PrinterSimulation()
+        sim.z_motor.position = 0.2
+        sim.set_extrusion_velocity(100)
+        sim.update(0.1)
+        self.assertAlmostEqual(sim.nozzle_height, 0.2)
+        self.assertAlmostEqual(sim.extrusion_width, sim.nozzle_diameter)
+        self.assertAlmostEqual(sim.adhesion, 1.0)
+        self.assertEqual(len(sim.visualizer.filament), 1)
+
+    def test_collision_and_detachment(self) -> None:
+        sim = PrinterSimulation()
+        sim.z_motor.position = -0.05
+        sim.set_axis_velocities(2, 0, 0)
+        sim.set_extrusion_velocity(100)
+        sim.update(0.1)
+        self.assertTrue(sim.collision)
+        self.assertGreater(sim.surface_damage, 0)
+        self.assertTrue(sim.part_detached)
+        self.assertEqual(len(sim.visualizer.filament), 0)
+
+    def test_high_clearance_no_adhesion(self) -> None:
+        sim = PrinterSimulation()
+        sim.z_motor.position = 0.5
+        sim.set_extrusion_velocity(100)
+        sim.update(0.1)
+        self.assertEqual(sim.adhesion, 0.0)
+        self.assertEqual(len(sim.visualizer.filament), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_3d_printer_sim_simulation.py
+++ b/tests/test_3d_printer_sim_simulation.py
@@ -17,12 +17,14 @@ PrinterSimulation = module.PrinterSimulation
 class TestSimulation(unittest.TestCase):
     def test_visual_sync_and_filament(self):
         sim = PrinterSimulation()
-        sim.set_axis_velocities(1, 2, 3)
+        # Keep nozzle at first-layer height to allow adhesion
+        sim.z_motor.position = 0.2
+        sim.set_axis_velocities(1, 2, 0)
         sim.set_extrusion_velocity(100)  # 1 mm/s with steps_per_mm=100
         sim.update(1.0)
         # Visualizer should track axis positions
-        self.assertEqual(list(sim.visualizer.extruder.position), [1, 2, 3])
-        # A filament segment should have been added
+        self.assertEqual(list(sim.visualizer.extruder.position), [1, 2, 0.2])
+        # A filament segment should have been added due to sufficient adhesion
         self.assertEqual(len(sim.visualizer.filament), 1)
 
     def test_axis_physics(self) -> None:


### PR DESCRIPTION
## Summary
- model nozzle height, adhesion and collision effects in the printer simulation
- add tests validating clearance, collision and adhesion behaviour
- mark development plan step 9.2 as complete

## Testing
- `python -m py_compile 3d_printer_sim/simulation.py tests/test_3d_printer_sim_nozzle_distance.py tests/test_3d_printer_sim_simulation.py`
- `python -m unittest tests.test_3d_printer_sim_bed_tilt -v`
- `python -m unittest tests.test_3d_printer_sim_config -v`
- `python -m unittest tests.test_3d_printer_sim_extrusion -v`
- `python -m unittest tests.test_3d_printer_sim_marlin_integration -v`
- `python -m unittest tests.test_3d_printer_sim_microcontroller -v`
- `python -m unittest tests.test_3d_printer_sim_pinmap -v`
- `python -m unittest tests.test_3d_printer_sim_sdcard -v`
- `python -m unittest tests.test_3d_printer_sim_sensors -v`
- `python -m unittest tests.test_3d_printer_sim_simulation -v`
- `python -m unittest tests.test_3d_printer_sim_stepper -v`
- `python -m unittest tests.test_3d_printer_sim_thermal -v`
- `python -m unittest tests.test_3d_printer_sim_usb -v`
- `python -m unittest tests.test_3d_printer_sim_visualization -v`
- `python -m unittest tests.test_3d_printer_sim_nozzle_distance -v`


------
https://chatgpt.com/codex/tasks/task_e_68b16c1f874c8327ba039a8968170c83