### PR TITLE
Add test output analysis rule and log adhesion metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,3 +417,15 @@ Benefit: Ensures complete test coverage and stable, predictable code behavior.
 Non-Conflict Statement: This rule complements the existing testing policy without contradicting any prior rule.
 Verification: Running the entire test suite reports zero skipped tests and emits no warnings or runtime errors.
 Rollback Plan: Remove this rule block from AGENTS.md if the testing policy changes.
+
+66) Test Output Analysis Rule
+
+Rule: Execute every test module individually and inspect its printed output for logical consistency.
+Context: Running and validating repository tests.
+Details:
+- All tests must provide concise, informative console output or reporter logs so their behavior can be analyzed.
+- If a test lacks sufficient output, extend the test (not the production code) to emit key metrics or counts.
+- When a test reveals logically inconsistent results, fix the underlying implementation code rather than altering the test expectations.
+Benefit: Ensures tests are both observable and trustworthy, enabling quick detection of subtle logic errors.
+Verification: Each test run prints or reports meaningful data, and successful tests show internally consistent values.
+Rollback Plan: Remove this rule block from AGENTS.md if testing policies change.

--- a/tests/test_3d_printer_sim_adhesion.py
+++ b/tests/test_3d_printer_sim_adhesion.py
@@ -2,6 +2,8 @@ import importlib.util
 import pathlib
 import unittest
 
+from marble.marblemain import report, clear_report_group
+
 
 def load_module(name: str, filename: str):
     spec = importlib.util.spec_from_file_location(name, pathlib.Path(filename))
@@ -22,6 +24,9 @@ TemperatureSensor = sensors_mod.TemperatureSensor
 
 
 class TestAdhesion(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_report_group("adhesion")
+
     def test_bed_temperature_influence(self) -> None:
         sim = PrinterSimulation()
         sim.z_motor.position = sim.layer_height
@@ -40,6 +45,8 @@ class TestAdhesion(unittest.TestCase):
         sim.bed_temperature = sim.optimal_bed_temp
         sim.update(0.1)
 
+        report("adhesion", "bed_temp", {"low": low_adh, "optimal": sim.adhesion})
+        print("bed adhesion", {"low": low_adh, "optimal": sim.adhesion})
         self.assertLess(low_adh, 0.5)
         self.assertLess(z_after, z_before)  # drooping occurred
         self.assertGreater(sim.adhesion, low_adh)
@@ -66,6 +73,8 @@ class TestAdhesion(unittest.TestCase):
         sensor.set_temperature(240)
         sim.update(0.1)
 
+        report("adhesion", "extruder_temp", {"low": low, "optimal": sim.adhesion})
+        print("extruder adhesion", {"low": low, "optimal": sim.adhesion})
         self.assertLess(low, 0.5)
         self.assertLess(z_after, z_before)
         self.assertGreater(sim.adhesion, low)


### PR DESCRIPTION
## Summary
- record detailed adhesion metrics in 3D printer simulation tests and clear reporter groups for clean runs
- document new testing policy requiring analysis of per-test output in AGENTS.md

## Testing
- `python -m unittest -v tests.test_datapair`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_3d_printer_sim_adhesion`


------
https://chatgpt.com/codex/tasks/task_e_68b1fbbc1cd883279fcd5c9de3a21d89