### PR TITLE
Ensure plugin auto-registration and validate neuroplasticity growth

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -2271,6 +2271,9 @@ __all__ += ["register_brain_train_type"]
 # Wanderer with Autograd + Plugins
 # -----------------------------
 
+# Import all plugin modules so they self-register with their registries.
+from . import plugins as _plugins  # noqa: F401
+
 # Plugin registry for Wanderer (moved). Import registry and registrar.
 from .wanderer import register_wanderer_type  # re-exported below
 from .wanderer import WANDERER_TYPES_REGISTRY as _WANDERER_TYPES

--- a/marble/plugins/__init__.py
+++ b/marble/plugins/__init__.py
@@ -1,2 +1,21 @@
-# Plugin package: each plugin resides in its own file.
+"""Plugin package auto-loader.
+
+Imports every module in this package so plugin classes self-register with
+their respective registries. Dropping a new plugin module into this
+directory makes it instantly available without manual wiring.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import List
+
+__all__: List[str] = []
+
+for mod in pkgutil.iter_modules(__path__):
+    if mod.name.startswith("_"):
+        continue
+    importlib.import_module(f"{__name__}.{mod.name}")
+    __all__.append(mod.name)
 

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -733,6 +733,12 @@ class Wanderer(_DeviceHelper):
                         pass
         except Exception:
             pass
+        res = {
+            "loss": final_loss_val,
+            "steps": int(steps),
+            "visited": int(len(self._visited)),
+            "step_metrics": step_metrics,
+        }
 
         for nplug in getattr(self, "_neuro_plugins", []) or []:
             try:
@@ -752,13 +758,6 @@ class Wanderer(_DeviceHelper):
                     plug.on_walk_end(self, res)  # type: ignore[attr-defined]
             except Exception:
                 pass
-
-        res = {
-            "loss": final_loss_val,
-            "steps": int(steps),
-            "visited": int(len(self._visited)),
-            "step_metrics": step_metrics,
-        }
         try:
             report("wanderer", "walk", res, "metrics")
         except Exception:

--- a/tests/test_neuroplasticity.py
+++ b/tests/test_neuroplasticity.py
@@ -8,6 +8,7 @@ class TestNeuroplasticity(unittest.TestCase):
         self.Codec = UniversalTensorCodec
         self.make_dp = make_datapair
         self.reporter = REPORTER
+        self.reporter.clear_group("neuroplasticity")
 
     def test_base_plugin_grows_graph_when_no_outgoing(self):
         b = self.Brain(2, size=(6, 6))
@@ -30,11 +31,13 @@ class TestNeuroplasticity(unittest.TestCase):
         after_neuron_count = len(b.neurons)
         print("neuroplasticity grow count:", before_neuron_count, "->", after_neuron_count)
 
-        # Either added a neuron or already had outgoing edges from last
-        self.assertGreaterEqual(after_neuron_count, before_neuron_count)
+        # Neuron count must increase
+        self.assertGreater(after_neuron_count, before_neuron_count)
         # Reporter emitted events
         init_log = self.reporter.item("init", "neuroplasticity", "events")
+        grow_log = self.reporter.item("grow", "neuroplasticity", "events")
         self.assertIsNotNone(init_log)
+        self.assertIsNotNone(grow_log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- auto-import all plugin modules so new plugins register themselves
- fix Wanderer to call neuroplasticity hooks with proper result payload
- tighten neuroplasticity test to require neuron growth and log events

## Testing
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_new_wanderer_plugins`
- `python -m unittest -v tests.test_wanderer`


------
https://chatgpt.com/codex/tasks/task_e_68b1f87a1e1c83278cc22500c2d5e664