### PR TITLE
Add advanced neuron plugins with learnable parameters

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,6 +29,11 @@ Core Components
   - `Polynomial` plugin: Computes `a*x^2 + b*x + c` with coefficients `a`, `b`, `c` as wanderer learnables via `expose_learnable_params`.
   - `Exponential` plugin: Returns `scale * exp(rate * x) + bias` where rate, scale and bias are learned using `expose_learnable_params`.
   - `RBF` plugin: Implements a radial basis function `scale * exp(-gamma*(x-center)^2) + bias` with center, gamma, scale and bias all registered through `expose_learnable_params`.
+  - `Fourier` plugin: Combines two sine/cosine harmonics `a1*sin(f1*x+p1) + a2*cos(f2*x+p2) + bias` with amplitudes, frequencies, phases and bias exposed via `expose_learnable_params`.
+  - `Rational` plugin: Evaluates `(a1*x + b1)/(a2*x + b2) + bias` while exposing all coefficients and bias through `expose_learnable_params`.
+  - `PiecewiseLinear` plugin: Applies two linear segments split at a learnable breakpoint; both slopes and intercepts are registered via `expose_learnable_params`.
+  - `Sigmoid` plugin: Implements `scale / (1 + exp(-k*(x - x0))) + bias` with scale, slope, midpoint and bias learnable via `expose_learnable_params`.
+  - `Wavelet` plugin: Uses a Morlet-style wavelet `scale * exp(-0.5*((x-shift)/sigma)^2) * cos(freq*(x-shift)) + bias`; all parameters are exposed via `expose_learnable_params`.
 
 - `Brain`: n-dimensional space that can be either:
   - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`). Omitting the `size` parameter enables a fully dynamic grid that expands as neurons are added; capacity becomes unbounded.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -402,17 +402,32 @@ try:
     from .plugins.polynomial import PolynomialNeuronPlugin
     from .plugins.exponential import ExponentialNeuronPlugin
     from .plugins.rbf import RBFNeuronPlugin
+    from .plugins.fourier import FourierSeriesNeuronPlugin
+    from .plugins.rational import RationalNeuronPlugin
+    from .plugins.piecewise_linear import PiecewiseLinearNeuronPlugin
+    from .plugins.sigmoid import SigmoidNeuronPlugin
+    from .plugins.wavelet import WaveletNeuronPlugin
     register_neuron_type("sinewave", SineWaveNeuronPlugin())
     register_neuron_type("gaussian", GaussianNeuronPlugin())
     register_neuron_type("polynomial", PolynomialNeuronPlugin())
     register_neuron_type("exponential", ExponentialNeuronPlugin())
     register_neuron_type("rbf", RBFNeuronPlugin())
+    register_neuron_type("fourier", FourierSeriesNeuronPlugin())
+    register_neuron_type("rational", RationalNeuronPlugin())
+    register_neuron_type("piecewise_linear", PiecewiseLinearNeuronPlugin())
+    register_neuron_type("sigmoid", SigmoidNeuronPlugin())
+    register_neuron_type("wavelet", WaveletNeuronPlugin())
     __all__ += [
         "SineWaveNeuronPlugin",
         "GaussianNeuronPlugin",
         "PolynomialNeuronPlugin",
         "ExponentialNeuronPlugin",
         "RBFNeuronPlugin",
+        "FourierSeriesNeuronPlugin",
+        "RationalNeuronPlugin",
+        "PiecewiseLinearNeuronPlugin",
+        "SigmoidNeuronPlugin",
+        "WaveletNeuronPlugin",
     ]
 except Exception:
     pass

--- a/marble/plugins/fourier.py
+++ b/marble/plugins/fourier.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Fourier series neuron plugin.
+
+This plugin combines sine and cosine harmonics with learnable amplitudes,
+frequencies and phases. All parameters are exposed via
+``expose_learnable_params`` so optimisation frameworks can tune each
+harmonic individually.
+"""
+
+from typing import Any, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class FourierSeriesNeuronPlugin:
+    """Apply a small Fourier series to the neuron value."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        fourier_a1: float = 1.0,
+        fourier_f1: float = 1.0,
+        fourier_p1: float = 0.0,
+        fourier_a2: float = 0.5,
+        fourier_f2: float = 2.0,
+        fourier_p2: float = 0.0,
+        fourier_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any, Any, Any, Any]:
+        return (
+            fourier_a1,
+            fourier_f1,
+            fourier_p1,
+            fourier_a2,
+            fourier_f2,
+            fourier_p2,
+            fourier_bias,
+        )
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        a1, f1, p1 = 1.0, 1.0, 0.0
+        a2, f2, p2 = 0.5, 2.0, 0.0
+        bias = 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                a1, f1, p1, a2, f2, p2, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = (
+                a1 * torch.sin(f1 * x + p1)
+                + a2 * torch.cos(f2 * x + p2)
+                + bias
+            )
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        a1_f = float(a1 if not hasattr(a1, "detach") else a1.detach().to("cpu").item())
+        f1_f = float(f1 if not hasattr(f1, "detach") else f1.detach().to("cpu").item())
+        p1_f = float(p1 if not hasattr(p1, "detach") else p1.detach().to("cpu").item())
+        a2_f = float(a2 if not hasattr(a2, "detach") else a2.detach().to("cpu").item())
+        f2_f = float(f2 if not hasattr(f2, "detach") else f2.detach().to("cpu").item())
+        p2_f = float(p2 if not hasattr(p2, "detach") else p2.detach().to("cpu").item())
+        b_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        out = [
+            a1_f * __import__("math").sin(f1_f * v + p1_f)
+            + a2_f * __import__("math").cos(f2_f * v + p2_f)
+            + b_f
+            for v in map(float, x_list)
+        ]
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["FourierSeriesNeuronPlugin"]
+

--- a/marble/plugins/piecewise_linear.py
+++ b/marble/plugins/piecewise_linear.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Piecewise linear neuron plugin.
+
+Implements two linear segments split at a learnable breakpoint. Each
+segment has its own learnable slope and intercept. Parameters are
+registered through ``expose_learnable_params`` so optimisation can shape
+the piecewise function.
+"""
+
+from typing import Any, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class PiecewiseLinearNeuronPlugin:
+    """Apply a two-segment piecewise linear transform."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        pw_break: float = 0.0,
+        pw_m1: float = 1.0,
+        pw_c1: float = 0.0,
+        pw_m2: float = 1.0,
+        pw_c2: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any, Any]:
+        return pw_break, pw_m1, pw_c1, pw_m2, pw_c2
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        brk, m1, c1, m2, c2 = 0.0, 1.0, 0.0, 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                brk, m1, c1, m2, c2 = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y1 = m1 * x + c1
+            y2 = m2 * x + c2
+            cond = x < brk
+            return torch.where(cond, y1, y2)
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        brk_f = float(brk if not hasattr(brk, "detach") else brk.detach().to("cpu").item())
+        m1_f = float(m1 if not hasattr(m1, "detach") else m1.detach().to("cpu").item())
+        c1_f = float(c1 if not hasattr(c1, "detach") else c1.detach().to("cpu").item())
+        m2_f = float(m2 if not hasattr(m2, "detach") else m2.detach().to("cpu").item())
+        c2_f = float(c2 if not hasattr(c2, "detach") else c2.detach().to("cpu").item())
+        out = [m1_f * v + c1_f if v < brk_f else m2_f * v + c2_f for v in map(float, x_list)]
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["PiecewiseLinearNeuronPlugin"]
+

--- a/marble/plugins/rational.py
+++ b/marble/plugins/rational.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Rational function neuron plugin.
+
+Computes a ratio of two linear polynomials with learnable coefficients.
+All coefficients are exposed via ``expose_learnable_params`` and a bias
+term is added to retain expressive power.
+"""
+
+from typing import Any, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class RationalNeuronPlugin:
+    """Apply a rational function ``(a1*x + b1)/(a2*x + b2) + bias``."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        rat_a1: float = 1.0,
+        rat_b1: float = 0.0,
+        rat_a2: float = 1.0,
+        rat_b2: float = 1.0,
+        rat_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any, Any]:
+        return rat_a1, rat_b1, rat_a2, rat_b2, rat_bias
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        a1, b1, a2, b2, bias = 1.0, 0.0, 1.0, 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                a1, b1, a2, b2, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        eps = 1e-6
+        if torch is not None and neuron._is_torch_tensor(x):
+            denom = a2 * x + b2
+            y = (a1 * x + b1) / (denom + eps) + bias
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        a1_f = float(a1 if not hasattr(a1, "detach") else a1.detach().to("cpu").item())
+        b1_f = float(b1 if not hasattr(b1, "detach") else b1.detach().to("cpu").item())
+        a2_f = float(a2 if not hasattr(a2, "detach") else a2.detach().to("cpu").item())
+        b2_f = float(b2 if not hasattr(b2, "detach") else b2.detach().to("cpu").item())
+        bias_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        out = [
+            (a1_f * v + b1_f) / (a2_f * v + b2_f + eps) + bias_f for v in map(float, x_list)
+        ]
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["RationalNeuronPlugin"]
+

--- a/marble/plugins/sigmoid.py
+++ b/marble/plugins/sigmoid.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Parameterized sigmoid neuron plugin.
+
+Implements a logistic function with learnable scale, slope, midpoint and
+bias, all registered via ``expose_learnable_params``.
+"""
+
+from typing import Any, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class SigmoidNeuronPlugin:
+    """Apply ``scale / (1 + exp(-k*(x - x0))) + bias``."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        sig_scale: float = 1.0,
+        sig_k: float = 1.0,
+        sig_x0: float = 0.0,
+        sig_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any]:
+        return sig_scale, sig_k, sig_x0, sig_bias
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        scale, k, x0, bias = 1.0, 1.0, 0.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                scale, k, x0, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = scale / (1 + torch.exp(-k * (x - x0))) + bias
+            return y
+
+        import math
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        scale_f = float(scale if not hasattr(scale, "detach") else scale.detach().to("cpu").item())
+        k_f = float(k if not hasattr(k, "detach") else k.detach().to("cpu").item())
+        x0_f = float(x0 if not hasattr(x0, "detach") else x0.detach().to("cpu").item())
+        bias_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        out = [scale_f / (1 + math.exp(-k_f * (v - x0_f))) + bias_f for v in map(float, x_list)]
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["SigmoidNeuronPlugin"]
+

--- a/marble/plugins/wavelet.py
+++ b/marble/plugins/wavelet.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+"""Wavelet neuron plugin using a Morlet-like transform."""
+
+from typing import Any, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class WaveletNeuronPlugin:
+    """Apply a Gaussian-windowed cosine (Morlet) wavelet."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        wav_scale: float = 1.0,
+        wav_shift: float = 0.0,
+        wav_sigma: float = 1.0,
+        wav_freq: float = 1.0,
+        wav_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any, Any, Any]:
+        return wav_scale, wav_shift, wav_sigma, wav_freq, wav_bias
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        scale, shift, sigma, freq, bias = 1.0, 0.0, 1.0, 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                scale, shift, sigma, freq, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            xc = x - shift
+            y = scale * torch.exp(-0.5 * (xc / sigma) ** 2) * torch.cos(freq * xc) + bias
+            return y
+
+        import math
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        scale_f = float(scale if not hasattr(scale, "detach") else scale.detach().to("cpu").item())
+        shift_f = float(shift if not hasattr(shift, "detach") else shift.detach().to("cpu").item())
+        sigma_f = float(sigma if not hasattr(sigma, "detach") else sigma.detach().to("cpu").item())
+        freq_f = float(freq if not hasattr(freq, "detach") else freq.detach().to("cpu").item())
+        bias_f = float(bias if not hasattr(bias, "detach") else bias.detach().to("cpu").item())
+        out = [
+            scale_f * math.exp(-0.5 * ((v - shift_f) / sigma_f) ** 2) * math.cos(freq_f * (v - shift_f)) + bias_f
+            for v in map(float, x_list)
+        ]
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["WaveletNeuronPlugin"]
+

--- a/tests/test_advanced_neuron_plugins.py
+++ b/tests/test_advanced_neuron_plugins.py
@@ -11,6 +11,31 @@ class AdvancedNeuronPluginTests(unittest.TestCase):
             "polynomial": ["poly_a", "poly_b", "poly_c"],
             "exponential": ["exp_rate", "exp_scale", "exp_bias"],
             "rbf": ["rbf_center", "rbf_gamma", "rbf_scale", "rbf_bias"],
+            "fourier": [
+                "fourier_a1",
+                "fourier_f1",
+                "fourier_p1",
+                "fourier_a2",
+                "fourier_f2",
+                "fourier_p2",
+                "fourier_bias",
+            ],
+            "rational": ["rat_a1", "rat_b1", "rat_a2", "rat_b2", "rat_bias"],
+            "piecewise_linear": [
+                "pw_break",
+                "pw_m1",
+                "pw_c1",
+                "pw_m2",
+                "pw_c2",
+            ],
+            "sigmoid": ["sig_scale", "sig_k", "sig_x0", "sig_bias"],
+            "wavelet": [
+                "wav_scale",
+                "wav_shift",
+                "wav_sigma",
+                "wav_freq",
+                "wav_bias",
+            ],
         }
 
         for name, params in plugins.items():


### PR DESCRIPTION
## Summary
- add FourierSeries, Rational, PiecewiseLinear, Sigmoid, and Wavelet neuron plugins, each exposing learnable parameters
- register new neuron plugins and document them in architecture overview
- extend advanced neuron plugin tests to cover new plugins

## Testing
- `python -m unittest -v tests.test_advanced_neuron_plugins`
- `python -m unittest -v tests.test_learnable_params`


------
https://chatgpt.com/codex/tasks/task_e_68b1e572ae04832788a23611f757bd64