### PR TITLE
Add advanced neuron plugins

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,6 +34,11 @@ Core Components
   - `PiecewiseLinear` plugin: Applies two linear segments split at a learnable breakpoint; both slopes and intercepts are registered via `expose_learnable_params`.
   - `Sigmoid` plugin: Implements `scale / (1 + exp(-k*(x - x0))) + bias` with scale, slope, midpoint and bias learnable via `expose_learnable_params`.
   - `Wavelet` plugin: Uses a Morlet-style wavelet `scale * exp(-0.5*((x-shift)/sigma)^2) * cos(freq*(x-shift)) + bias`; all parameters are exposed via `expose_learnable_params`.
+  - `Swish` plugin: Computes `x * sigmoid(beta*x)` with a learnable `swish_beta` controlling activation sharpness.
+  - `Mish` plugin: Applies `x * tanh(softplus(beta*x))` exposing the `mish_beta` parameter for curvature control.
+  - `GELU` plugin: Evaluates `scale * 0.5 * x * (1 + erf(x/\sqrt{2}))` with learnable scaling `gelu_scale`.
+  - `SoftPlus` plugin: Uses `(1/beta)*log(1+exp(beta*x))` with learnable `splus_beta` and a saturation `splus_threshold`.
+  - `LeakyExp` plugin: Behaves linearly for positives and `alpha*(exp(beta*x)-1)` for negatives, learning `leak_alpha` and `leak_beta`.
 
 - `Brain`: n-dimensional space that can be either:
   - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`). Omitting the `size` parameter enables a fully dynamic grid that expands as neurons are added; capacity becomes unbounded.

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -12,3 +12,18 @@ Move remaining plugin classes out of `marble/marblemain.py` into dedicated modul
 6. Create a new plugin module for `BaseNeuroplasticityPlugin` (e.g., `marble/plugins/neuroplasticity_base.py`) and move its implementation there with a `register_neuroplasticity_type` call. [complete]
 7. Run the full test suite (`py -3 -m unittest -v tests.<module>`) to ensure all functionality remains intact, focusing on tests covering convolution, pooling, unpooling, and wanderer plugins. [complete]
 8. Update `ARCHITECTURE.md` to document that plugin implementations now reside in their own modules rather than in `marble/marblemain.py`. [complete]
+
+# Add new plugin suites
+
+## Goal
+Introduce five new advanced plugins for each plugin type, exposing all parameters via `expose_learnable_params`.
+
+## Steps
+1. Enumerate existing plugin types in the repository. [complete]
+2. Implement neuron plugin suite (Swish, Mish, GELU, SoftPlus, LeakyExp) and register them with tests and docs. [complete]
+3. Implement synapse plugin suite.
+4. Implement wanderer plugin suite.
+5. Implement brain_train plugin suite.
+6. Implement selfattention plugin suite.
+7. Implement learning_paradigm plugin suite.
+8. Implement neuroplasticity plugin suite.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -407,6 +407,11 @@ try:
     from .plugins.piecewise_linear import PiecewiseLinearNeuronPlugin
     from .plugins.sigmoid import SigmoidNeuronPlugin
     from .plugins.wavelet import WaveletNeuronPlugin
+    from .plugins.swish import SwishNeuronPlugin
+    from .plugins.mish import MishNeuronPlugin
+    from .plugins.gelu import GELUNeuronPlugin
+    from .plugins.softplus import SoftPlusNeuronPlugin
+    from .plugins.leaky_exp import LeakyExpNeuronPlugin
     register_neuron_type("sinewave", SineWaveNeuronPlugin())
     register_neuron_type("gaussian", GaussianNeuronPlugin())
     register_neuron_type("polynomial", PolynomialNeuronPlugin())
@@ -417,6 +422,11 @@ try:
     register_neuron_type("piecewise_linear", PiecewiseLinearNeuronPlugin())
     register_neuron_type("sigmoid", SigmoidNeuronPlugin())
     register_neuron_type("wavelet", WaveletNeuronPlugin())
+    register_neuron_type("swish", SwishNeuronPlugin())
+    register_neuron_type("mish", MishNeuronPlugin())
+    register_neuron_type("gelu", GELUNeuronPlugin())
+    register_neuron_type("softplus", SoftPlusNeuronPlugin())
+    register_neuron_type("leakyexp", LeakyExpNeuronPlugin())
     __all__ += [
         "SineWaveNeuronPlugin",
         "GaussianNeuronPlugin",
@@ -428,6 +438,11 @@ try:
         "PiecewiseLinearNeuronPlugin",
         "SigmoidNeuronPlugin",
         "WaveletNeuronPlugin",
+        "SwishNeuronPlugin",
+        "MishNeuronPlugin",
+        "GELUNeuronPlugin",
+        "SoftPlusNeuronPlugin",
+        "LeakyExpNeuronPlugin",
     ]
 except Exception:
     pass

--- a/marble/plugins/gelu.py
+++ b/marble/plugins/gelu.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""GELU neuron plugin with learnable scale."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class GELUNeuronPlugin:
+    """Apply scaled Gaussian error linear unit."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer: "Wanderer", *, gelu_scale: float = 1.0) -> Tuple[Any]:
+        return (gelu_scale,)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        scale = 1.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                (scale,) = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = scale * 0.5 * x * (1.0 + torch.erf(x / math.sqrt(2.0)))
+            try:
+                report(
+                    "neuron",
+                    "gelu_forward",
+                    {"scale": float(scale.detach().to("cpu").item()) if hasattr(scale, "detach") else float(scale)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        scale_f = float(scale if not hasattr(scale, "detach") else scale.detach().to("cpu").item())
+        out = [scale_f * 0.5 * v * (1.0 + math.erf(v / math.sqrt(2.0))) for v in x_list]
+        try:
+            report("neuron", "gelu_forward", {"scale": scale_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["GELUNeuronPlugin"]

--- a/marble/plugins/leaky_exp.py
+++ b/marble/plugins/leaky_exp.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Leaky exponential linear unit with learnable alpha and beta."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class LeakyExpNeuronPlugin:
+    """Like ELU but with learnable alpha and exponential rate."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer", *, leak_alpha: float = 1.0, leak_beta: float = 1.0
+    ) -> Tuple[Any, Any]:
+        return leak_alpha, leak_beta
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        alpha, beta = 1.0, 1.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                alpha, beta = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            pos = torch.clamp(x, min=0.0)
+            neg = torch.clamp(x, max=0.0)
+            y = pos + alpha * (torch.exp(beta * neg) - 1.0)
+            try:
+                report(
+                    "neuron",
+                    "leakyexp_forward",
+                    {
+                        "alpha": float(alpha.detach().to("cpu").item()) if hasattr(alpha, "detach") else float(alpha),
+                        "beta": float(beta.detach().to("cpu").item()) if hasattr(beta, "detach") else float(beta),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        alpha_f = float(alpha if not hasattr(alpha, "detach") else alpha.detach().to("cpu").item())
+        beta_f = float(beta if not hasattr(beta, "detach") else beta.detach().to("cpu").item())
+        out = [v if v > 0 else alpha_f * (math.exp(beta_f * v) - 1.0) for v in x_list]
+        try:
+            report("neuron", "leakyexp_forward", {"alpha": alpha_f, "beta": beta_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["LeakyExpNeuronPlugin"]

--- a/marble/plugins/mish.py
+++ b/marble/plugins/mish.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Mish neuron plugin applying x * tanh(softplus(beta*x))."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class MishNeuronPlugin:
+    """Apply Mish activation with learnable beta."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer: "Wanderer", *, mish_beta: float = 1.0) -> Tuple[Any]:
+        return (mish_beta,)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        beta = 1.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                (beta,) = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = x * torch.tanh(torch.nn.functional.softplus(beta * x))
+            try:
+                report(
+                    "neuron",
+                    "mish_forward",
+                    {"beta": float(beta.detach().to("cpu").item()) if hasattr(beta, "detach") else float(beta)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        beta_f = float(beta if not hasattr(beta, "detach") else beta.detach().to("cpu").item())
+        out = [v * math.tanh(math.log1p(math.exp(beta_f * v))) for v in x_list]
+        try:
+            report("neuron", "mish_forward", {"beta": beta_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["MishNeuronPlugin"]

--- a/marble/plugins/softplus.py
+++ b/marble/plugins/softplus.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""SoftPlus neuron plugin with learnable beta and threshold."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class SoftPlusNeuronPlugin:
+    """Apply SoftPlus activation with learnable parameters."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer", *, splus_beta: float = 1.0, splus_threshold: float = 20.0
+    ) -> Tuple[Any, Any]:
+        return splus_beta, splus_threshold
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        beta, threshold = 1.0, 20.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                beta, threshold = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            beta_t = torch.as_tensor(beta, device=x.device, dtype=x.dtype)
+            thresh_t = torch.as_tensor(threshold, device=x.device, dtype=x.dtype)
+            y = torch.where(
+                beta_t * x < thresh_t,
+                torch.log1p(torch.exp(beta_t * x)) / beta_t,
+                x,
+            )
+            try:
+                report(
+                    "neuron",
+                    "softplus_forward",
+                    {
+                        "beta": float(beta_t.detach().to("cpu").item()),
+                        "threshold": float(thresh_t.detach().to("cpu").item()),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        beta_f = float(beta if not hasattr(beta, "detach") else beta.detach().to("cpu").item())
+        thresh_f = float(threshold if not hasattr(threshold, "detach") else threshold.detach().to("cpu").item())
+        out = [
+            (1.0 / beta_f) * math.log1p(math.exp(beta_f * v)) if beta_f * v < thresh_f else v
+            for v in x_list
+        ]
+        try:
+            report(
+                "neuron",
+                "softplus_forward",
+                {"beta": beta_f, "threshold": thresh_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["SoftPlusNeuronPlugin"]

--- a/marble/plugins/swish.py
+++ b/marble/plugins/swish.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+"""Swish neuron plugin applying x * sigmoid(beta*x)."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class SwishNeuronPlugin:
+    """Apply Swish activation with learnable beta."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer: "Wanderer", *, swish_beta: float = 1.0) -> Tuple[Any]:
+        return (swish_beta,)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        beta = 1.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                (beta,) = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = x * torch.sigmoid(beta * x)
+            try:
+                report(
+                    "neuron",
+                    "swish_forward",
+                    {"beta": float(beta.detach().to("cpu").item()) if hasattr(beta, "detach") else float(beta)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        beta_f = float(beta if not hasattr(beta, "detach") else beta.detach().to("cpu").item())
+        out = [v * (1.0 / (1.0 + math.exp(-beta_f * v))) for v in x_list]
+        try:
+            report("neuron", "swish_forward", {"beta": beta_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["SwishNeuronPlugin"]

--- a/tests/test_advanced_neuron_plugins.py
+++ b/tests/test_advanced_neuron_plugins.py
@@ -36,6 +36,11 @@ class AdvancedNeuronPluginTests(unittest.TestCase):
                 "wav_freq",
                 "wav_bias",
             ],
+            "swish": ["swish_beta"],
+            "mish": ["mish_beta"],
+            "gelu": ["gelu_scale"],
+            "softplus": ["splus_beta", "splus_threshold"],
+            "leakyexp": ["leak_alpha", "leak_beta"],
         }
 
         for name, params in plugins.items():


### PR DESCRIPTION
## Summary
- add five new learnable neuron plugins (Swish, Mish, GELU, SoftPlus, LeakyExp)
- register plugins and document them in architecture notes
- extend advanced neuron plugin tests

## Testing
- `python -m unittest -v tests.test_advanced_neuron_plugins`
- `python -m unittest -v tests.test_3d_printer_sim_config`


------
https://chatgpt.com/codex/tasks/task_e_68b1e791a17083278ccf493810ddd021