### PR TITLE
feat: enforce unskipped tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,3 +408,12 @@ Hugging Face Datasets Policy (additive)
 62. After every change within `3d_printer_sim`, evaluate whether new tasks for visualization or full live 3D rendering are required. If so, update `3d_printer_sim/developmentplan.md` with the necessary steps.
 63. Treat the `3d_printer_sim` directory as a fully distinct project. Repository rules that only concern other parts of the repo do not apply inside this folder unless they logically make sense for both projects.
 64. All steps in `3d_printer_sim/developmentplan.md` must be implemented fully and exactly as written—no mocking, stubs, skeletons, or minimal implementations are ever permitted.
+65) No Skipped Tests Rule
+
+Rule: Tests must never be skipped; install all missing dependencies and resolve any warnings or runtime errors during testing.
+Context: Repository-wide testing activities.
+Problem: Skipped tests or unresolved warnings/errors can hide defects and undermine reliability.
+Benefit: Ensures complete test coverage and stable, predictable code behavior.
+Non-Conflict Statement: This rule complements the existing testing policy without contradicting any prior rule.
+Verification: Running the entire test suite reports zero skipped tests and emits no warnings or runtime errors.
+Rollback Plan: Remove this rule block from AGENTS.md if the testing policy changes.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -651,6 +651,18 @@ try:
 except Exception:
     pass
 
+# Ensure additional Wanderer plugins register their learnable parameters.
+try:  # pragma: no cover - plugin availability may vary
+    from .plugins import (
+        wanderer_boltzmann as _wanderer_boltzmann,
+        wanderer_pheromone as _wanderer_pheromone,
+        wanderer_momentum as _wanderer_momentum,
+        wanderer_temporal_decay as _wanderer_temporal_decay,
+        wanderer_entropy as _wanderer_entropy,
+    )  # noqa: F401
+except Exception:
+    pass
+
 # -----------------------------
 # SelfAttention Routine: Adaptive Grad Clip
 # -----------------------------

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -896,9 +896,25 @@ class Wanderer(_DeviceHelper):
             return self._learnables[name]["tensor"]
         torch = self._torch  # type: ignore[assignment]
         try:
-            t = torch.tensor(init_value, dtype=torch.float32, device=self._device, requires_grad=requires_grad)
+            if hasattr(init_value, "detach"):
+                t = init_value.detach().clone().to(
+                    dtype=torch.float32, device=self._device
+                )
+                t.requires_grad_(requires_grad)
+            else:
+                t = torch.tensor(
+                    init_value,
+                    dtype=torch.float32,
+                    device=self._device,
+                    requires_grad=requires_grad,
+                )
         except Exception:
-            t = torch.tensor([float(init_value)], dtype=torch.float32, device=self._device, requires_grad=requires_grad)
+            t = torch.tensor(
+                [float(init_value)],
+                dtype=torch.float32,
+                device=self._device,
+                requires_grad=requires_grad,
+            )
         self._learnables[name] = {"tensor": t, "opt": False, "lr": lr}
         self._plugin_state.setdefault("learnable_params", {})[name] = t
         try:

--- a/tests/test_new_wanderer_plugins.py
+++ b/tests/test_new_wanderer_plugins.py
@@ -1,5 +1,5 @@
 import unittest
-HAVE_TORCH = False
+import torch
 
 from marble.marblemain import Brain, Wanderer
 
@@ -12,7 +12,6 @@ class TestNewWandererPlugins(unittest.TestCase):
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
         return b
 
-    @unittest.skipUnless(HAVE_TORCH, "torch required")
     def test_plugins_register_learnables(self):
         plugins = {
             "boltzmann": "temperature",


### PR DESCRIPTION
## Summary
- ban skipping tests and require dependency installation in AGENTS.md
- load Wanderer plugins and ensure learnable params avoid torch warnings
- activate Wanderer plugin tests without skips

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `pip install pythreejs`
- `python -m unittest -v tests.test_latent_and_synthetic_plugins`
- `python -m unittest -v tests.test_new_wanderer_plugins`
- `for f in tests/test_3d_printer_sim_adhesion.py tests/test_wanderer_wayfinder_plugin.py; do python -m unittest -v tests.$(basename $f .py); done`


------
https://chatgpt.com/codex/tasks/task_e_68b1f5133b48832789458a6f9b671afc