### PR TITLE
Add advanced neuron plugins with learnable parameters

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,6 +24,11 @@ Core Components
 
   - `AutoNeuron` plugin: Learns via `expose_learnable_params` to delegate each forward pass to the most promising neuron type. On failures (e.g., wiring errors), it reverts to the previous successful type and retries, preserving gradient flow. Can be instantiated with `disabled_types=[...]` to skip specific neuron plugins entirely.
   - `QuantumType` plugin: Maintains multiple weight/bias/position states in superposition and blends them via a learnable wave function (logits exposed through `expose_learnable_params`). The forward pass computes the probability-weighted expectation, yielding stable gradients and deterministic behaviour while still expressing quantum-like branching.
+  - `SineWave` plugin: Applies `y = A * sin(F * x + P) + B` using learnable amplitude, frequency, phase and bias registered via `expose_learnable_params`.
+  - `Gaussian` plugin: Evaluates a Gaussian radial basis `scale * exp(-((x-mean)^2)/(2*sigma^2)) + bias` with mean, sigma, scale and bias exposed through `expose_learnable_params`.
+  - `Polynomial` plugin: Computes `a*x^2 + b*x + c` with coefficients `a`, `b`, `c` as wanderer learnables via `expose_learnable_params`.
+  - `Exponential` plugin: Returns `scale * exp(rate * x) + bias` where rate, scale and bias are learned using `expose_learnable_params`.
+  - `RBF` plugin: Implements a radial basis function `scale * exp(-gamma*(x-center)^2) + bias` with center, gamma, scale and bias all registered through `expose_learnable_params`.
 
 - `Brain`: n-dimensional space that can be either:
   - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`). Omitting the `size` parameter enables a fully dynamic grid that expands as neurons are added; capacity becomes unbounded.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -394,6 +394,30 @@ except Exception:
     pass
 
 # -----------------------------
+# Neuron Plugins: Advanced types
+# -----------------------------
+try:
+    from .plugins.sinewave import SineWaveNeuronPlugin
+    from .plugins.gaussian import GaussianNeuronPlugin
+    from .plugins.polynomial import PolynomialNeuronPlugin
+    from .plugins.exponential import ExponentialNeuronPlugin
+    from .plugins.rbf import RBFNeuronPlugin
+    register_neuron_type("sinewave", SineWaveNeuronPlugin())
+    register_neuron_type("gaussian", GaussianNeuronPlugin())
+    register_neuron_type("polynomial", PolynomialNeuronPlugin())
+    register_neuron_type("exponential", ExponentialNeuronPlugin())
+    register_neuron_type("rbf", RBFNeuronPlugin())
+    __all__ += [
+        "SineWaveNeuronPlugin",
+        "GaussianNeuronPlugin",
+        "PolynomialNeuronPlugin",
+        "ExponentialNeuronPlugin",
+        "RBFNeuronPlugin",
+    ]
+except Exception:
+    pass
+
+# -----------------------------
 # Learning Paradigm Plugins (Brain-level orchestration) (Brain-level orchestration)
 # -----------------------------
 

--- a/marble/plugins/exponential.py
+++ b/marble/plugins/exponential.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Exponential neuron plugin with learnable rate, scale and bias.
+
+Implements ``y = scale * exp(rate * x) + bias`` with all parameters exposed
+through :func:`expose_learnable_params`.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class ExponentialNeuronPlugin:
+    """Apply a learnable exponential transform to the neuron value."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        exp_rate: float = 1.0,
+        exp_scale: float = 1.0,
+        exp_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any]:
+        return exp_rate, exp_scale, exp_bias
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+        rate, scale, bias = 1.0, 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                rate, scale, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = scale * torch.exp(rate * x) + bias
+            try:
+                report(
+                    "neuron",
+                    "exp_forward",
+                    {"rate": float(rate.detach().to("cpu").item()) if hasattr(rate, "detach") else float(rate)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        rate_f = float(rate if not hasattr(rate, "detach") else rate.detach().to("cpu").item())
+        scale_f = float(scale if not hasattr(scale, "detach") else scale.detach().to("cpu").item())
+        bias_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        out = [scale_f * math.exp(rate_f * float(v)) + bias_f for v in x_list]
+        try:
+            report("neuron", "exp_forward", {"rate": rate_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["ExponentialNeuronPlugin"]
+

--- a/marble/plugins/gaussian.py
+++ b/marble/plugins/gaussian.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+"""Gaussian neuron plugin with learnable mean, sigma, scale and bias.
+
+The plugin evaluates a Gaussian radial basis function for the neuron input
+using parameters exposed via :func:`expose_learnable_params`:
+
+``y = scale * exp(-((x - mean)**2) / (2 * sigma**2)) + bias``
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class GaussianNeuronPlugin:
+    """Apply a learnable Gaussian RBF to the neuron value."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        gauss_mean: float = 0.0,
+        gauss_sigma: float = 1.0,
+        gauss_scale: float = 1.0,
+        gauss_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any]:
+        return gauss_mean, gauss_sigma, gauss_scale, gauss_bias
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+        mean, sigma, scale, bias = 0.0, 1.0, 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                mean, sigma, scale, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            denom = 2.0 * sigma * sigma
+            y = scale * torch.exp(-((x - mean) ** 2) / denom) + bias
+            try:
+                report(
+                    "neuron",
+                    "gaussian_forward",
+                    {"sigma": float(sigma.detach().to("cpu").item()) if hasattr(sigma, "detach") else float(sigma)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        mean_f = float(mean if not hasattr(mean, "detach") else mean.detach().to("cpu").item())
+        sigma_f = float(sigma if not hasattr(sigma, "detach") else sigma.detach().to("cpu").item())
+        scale_f = float(scale if not hasattr(scale, "detach") else scale.detach().to("cpu").item())
+        bias_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        denom_f = 2.0 * sigma_f * sigma_f if sigma_f != 0 else 1.0
+        out = [scale_f * math.exp(-((float(v) - mean_f) ** 2) / denom_f) + bias_f for v in x_list]
+        try:
+            report("neuron", "gaussian_forward", {"sigma": sigma_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["GaussianNeuronPlugin"]
+

--- a/marble/plugins/polynomial.py
+++ b/marble/plugins/polynomial.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+"""Polynomial neuron plugin with learnable quadratic coefficients.
+
+The plugin evaluates ``y = a * x**2 + b * x + c`` with parameters ``a``, ``b``
+and ``c`` exposed via :func:`expose_learnable_params`.
+"""
+
+from typing import Any, Tuple
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class PolynomialNeuronPlugin:
+    """Apply a learnable quadratic polynomial to the neuron value."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        poly_a: float = 1.0,
+        poly_b: float = 0.0,
+        poly_c: float = 0.0,
+    ) -> Tuple[Any, Any, Any]:
+        return poly_a, poly_b, poly_c
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        a, b, c = 1.0, 0.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                a, b, c = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = a * (x ** 2) + b * x + c
+            try:
+                report(
+                    "neuron",
+                    "poly_forward",
+                    {"a": float(a.detach().to("cpu").item()) if hasattr(a, "detach") else float(a)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        a_f = float(a if not hasattr(a, "detach") else a.detach().to("cpu").item())
+        b_f = float(b if not hasattr(b, "detach") else b.detach().to("cpu").item())
+        c_f = float(c if not hasattr(c, "detach") else c.detach().to("cpu").item())
+        out = [a_f * float(v) * float(v) + b_f * float(v) + c_f for v in x_list]
+        try:
+            report("neuron", "poly_forward", {"a": a_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["PolynomialNeuronPlugin"]
+

--- a/marble/plugins/rbf.py
+++ b/marble/plugins/rbf.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Radial basis function neuron plugin with learnable center, gamma, scale and bias.
+
+Computes ``y = scale * exp(-gamma * (x - center)**2) + bias`` exposing all
+parameters via :func:`expose_learnable_params`.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class RBFNeuronPlugin:
+    """Apply a learnable radial basis function to the neuron value."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        rbf_center: float = 0.0,
+        rbf_gamma: float = 1.0,
+        rbf_scale: float = 1.0,
+        rbf_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any]:
+        return rbf_center, rbf_gamma, rbf_scale, rbf_bias
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+        center, gamma, scale, bias = 0.0, 1.0, 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                center, gamma, scale, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = scale * torch.exp(-gamma * (x - center) ** 2) + bias
+            try:
+                report(
+                    "neuron",
+                    "rbf_forward",
+                    {"gamma": float(gamma.detach().to("cpu").item()) if hasattr(gamma, "detach") else float(gamma)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        center_f = float(center if not hasattr(center, "detach") else center.detach().to("cpu").item())
+        gamma_f = float(gamma if not hasattr(gamma, "detach") else gamma.detach().to("cpu").item())
+        scale_f = float(scale if not hasattr(scale, "detach") else scale.detach().to("cpu").item())
+        bias_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        out = [scale_f * math.exp(-gamma_f * (float(v) - center_f) ** 2) + bias_f for v in x_list]
+        try:
+            report("neuron", "rbf_forward", {"gamma": gamma_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["RBFNeuronPlugin"]
+

--- a/marble/plugins/sinewave.py
+++ b/marble/plugins/sinewave.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Sine wave neuron plugin with learnable amplitude, frequency, phase and bias.
+
+All parameters are exposed via :func:`expose_learnable_params` so the
+``Wanderer`` tracks gradients for them.  The plugin computes
+
+``y = amplitude * sin(frequency * x + phase) + bias``
+
+for any input tensor ``x``.  Torch tensors are used when available, otherwise
+pure Python fallbacks keep the behaviour functional during tests without
+PyTorch.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class SineWaveNeuronPlugin:
+    """Apply a learnable sine transformation to the neuron value."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        sine_amp: float = 1.0,
+        sine_freq: float = 1.0,
+        sine_phase: float = 0.0,
+        sine_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any]:
+        """Return learnable tensors for all plugin parameters."""
+
+        return sine_amp, sine_freq, sine_phase, sine_bias
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        amp, freq, phase, bias = 1.0, 1.0, 0.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                amp, freq, phase, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = amp * torch.sin(freq * x + phase) + bias
+            try:
+                report(
+                    "neuron",
+                    "sine_forward",
+                    {"amp": float(amp.detach().to("cpu").item()) if hasattr(amp, "detach") else float(amp)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        amp_f = float(amp if not hasattr(amp, "detach") else amp.detach().to("cpu").item())
+        freq_f = float(freq if not hasattr(freq, "detach") else freq.detach().to("cpu").item())
+        phase_f = float(phase if not hasattr(phase, "detach") else phase.detach().to("cpu").item())
+        bias_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        out = [amp_f * math.sin(freq_f * float(v) + phase_f) + bias_f for v in x_list]
+        try:
+            report("neuron", "sine_forward", {"amp": amp_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["SineWaveNeuronPlugin"]
+

--- a/tests/test_advanced_neuron_plugins.py
+++ b/tests/test_advanced_neuron_plugins.py
@@ -1,0 +1,30 @@
+import unittest
+
+
+class AdvancedNeuronPluginTests(unittest.TestCase):
+    def test_plugins_register_and_expose_params(self) -> None:
+        from marble.marblemain import Brain, Wanderer, _NEURON_TYPES
+
+        plugins = {
+            "sinewave": ["sine_amp", "sine_freq", "sine_phase", "sine_bias"],
+            "gaussian": ["gauss_mean", "gauss_sigma", "gauss_scale", "gauss_bias"],
+            "polynomial": ["poly_a", "poly_b", "poly_c"],
+            "exponential": ["exp_rate", "exp_scale", "exp_bias"],
+            "rbf": ["rbf_center", "rbf_gamma", "rbf_scale", "rbf_bias"],
+        }
+
+        for name, params in plugins.items():
+            self.assertIn(name, _NEURON_TYPES)
+            brain = Brain(1, size=1)
+            w = Wanderer(brain)
+            n = brain.add_neuron(brain.available_indices()[0], tensor=[0.0], type_name=name)
+            n._plugin_state["wanderer"] = w
+            plug = _NEURON_TYPES[name]
+            plug.forward(n, input_value=[0.0])
+            for p in params:
+                self.assertIn(p, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- introduce sinewave, gaussian, polynomial, exponential, and radial-basis neuron plugins with `expose_learnable_params`
- register advanced neuron plugins in marblemain and document them in architecture notes
- cover plugin registration and learnable parameter exposure with new unit test

## Testing
- `python -m unittest -v tests.test_advanced_neuron_plugins`
- `python -m unittest -v tests.test_learnable_params`
- `python -m unittest -v tests.test_quantumtype_plugin`
- `python -m unittest -v tests.test_wanderer`


------
https://chatgpt.com/codex/tasks/task_e_68b1e191c6b48327a595e808f9ed274c