### PR TITLE
Simulate filament adhesion to bed and layers

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -70,7 +70,7 @@ Step 9: Advanced Physics and Failure Modes
         Subsubstep 9.2.6: Model part displacement or detachment when nozzle contact exerts excessive force [complete]
     Substep 9.3: Implement realistic molten filament behavior including adherence, stickiness, cooling, and layer bonding
         Subsubstep 9.3.1: Model temperature-dependent viscosity and flow characteristics [complete]
-        Subsubstep 9.3.2: Simulate adhesion to the bed and existing layers
+        Subsubstep 9.3.2: Simulate adhesion to the bed and existing layers [complete]
         Subsubstep 9.3.3: Track cooling rates influenced by ambient conditions and fan airflow
         Subsubstep 9.3.4: Represent stringing or drooping when filament lacks support
         Subsubstep 9.3.5: Depict filament squish profiles based on nozzle height and bed tilt

--- a/tests/test_3d_printer_sim_adhesion.py
+++ b/tests/test_3d_printer_sim_adhesion.py
@@ -1,0 +1,71 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+def load_module(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, pathlib.Path(filename))
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    __import__("sys").modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sim_mod = load_module("sim", "3d_printer_sim/simulation.py")
+mc_mod = load_module("mc", "3d_printer_sim/microcontroller.py")
+sensors_mod = load_module("sensors", "3d_printer_sim/sensors.py")
+
+PrinterSimulation = sim_mod.PrinterSimulation
+Microcontroller = mc_mod.Microcontroller
+TemperatureSensor = sensors_mod.TemperatureSensor
+
+
+class TestAdhesion(unittest.TestCase):
+    def test_bed_temperature_influence(self) -> None:
+        sim = PrinterSimulation()
+        sim.z_motor.position = sim.layer_height
+        sim.set_extrusion_velocity(100)
+
+        sim.bed_temperature = 20
+        sim.update(0.1)
+        low_adh = sim.adhesion
+        count_low = len(sim.visualizer.filament)
+
+        sim.extruder.reset()
+        sim._last_extruded = 0.0
+        sim.bed_temperature = sim.optimal_bed_temp
+        sim.update(0.1)
+
+        self.assertLess(low_adh, 0.5)
+        self.assertEqual(count_low, 0)
+        self.assertGreater(sim.adhesion, low_adh)
+        self.assertEqual(len(sim.visualizer.filament), 1)
+
+    def test_extruder_temperature_influence(self) -> None:
+        sim = PrinterSimulation()
+        mc = Microcontroller()
+        sensor = TemperatureSensor(mc, pin=0, value=150)
+        sim.extruder.temperature_sensor = sensor
+
+        sim.z_motor.position = sim.layer_height * 2
+        sim.set_extrusion_velocity(100)
+
+        sim.update(0.1)
+        low = sim.adhesion
+        count_low = len(sim.visualizer.filament)
+
+        sim.extruder.reset()
+        sim._last_extruded = 0.0
+        sensor.set_temperature(240)
+        sim.update(0.1)
+
+        self.assertLess(low, 0.5)
+        self.assertEqual(count_low, 0)
+        self.assertGreater(sim.adhesion, low)
+        self.assertEqual(len(sim.visualizer.filament), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- model bed and inter-layer adhesion using bed temperature, layer alignment, and extrusion flow
- track bed temperature in the printer simulation
- add tests covering bed and extruder temperature influence on adhesion

## Testing
- `pip install pythreejs`
- `python -m unittest -v tests.test_3d_printer_sim_nozzle_distance`
- `python -m unittest -v tests.test_3d_printer_sim_simulation`
- `python -m unittest -v tests.test_3d_printer_sim_adhesion`


------
https://chatgpt.com/codex/tasks/task_e_68b1730544a88327872021ec3b9e812a