### PR TITLE
Add quantum superposition neuron plugin

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,7 @@ Core Components
   Synapses may also connect directly to other synapses; transmission recursively traverses until a neuron endpoint is reached. When a neuron is removed, its adjacent synapses are bridged to maintain path continuity.
 
   - `AutoNeuron` plugin: Learns via `expose_learnable_params` to delegate each forward pass to the most promising neuron type. On failures (e.g., wiring errors), it reverts to the previous successful type and retries, preserving gradient flow. Can be instantiated with `disabled_types=[...]` to skip specific neuron plugins entirely.
+  - `QuantumType` plugin: Maintains multiple weight/bias/position states in superposition and blends them via a learnable wave function (logits exposed through `expose_learnable_params`). The forward pass computes the probability-weighted expectation, yielding stable gradients and deterministic behaviour while still expressing quantum-like branching.
 
 - `Brain`: n-dimensional space that can be either:
   - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`). Omitting the `size` parameter enables a fully dynamic grid that expands as neurons are added; capacity becomes unbounded.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -383,6 +383,17 @@ except Exception:
     pass
 
 # -----------------------------
+# Neuron Plugin: QuantumType
+# -----------------------------
+
+try:
+    from .plugins.quantumtype import QuantumTypeNeuronPlugin
+    register_neuron_type("quantumtype", QuantumTypeNeuronPlugin())
+    __all__ += ["QuantumTypeNeuronPlugin"]
+except Exception:
+    pass
+
+# -----------------------------
 # Learning Paradigm Plugins (Brain-level orchestration) (Brain-level orchestration)
 # -----------------------------
 

--- a/marble/plugins/quantumtype.py
+++ b/marble/plugins/quantumtype.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+"""QuantumType neuron plugin implementing weight superposition.
+
+Each neuron keeps ``n`` candidate weights and biases simultaneously. A
+learnable wave function (implemented via softmax over logits) assigns a
+probability to every candidate state. During the forward pass the output is
+the expectation over all states which keeps the computation fully
+differentiable and avoids the high gradient variance that a pure sampling
+approach would introduce.
+
+The plugin exposes the wave-function logits through
+``expose_learnable_params`` so that they are registered as learnable
+parameters on the :class:`~marble.wanderer.Wanderer`.  The per-neuron weights
+and biases are tracked in ``neuron._plugin_state['learnable_params']`` which
+ensures gradients flow to every superposed value.
+
+This design solves several of the downsides mentioned in the high level
+discussion:
+
+* **Stable gradients** – The expectation formulation eliminates stochastic
+  gradients caused by random collapse.
+* **Differentiable probabilities** – Logits are trained directly and turned
+  into probabilities via ``softmax`` which provides smooth gradients.
+* **Single-pass computation** – All states are evaluated in parallel and
+  combined in one pass, avoiding expensive resampling.
+
+The plugin also keeps track of possible neuron positions.  The neuron's
+``position`` attribute is updated to the probability‑weighted expectation of
+all candidate positions so that downstream logic receives a deterministic
+coordinate.
+"""
+
+from typing import Any, List, Sequence, Tuple
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class QuantumTypeNeuronPlugin:
+    """Neuron plugin that models a superposition of multiple weights.
+
+    Parameters
+    ----------
+    n_states:
+        Number of simultaneous weight/bias/position states maintained by the
+        neuron.  More states increase expressiveness at the cost of compute.
+    """
+
+    def __init__(self, n_states: int = 2) -> None:
+        self.n_states = int(max(1, n_states))
+
+    # ------------------------------------------------------------------
+    # Learnable global wave-function parameters
+    @staticmethod
+    @expose_learnable_params
+    def _wave_logits(
+        wanderer: "Wanderer",
+        *,
+        logits: Sequence[float] | None = None,
+    ):
+        """Return learnable logits for the wave function.
+
+        ``expose_learnable_params`` ensures that a single tensor named
+        ``"logits"`` lives on the :class:`Wanderer`.  The tensor holds
+        ``n_states`` values representing the unnormalised log probabilities for
+        the neuron to collapse into each state.
+        """
+
+        if logits is None:
+            logits = [0.0] * self.n_states
+        return logits
+
+    # ------------------------------------------------------------------
+    def _ensure_internal_params(self, neuron: "Neuron") -> Tuple[Any, Any, List[Any]]:
+        """Initialise and return (weights, biases, positions) for the neuron."""
+
+        store = neuron._plugin_state.setdefault("learnable_params", {})
+        torch = neuron._torch
+        device = getattr(neuron, "_device", "cpu")
+
+        if "weights" not in store:
+            if torch is not None:
+                store["weights"] = torch.full(
+                    (self.n_states,), float(neuron.weight), dtype=torch.float32, device=device
+                )
+            else:
+                store["weights"] = [float(neuron.weight)] * self.n_states
+
+        if "biases" not in store:
+            if torch is not None:
+                store["biases"] = torch.full(
+                    (self.n_states,), float(neuron.bias), dtype=torch.float32, device=device
+                )
+            else:
+                store["biases"] = [float(neuron.bias)] * self.n_states
+
+        if "positions" not in store:
+            pos = getattr(neuron, "position", None)
+            store["positions"] = [pos for _ in range(self.n_states)]
+
+        return store["weights"], store["biases"], store["positions"]
+
+    # ------------------------------------------------------------------
+    def forward(self, neuron: "Neuron", input_value=None):
+        """Compute expectation over all weight states."""
+
+        torch = neuron._torch
+        device = getattr(neuron, "_device", "cpu")
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+        weights, biases, positions = self._ensure_internal_params(neuron)
+
+        wanderer = neuron._plugin_state.get("wanderer")
+        logits = None
+        if wanderer is not None:
+            try:
+                logits = self._wave_logits(wanderer)
+            except Exception:
+                logits = None
+
+        if torch is not None and neuron._is_torch_tensor(x):
+            w = weights if hasattr(weights, "to") else torch.tensor(weights, dtype=torch.float32, device=device)
+            b = biases if hasattr(biases, "to") else torch.tensor(biases, dtype=torch.float32, device=device)
+            if logits is None:
+                logits_t = torch.zeros(self.n_states, dtype=torch.float32, device=device)
+            else:
+                logits_t = logits if hasattr(logits, "to") else torch.tensor(logits, dtype=torch.float32, device=device)
+            probs = torch.softmax(logits_t, dim=0)
+
+            out_each = x * w.view(-1, *([1] * (x.dim() if hasattr(x, "dim") else 1))) + b.view(
+                -1, *([1] * (x.dim() if hasattr(x, "dim") else 1))
+            )
+            result = (probs.view(-1, *([1] * (out_each.dim() - 1))) * out_each).sum(0)
+
+            # Update expected position deterministically
+            try:
+                pos_tensors = []
+                for p in positions:
+                    if isinstance(p, (tuple, list)):
+                        pos_tensors.append(torch.tensor(p, dtype=torch.float32, device=device))
+                    else:
+                        pos_tensors.append(torch.zeros(1, dtype=torch.float32, device=device))
+                if pos_tensors:
+                    pos_stack = torch.stack(pos_tensors)
+                    exp_pos = (probs.view(-1, 1) * pos_stack).sum(0)
+                    neuron.position = tuple(float(v.detach().to("cpu").item()) for v in exp_pos)
+            except Exception:
+                pass
+
+            try:
+                report(
+                    "neuron",
+                    "quantum_forward",
+                    {"states": self.n_states, "prob_max": float(probs.max().detach().to("cpu").item())},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return result
+
+        # Fallback to pure Python lists
+        x_list = x if isinstance(x, list) else [float(x)]
+        w_list = list(weights)
+        b_list = list(biases)
+        log_list = list(logits) if logits is not None else [0.0] * self.n_states
+        max_log = max(log_list)
+        exp_vals = [pow(2.718281828459045, l - max_log) for l in log_list]
+        norm = sum(exp_vals) if exp_vals else 1.0
+        probs = [v / norm for v in exp_vals]
+        out_vals: List[List[float]] = []
+        for p, wv, bv in zip(probs, w_list, b_list):
+            out_vals.append([p * (wv * float(v) + bv) for v in x_list])
+        result = [sum(vals) for vals in zip(*out_vals)]
+        try:
+            report(
+                "neuron",
+                "quantum_forward",
+                {"states": self.n_states, "prob_max": max(probs) if probs else 0.0},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return result if len(result) > 1 else result[0]
+
+    # ------------------------------------------------------------------
+    def receive(self, neuron: "Neuron", value):
+        """Store incoming value as base tensor."""
+
+        neuron.tensor = neuron._ensure_tensor(value)
+
+
+__all__ = ["QuantumTypeNeuronPlugin"]
+

--- a/tests/test_quantumtype_plugin.py
+++ b/tests/test_quantumtype_plugin.py
@@ -1,0 +1,59 @@
+import unittest
+
+from marble.reporter import REPORTER, clear_report_group
+
+
+class TestQuantumTypeNeuron(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_report_group("quantum")
+
+    def test_forward_expectation(self) -> None:
+        from marble.marblemain import Brain, Wanderer, _NEURON_TYPES
+
+        b = Brain(1, size=(3,))
+        src = b.add_neuron((0,), tensor=[2.0])
+        q = b.add_neuron((1,), tensor=[0.0], type_name="quantumtype")
+        dst = b.add_neuron((2,), tensor=[0.0])
+        b.connect((0,), (1,), direction="uni")
+        b.connect((1,), (2,), direction="uni")
+
+        plug = _NEURON_TYPES["quantumtype"]
+        weights, biases, _ = plug._ensure_internal_params(q)
+        torch = getattr(q, "_torch", None)
+        device = getattr(q, "_device", "cpu")
+        if torch is not None:
+            weights.data = torch.tensor([2.0, -1.0], dtype=torch.float32, device=device)
+            biases.data = torch.tensor([0.0, 0.0], dtype=torch.float32, device=device)
+        else:
+            weights[:] = [2.0, -1.0]
+            biases[:] = [0.0, 0.0]
+
+        wdr = Wanderer(b, seed=1)
+        q._plugin_state["wanderer"] = wdr
+        logits = plug._wave_logits(wdr, logits=[0.0, 1.0])
+        if torch is not None and hasattr(logits, "data"):
+            logits.data = torch.tensor([0.0, 1.0], dtype=torch.float32, device=device)
+        else:
+            try:
+                logits[:] = [0.0, 1.0]
+            except Exception:
+                pass
+
+        out = q.forward([3.0])
+
+        if torch is not None and getattr(out, "detach", None):
+            val = float(out.detach().to("cpu").view(-1)[0].item())
+        elif isinstance(out, list):
+            val = float(out[0])
+        else:
+            val = float(out)
+
+        REPORTER.item[("output", "quantum")] = val
+
+        expected = (0.2689414213699951 * (2.0 * 3.0) + 0.7310585786300049 * (-1.0 * 3.0))
+        self.assertAlmostEqual(val, expected, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add QuantumType neuron plugin that blends multiple weight states via learnable wave-function logits
- register QuantumType in `marblemain` and document in ARCHITECTURE
- include unit test validating probability-weighted forward pass

## Testing
- `python tests/test_quantumtype_plugin.py`
- `python tests/test_reporter.py`
- `python tests/test_learnable_params.py`


------
https://chatgpt.com/codex/tasks/task_e_68b1d979229c83278a8fc13805ccd14f