### PR TITLE
Add support and brim generation

### DIFF
--- a/3d_printer_sim/TUTORIAL.md
+++ b/3d_printer_sim/TUTORIAL.md
@@ -58,6 +58,18 @@ renderer = printer.visualizer.get_isometric_view()
 
 The extruder moves along the X axis and deposits a short filament segment while the renderer stays in sync.
 
+5. Add supports and brims:
+
+```python
+printer.generate_brim(radius=10, segments=30)
+printer.set_axis_velocities(0, 0, 0)
+printer.z_motor.position = 10  # start in mid-air to force support generation
+printer.set_extrusion_velocity(100)
+printer.update(1.0)
+```
+
+The `generate_brim` call lays down a circular brim on the build plate. If filament is extruded without underlying material, the simulator automatically creates vertical support structures so the deposit is fully supported.
+
 ## Configuring Your Printer
 
 To set up a printer model, create a `config.yaml` file with sections for

--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -76,10 +76,12 @@ Step 9: Advanced Physics and Failure Modes
         Subsubstep 9.3.5: Depict filament squish profiles based on nozzle height and bed tilt [complete]
         Subsubstep 9.3.6: Simulate crystallization and shrinkage as filament transitions from molten to solid [complete]
     Substep 9.4: Simulate supports, brims, and other adhesion aids with realistic physics
-        Subsubstep 9.4.1: Generate supports and brims based on print geometry
-        Subsubstep 9.4.2: Apply distinct adhesion and removal properties to support structures
-        Subsubstep 9.4.3: Estimate realistic removal forces and resulting surface scars
-        Subsubstep 9.4.4: Adjust support failure probability based on overhang angle and cooling efficiency
+        Group 9.4.A: Support and brim generation with adhesion tuning [complete]
+            Subsubstep 9.4.1: Generate supports and brims based on print geometry [complete]
+            Subsubstep 9.4.2: Apply distinct adhesion and removal properties to support structures [complete]
+        Group 9.4.B: Removal forces and failure probabilities
+            Subsubstep 9.4.3: Estimate realistic removal forces and resulting surface scars
+            Subsubstep 9.4.4: Adjust support failure probability based on overhang angle and cooling efficiency
     Substep 9.5: Model print errors such as filament not sticking and spaghetti failures
         Subsubstep 9.5.1: Detect scenarios with insufficient bed or layer adhesion
         Subsubstep 9.5.2: Produce tangled filament paths ("spaghetti") when extrusion continues without adhesion

--- a/3d_printer_sim/visualization.py
+++ b/3d_printer_sim/visualization.py
@@ -109,9 +109,39 @@ class PrinterVisualizer:
     def update_extruder_position(self, x: float, y: float, z: float) -> None:
         self.extruder.position = (x, y, z)
 
-    def add_filament_segment(self, x: float, y: float, z: float, radius: float = 0.5) -> None:
-        cyl = CylinderGeometry(radiusTop=radius, radiusBottom=radius, height=1)
+    def add_filament_segment(
+        self, x: float, y: float, z: float, radius: float = 0.5, height: float = 1.0
+    ) -> Mesh:
+        """Add a generic filament segment to the scene."""
+
+        cyl = CylinderGeometry(radiusTop=radius, radiusBottom=radius, height=height)
         mat = MeshLambertMaterial(color="#ffa500")
+        seg = Mesh(cyl, mat)
+        seg.position = (x, y, z)
+        self.scene.add(seg)
+        self.filament.append(seg)
+        return seg
+
+    def add_support_segment(
+        self, x: float, y: float, z: float, radius: float = 0.5, height: float = 1.0
+    ) -> Mesh:
+        """Add a support structure segment in a distinct color."""
+
+        cyl = CylinderGeometry(radiusTop=radius, radiusBottom=radius, height=height)
+        mat = MeshLambertMaterial(color="#00ff00")
+        seg = Mesh(cyl, mat)
+        seg.position = (x, y, z)
+        self.scene.add(seg)
+        self.filament.append(seg)
+        return seg
+
+    def add_brim_segment(
+        self, x: float, y: float, z: float, radius: float = 0.5, height: float = 1.0
+    ) -> Mesh:
+        """Add a brim segment around the model base."""
+
+        cyl = CylinderGeometry(radiusTop=radius, radiusBottom=radius, height=height)
+        mat = MeshLambertMaterial(color="#0000ff")
         seg = Mesh(cyl, mat)
         seg.position = (x, y, z)
         self.scene.add(seg)

--- a/tests/test_3d_printer_sim_supports.py
+++ b/tests/test_3d_printer_sim_supports.py
@@ -1,0 +1,42 @@
+import importlib.util
+import pathlib
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "simulation", pathlib.Path("3d_printer_sim/simulation.py")
+)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys_modules = __import__("sys").modules
+sys_modules[spec.name] = module
+spec.loader.exec_module(module)
+PrinterSimulation = module.PrinterSimulation
+FilamentSegment = module.FilamentSegment
+
+
+class TestSupportsAndBrims(unittest.TestCase):
+    def test_brim_generation(self) -> None:
+        sim = PrinterSimulation()
+        sim.generate_brim(radius=2, segments=4)
+        self.assertEqual(len(sim.segments), 4)
+        for seg in sim.segments:
+            self.assertEqual(seg.kind, "brim")
+            self.assertGreater(seg.adhesion_strength, 1.0)
+            self.assertLess(seg.removal_force, 1.0)
+
+    def test_support_creation(self) -> None:
+        sim = PrinterSimulation()
+        sim.enable_auto_support(True)
+        sim.z_motor.position = 10.3
+        sim.set_extrusion_velocity(100)
+        sim.update(1.0)
+        kinds = [seg.kind for seg in sim.segments]
+        self.assertIn("support", kinds)
+        self.assertIn("normal", kinds)
+        support_segments = [seg for seg in sim.segments if seg.kind == "support"]
+        self.assertTrue(all(abs(seg.adhesion_strength - 0.5) < 1e-6 for seg in support_segments))
+        self.assertTrue(all(abs(seg.removal_force - 0.5) < 1e-6 for seg in support_segments))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add rendering helpers for supports and brims
- generate support pillars and circular brims with adjustable adhesion
- document usage and extend development plan

## Testing
- `python -m py_compile 3d_printer_sim/simulation.py 3d_printer_sim/visualization.py tests/test_3d_printer_sim_supports.py`
- `python -m unittest -v tests.test_3d_printer_sim_supports`
- `python -m unittest -v tests.test_3d_printer_sim_simulation`
- `python -m unittest -v tests.test_3d_printer_sim_adhesion`


------
https://chatgpt.com/codex/tasks/task_e_68b1776603548327887b325b349913ba