### PR TITLE
Model temperature-dependent filament flow

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -69,7 +69,7 @@ Step 9: Advanced Physics and Failure Modes
         Subsubstep 9.2.5: Capture surface deformation and delamination when the nozzle scrapes deposited material [complete]
         Subsubstep 9.2.6: Model part displacement or detachment when nozzle contact exerts excessive force [complete]
     Substep 9.3: Implement realistic molten filament behavior including adherence, stickiness, cooling, and layer bonding
-        Subsubstep 9.3.1: Model temperature-dependent viscosity and flow characteristics
+        Subsubstep 9.3.1: Model temperature-dependent viscosity and flow characteristics [complete]
         Subsubstep 9.3.2: Simulate adhesion to the bed and existing layers
         Subsubstep 9.3.3: Track cooling rates influenced by ambient conditions and fan airflow
         Subsubstep 9.3.4: Represent stringing or drooping when filament lacks support


### PR DESCRIPTION
## Summary
- make extrusion volume depend on hotend temperature via logistic viscosity model
- cover temperature-based flow in extruder tests
- track plan progress for molten filament modelling

## Testing
- `python -m unittest -v tests.test_3d_printer_sim_extrusion`
- `python -m unittest -v tests.test_3d_printer_sim_simulation`
- `python -m unittest -v tests.test_3d_printer_sim_thermal`


------
https://chatgpt.com/codex/tasks/task_e_68b16e747d548327a8be1f53c367a3c2