### PR TITLE
feat: allow plugin exclusion

### DIFF
--- a/tests/test_autoneuron.py
+++ b/tests/test_autoneuron.py
@@ -25,6 +25,32 @@ class TestAutoNeuron(unittest.TestCase):
         self.assertIn("loss", res)
         self.assertEqual(n.type_name, "autoneuron")
 
+    def test_exclude_prevents_usage(self):
+        from marble.marblemain import register_neuron_type
+        from marble.plugins.autoneuron import AutoNeuronPlugin
+
+        class FailingPlugin:
+            def __init__(self):
+                self.calls = 0
+
+            def forward(self, neuron, input_value=None):
+                self.calls += 1
+                raise RuntimeError("boom")
+
+        fail_impl = FailingPlugin()
+        register_neuron_type("fail2", fail_impl)
+        register_neuron_type("autoneuron_nofail", AutoNeuronPlugin(disabled_types=["fail2"]))
+
+        b = self.Brain(1, size=(1,))
+        idx = b.available_indices()[0]
+        n = b.add_neuron(idx, tensor=[1.0], type_name="autoneuron_nofail")
+        w = self.Wanderer(b, seed=0)
+        w.ensure_learnable_param("autoneuron_bias_fail2", 10.0)
+        w.ensure_learnable_param("autoneuron_bias_base", -10.0)
+        res = w.walk(max_steps=1, start=n, lr=0.0)
+        self.assertIn("loss", res)
+        self.assertEqual(fail_impl.calls, 0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_autoplugin_exclude.py
+++ b/tests/test_autoplugin_exclude.py
@@ -1,0 +1,29 @@
+import unittest
+
+
+class TestAutoPluginExclude(unittest.TestCase):
+    def test_excluded_plugin_removed(self):
+        from marble.marblemain import Brain, Wanderer, register_wanderer_type
+        from marble.plugins.wanderer_autoplugin import AutoPlugin
+
+        b = Brain(1, size=(1,))
+        idx = b.available_indices()[0]
+        b.add_neuron(idx, tensor=[1.0], type_name="autoneuron")
+
+        # Register AutoPlugin variant that disables EpsilonGreedyChooserPlugin
+        register_wanderer_type(
+            "autoplugin_no_eps",
+            AutoPlugin(disabled_plugins=["EpsilonGreedyChooserPlugin"]),
+        )
+
+        w = Wanderer(b, type_name="epsilongreedy,autoplugin_no_eps", neuroplasticity_type="base", seed=0)
+
+        # The excluded plugin should not be present in the wanderer stack
+        self.assertFalse(
+            any("EpsilonGreedyChooserPlugin" == p.__class__.__name__ for p in w._wplugins)
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- allow AutoPlugin to receive a disabled plugin list and drop them from stacks
- allow AutoNeuronPlugin to exclude neuron types
- document and test plugin exclusion helpers

## Testing
- `python -m unittest -v tests.test_autoplugin_exclude`
- `python -m unittest -v tests.test_autoplugin_explicit`
- `python -m unittest -v tests.test_autoneuron`


------
https://chatgpt.com/codex/tasks/task_e_68b1d6ea6fe48327bcc584bde8b2b430