### PR TITLE
Respect explicit plugins

### DIFF
--- a/tests/test_autoplugin_explicit.py
+++ b/tests/test_autoplugin_explicit.py
@@ -1,0 +1,29 @@
+import unittest
+
+
+class TestAutoPluginExplicit(unittest.TestCase):
+    def test_explicit_plugin_not_deactivated(self):
+        from marble.marblemain import Brain, Wanderer
+        from marble.plugins.wanderer_autoplugin import AutoPlugin
+        from marble.plugins.wanderer_epsgreedy import EpsilonGreedyChooserPlugin
+
+        b = Brain(1, size=(1,))
+        idx = b.available_indices()[0]
+        b.add_neuron(idx, tensor=[1.0], type_name="autoneuron")
+        w = Wanderer(
+            b,
+            type_name="epsilongreedy,autoplugin",
+            neuroplasticity_type="base",
+            seed=0,
+        )
+        w.ensure_learnable_param("autoplugin_bias_EpsilonGreedyChooserPlugin", -10.0)
+        auto = next(p for p in w._wplugins if isinstance(p, AutoPlugin))
+        self.assertTrue(auto.is_active(w, "EpsilonGreedyChooserPlugin", None))
+        self.assertTrue(
+            any(isinstance(p, EpsilonGreedyChooserPlugin) for p in w._wplugins)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- track wanderer and neuroplasticity plugins explicitly requested by the user
- skip AutoPlugin gating for explicit plugins and treat them as always active
- test that AutoPlugin leaves explicitly loaded plugins enabled

## Testing
- `python -m unittest -v tests.test_autoplugin_explicit`
- `python -m unittest -v tests.test_autoneuron`


------
https://chatgpt.com/codex/tasks/task_e_68b179df87e48327bd0436b9c3bda46c