### PR TITLE
Add learnable synapse plugin suite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -536,6 +536,11 @@ Convenience
 New Additive Plugins (this change)
 
 - Synapse plugin `noisy`: Adds zero-mean Gaussian noise during `transmit`. Configure per-synapse via `syn._plugin_state['sigma']` (default `0.01`). Runs on CUDA when available; otherwise falls back to Python lists. Registered by name `"noisy"`.
+- Synapse plugin `dropout`: Zeroes transmissions with learnable probability `dropout_p`, allowing stochastic pruning of paths during training.
+- Synapse plugin `hebbian`: Online Hebbian rule updating `synapse.weight` by `hebb_rate` and decaying via `hebb_decay`, both learnable.
+- Synapse plugin `resonant`: Damped harmonic filter maintaining internal state with learnable `res_freq` and `res_damp` parameters.
+- Synapse plugin `delay`: Exponential moving average over past outputs blended by learnable `delay_alpha`.
+- Synapse plugin `spike_gate`: Logistic gate that passes values above learnable `gate_thresh` with sharpness `gate_sharp`.
 - Wanderer plugin `l2_weight_penalty`: Contributes an L2 penalty term over the visited neurons’ autograd parameters (weights and biases). Lambda read from `wanderer._neuro_cfg['l2_lambda']` (default `0.0`). Registered as `"l2_weight_penalty"` and composes additively with other loss plugins.
 - SelfAttention routine `adaptive_grad_clip`: Observes per-step loss via the reporter and, when a step loss spikes by a configurable ratio, sets gradient clipping on the owning `Wanderer` for the next step (`method='norm'`, configurable `max_norm`). Constructor defaults: `threshold_ratio=1.5`, `max_norm=1.0`, `cooldown=5`. Registered via `register_selfattention_type("adaptive_grad_clip", ...)`.
 - SelfAttention routine `context_noise_profiler`: Exposes learnable `noise_variance` and `spatial_factor` parameters via `expose_learnable_params`, computes a per-step noise score, and nudges learning rate to compensate for sensor artifacts. Registered as `"context_noise_profiler"`.

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -21,7 +21,7 @@ Introduce five new advanced plugins for each plugin type, exposing all parameter
 ## Steps
 1. Enumerate existing plugin types in the repository. [complete]
 2. Implement neuron plugin suite (Swish, Mish, GELU, SoftPlus, LeakyExp) and register them with tests and docs. [complete]
-3. Implement synapse plugin suite.
+3. Implement synapse plugin suite. [complete]
 4. Implement wanderer plugin suite.
 5. Implement brain_train plugin suite.
 6. Implement selfattention plugin suite.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -619,6 +619,11 @@ __all__ += [
 # -----------------------------
 
 from .plugins.synapse_noisy import NoisySynapsePlugin as _NoisySynapsePlugin  # noqa: F401
+from .plugins.synapse_dropout import DropoutSynapsePlugin as _DropoutSynapsePlugin  # noqa: F401
+from .plugins.synapse_hebbian import HebbianSynapsePlugin as _HebbianSynapsePlugin  # noqa: F401
+from .plugins.synapse_resonant import ResonantSynapsePlugin as _ResonantSynapsePlugin  # noqa: F401
+from .plugins.synapse_delay import DelaySynapsePlugin as _DelaySynapsePlugin  # noqa: F401
+from .plugins.synapse_spike_gate import SpikeGateSynapsePlugin as _SpikeGateSynapsePlugin  # noqa: F401
 
 
 # -----------------------------

--- a/marble/plugins/synapse_delay.py
+++ b/marble/plugins/synapse_delay.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Delay synapse plugin.
+
+Implements a first-order IIR low-pass filter (exponential moving average) with a
+learnable blending factor controlling how much of the previous output is mixed
+into the current transmission.
+"""
+
+from typing import Any, List
+
+from ..graph import register_synapse_type, Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class DelaySynapsePlugin:
+    """Exponential moving average across transmissions."""
+
+    def __init__(self) -> None:
+        self._prev = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, delay_alpha: float = 0.5) -> Any:
+        return (delay_alpha,)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        alpha = 0.5
+        if wanderer is not None:
+            (alpha,) = self._params(wanderer)
+        alpha_f = float(alpha.detach().to("cpu").item()) if hasattr(alpha, "detach") else float(alpha)
+
+        prev = self._prev.get(id(syn), 0.0)
+        vals = self._to_list(value)
+        out_vals: List[float] = []
+        for v in vals:
+            prev = alpha_f * prev + (1.0 - alpha_f) * v
+            out_vals.append(prev)
+        self._prev[id(syn)] = prev
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "delay_step",
+                {"alpha": alpha_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+try:
+    register_synapse_type("delay", DelaySynapsePlugin())
+except Exception:
+    pass
+
+__all__ = ["DelaySynapsePlugin"]
+

--- a/marble/plugins/synapse_dropout.py
+++ b/marble/plugins/synapse_dropout.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Dropout-style synapse plugin.
+
+Randomly drops the transmitted value according to a learnable probability.
+Uses :func:`expose_learnable_params` so optimisation frameworks can tune the
+drop rate during training.
+"""
+
+from typing import Any, List
+import random
+
+from ..graph import register_synapse_type, Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class DropoutSynapsePlugin:
+    """Zeroes transmissions with a learnable probability."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, dropout_p: float = 0.1) -> Any:
+        return (dropout_p,)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        # Obtain wanderer from source/target plugin state
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        drop = 0.0
+        if wanderer is not None:
+            (drop,) = self._params(wanderer)
+
+        torch = getattr(syn, "_torch", None)
+        dev = getattr(syn, "_device", "cpu")
+        if torch is not None:
+            vt = value
+            if not (hasattr(vt, "detach") and hasattr(vt, "to")):
+                vt = torch.tensor(self._to_list(value), dtype=torch.float32, device=dev)
+            mask = (torch.rand_like(vt) > drop).float()
+            out = vt * mask
+        else:
+            vals = self._to_list(value)
+            out = [0.0 if random.random() < float(drop) else v for v in vals]
+            if len(out) == 1:
+                out = out[0]
+
+        try:
+            report(
+                "synapse",
+                "dropout_transmit",
+                {"p": float(drop.detach().to("cpu").item()) if hasattr(drop, "detach") else float(drop)},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+try:
+    register_synapse_type("dropout", DropoutSynapsePlugin())
+except Exception:
+    pass
+
+__all__ = ["DropoutSynapsePlugin"]
+

--- a/marble/plugins/synapse_hebbian.py
+++ b/marble/plugins/synapse_hebbian.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Hebbian synapse plugin.
+
+Applies a simple Hebbian update to the synapse weight based on the mean of the
+pre- and post-synaptic activations. Two learnable parameters control the update
+rate and weight decay.
+"""
+
+from typing import Any, List
+
+from ..graph import register_synapse_type, Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class HebbianSynapsePlugin:
+    """Online Hebbian rule with learnable rate and decay."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, hebb_rate: float = 0.01, hebb_decay: float = 0.0) -> Any:
+        return (hebb_rate, hebb_decay)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        rate, decay = 0.0, 0.0
+        if wanderer is not None:
+            rate, decay = self._params(wanderer)
+
+        pre_vals = self._to_list(value)
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            out_neuron = Synapse.transmit(syn, value, direction=direction)
+        finally:
+            syn.type_name = orig
+
+        try:
+            post_vals = self._to_list(getattr(out_neuron, "tensor", 0.0))
+            pre_mean = sum(pre_vals) / max(1, len(pre_vals))
+            post_mean = sum(post_vals) / max(1, len(post_vals))
+            update = pre_mean * post_mean * rate
+            update_f = (
+                float(update.detach().to("cpu").item())
+                if hasattr(update, "detach")
+                else float(update)
+            )
+            decay_f = (
+                float(decay.detach().to("cpu").item())
+                if hasattr(decay, "detach")
+                else float(decay)
+            )
+            syn.weight += update_f
+            syn.weight *= (1.0 - decay_f)
+            report(
+                "synapse",
+                "hebbian_update",
+                {
+                    "rate": float(rate.detach().to("cpu").item()) if hasattr(rate, "detach") else float(rate),
+                    "decay": decay_f,
+                },
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        return out_neuron
+
+
+try:
+    register_synapse_type("hebbian", HebbianSynapsePlugin())
+except Exception:
+    pass
+
+__all__ = ["HebbianSynapsePlugin"]
+

--- a/marble/plugins/synapse_resonant.py
+++ b/marble/plugins/synapse_resonant.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Resonant synapse plugin.
+
+Models a damped harmonic oscillator that filters the incoming signal. The
+oscillation frequency and damping factor are learnable, enabling the network to
+specialise transmission dynamics.
+"""
+
+from typing import Any, List
+
+from ..graph import register_synapse_type, Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class ResonantSynapsePlugin:
+    """Damped oscillator filter with learnable frequency and damping."""
+
+    def __init__(self) -> None:
+        self._state = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, res_freq: float = 1.0, res_damp: float = 0.1) -> Any:
+        return (res_freq, res_damp)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        freq, damp = 1.0, 0.1
+        if wanderer is not None:
+            freq, damp = self._params(wanderer)
+        freq_f = float(freq.detach().to("cpu").item()) if hasattr(freq, "detach") else float(freq)
+        damp_f = float(damp.detach().to("cpu").item()) if hasattr(damp, "detach") else float(damp)
+
+        vals = self._to_list(value)
+        st = self._state.setdefault(id(syn), {"pos": 0.0, "vel": 0.0})
+        out_vals: List[float] = []
+        for v in vals:
+            vel = st["vel"] + freq_f * (v - st["pos"]) - damp_f * st["vel"]
+            pos = st["pos"] + vel
+            st["vel"], st["pos"] = vel, pos
+            out_vals.append(pos)
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "resonant_step",
+                {
+                    "freq": freq_f,
+                    "damp": damp_f,
+                },
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+try:
+    register_synapse_type("resonant", ResonantSynapsePlugin())
+except Exception:
+    pass
+
+__all__ = ["ResonantSynapsePlugin"]
+

--- a/marble/plugins/synapse_spike_gate.py
+++ b/marble/plugins/synapse_spike_gate.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Spike gating synapse plugin.
+
+Applies a smooth threshold via a logistic gate. Two learnable parameters control
+the threshold and sharpness of the gate.
+"""
+
+from typing import Any, List
+import math
+
+from ..graph import register_synapse_type, Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class SpikeGateSynapsePlugin:
+    """Logistic gating with learnable threshold and sharpness."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, gate_thresh: float = 0.5, gate_sharp: float = 10.0) -> Any:
+        return (gate_thresh, gate_sharp)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        thresh, sharp = 0.5, 10.0
+        if wanderer is not None:
+            thresh, sharp = self._params(wanderer)
+
+        vals = self._to_list(value)
+        torch = getattr(syn, "_torch", None)
+        dev = getattr(syn, "_device", "cpu")
+        if torch is not None:
+            vt = value
+            if not (hasattr(vt, "detach") and hasattr(vt, "to")):
+                vt = torch.tensor(vals, dtype=torch.float32, device=dev)
+            gate = torch.sigmoid((vt - thresh) * sharp)
+            out = vt * gate
+        else:
+            gate = [1.0 / (1.0 + math.exp(-((v - float(thresh)) * float(sharp)))) for v in vals]
+            out_vals = [v * g for v, g in zip(vals, gate)]
+            out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "spike_gate",
+                {
+                    "thresh": float(thresh.detach().to("cpu").item()) if hasattr(thresh, "detach") else float(thresh),
+                    "sharp": float(sharp.detach().to("cpu").item()) if hasattr(sharp, "detach") else float(sharp),
+                },
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+try:
+    register_synapse_type("spike_gate", SpikeGateSynapsePlugin())
+except Exception:
+    pass
+
+__all__ = ["SpikeGateSynapsePlugin"]
+

--- a/tests/test_synapse_plugins.py
+++ b/tests/test_synapse_plugins.py
@@ -1,0 +1,39 @@
+import unittest
+
+
+class TestAdvancedSynapsePlugins(unittest.TestCase):
+    def _build_brain_with_plugin(self, plugin_name: str):
+        from marble.marblemain import Brain
+
+        b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.add_neuron((1.0, 0.0), tensor=[0.0], weight=1.0, bias=0.0)
+        b.connect((0.0, 0.0), (1.0, 0.0), direction="uni", type_name=plugin_name)
+        return b
+
+    def _walk_and_collect(self, brain):
+        from marble.marblemain import Wanderer
+
+        w = Wanderer(brain, seed=1)
+        start = brain.get_neuron((0.0, 0.0))
+        w.walk(max_steps=1, lr=1e-2, start=start)
+        return w
+
+    def test_synapse_plugins_register_learnables(self):
+        plugin_params = {
+            "dropout": ["dropout_p"],
+            "hebbian": ["hebb_rate", "hebb_decay"],
+            "resonant": ["res_freq", "res_damp"],
+            "delay": ["delay_alpha"],
+            "spike_gate": ["gate_thresh", "gate_sharp"],
+        }
+        for name, params in plugin_params.items():
+            brain = self._build_brain_with_plugin(name)
+            w = self._walk_and_collect(brain)
+            for p in params:
+                self.assertIn(p, w._learnables, f"{name} missing {p}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add advanced synapse plugins (dropout, hebbian, resonant, delay, spike_gate) exposing parameters via `expose_learnable_params`
- document new synapse plugins in ARCHITECTURE.md and mark plan step complete
- cover new plugins with unit test ensuring parameters register on a Wanderer walk

## Testing
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_synapse_plugins`


------
https://chatgpt.com/codex/tasks/task_e_68b1eaffda2c8327ad38a3a87f4ffcbc