### PR TITLE
Add lobe subgraph training with plugin inheritance

### DIFF
--- a/marble/lobe.py
+++ b/marble/lobe.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Sequence, Set, Union, Iterable
+
+from .graph import Neuron, Synapse
+
+
+class Lobe:
+    """Represents a subgraph of a Brain that can be trained independently.
+
+    Parameters
+    ----------
+    neurons:
+        Sequence of neurons contained in the lobe.
+    synapses:
+        Optional sequence of synapses. If omitted, all synapses whose
+        endpoints lie inside ``neurons`` are included.
+    plugin_types:
+        Optional wanderer plugin names specific to this lobe.
+    neuro_config:
+        Configuration dictionary for plugins. Only used when
+        ``inherit_plugins`` is ``False``.
+    inherit_plugins:
+        If True (default) the lobe uses whatever plugins are active for the
+        training call. When False, ``plugin_types`` and ``neuro_config`` are
+        used instead.
+    """
+
+    def __init__(
+        self,
+        neurons: Sequence[Neuron],
+        synapses: Optional[Sequence[Synapse]] = None,
+        *,
+        plugin_types: Optional[Union[str, Sequence[str]]] = None,
+        neuro_config: Optional[Dict[str, object]] = None,
+        inherit_plugins: bool = True,
+    ) -> None:
+        self.neurons: Set[Neuron] = set(neurons)
+        if synapses is None:
+            self.synapses: Set[Synapse] = {
+                s
+                for s in self._infer_synapses(self.neurons)
+            }
+        else:
+            self.synapses = set(synapses)
+        self.plugin_types = plugin_types
+        self.neuro_config: Dict[str, object] = dict(neuro_config or {})
+        self.inherit_plugins = bool(inherit_plugins)
+
+    @staticmethod
+    def _infer_synapses(neurons: Iterable[Neuron]) -> Iterable[Synapse]:
+        for n in neurons:
+            for s in getattr(n, "outgoing", []) or []:
+                if getattr(s, "target", None) in neurons:
+                    yield s
+            for s in getattr(n, "incoming", []) or []:
+                if getattr(s, "source", None) in neurons:
+                    yield s
+
+__all__ = ["Lobe"]

--- a/tests/test_lobe_training.py
+++ b/tests/test_lobe_training.py
@@ -1,0 +1,57 @@
+import unittest
+
+from marble.marblemain import Brain, run_wanderer_training
+
+
+class LobeTrainingTests(unittest.TestCase):
+    def test_lobe_independent_training_and_plugins(self):
+        b = Brain(1, size=4)
+        n0 = b.add_neuron((0,), tensor=1.0)
+        n1 = b.add_neuron((1,), tensor=0.0)
+        n2 = b.add_neuron((2,), tensor=1.0)
+        n3 = b.add_neuron((3,), tensor=0.0)
+        s01 = b.connect((0,), (1,))
+        s23 = b.connect((2,), (3,))
+
+        lobe1 = b.define_lobe("first", [n0, n1], [s01])
+
+        w0_before = float(n0.weight)
+        w2_before = float(n2.weight)
+
+        res1 = run_wanderer_training(
+            b,
+            num_walks=1,
+            max_steps=1,
+            lr=0.1,
+            start_selector=lambda _b: n0,
+            wanderer_type="epsilongreedy",
+            loss=lambda outs: outs[0].sum(),
+            lobe=lobe1,
+        )
+        self.assertIn("EpsilonGreedyChooserPlugin", res1["history"][0]["plugins"])
+        self.assertNotEqual(w0_before, float(n0.weight))
+        self.assertEqual(w2_before, float(n2.weight))
+
+        lobe2 = b.define_lobe(
+            "second",
+            [n2, n3],
+            [s23],
+            inherit_plugins=False,
+            plugin_types="wanderalongsynapseweights",
+        )
+        res2 = run_wanderer_training(
+            b,
+            num_walks=1,
+            max_steps=1,
+            lr=0.1,
+            start_selector=lambda _b: n2,
+            wanderer_type="epsilongreedy",
+            loss=lambda outs: outs[0].sum(),
+            lobe=lobe2,
+        )
+        self.assertIn("WanderAlongSynapseWeightsPlugin", res2["history"][0]["plugins"])
+        self.assertNotIn("EpsilonGreedyChooserPlugin", res2["history"][0]["plugins"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow creating Brain lobes as trainable neuron/synapse subgraphs
- support lobe-specific plugin stacks and configs in wanderer/datapair training
- document lobe concept and add regression tests

## Testing
- `python -m unittest -v tests.test_lobe_training`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_training_with_datapairs`


------
https://chatgpt.com/codex/tasks/task_e_68b17d4315dc8327b66048d00fc9b554