### PR TITLE
Add diagnostic prints to silent tests

### DIFF
--- a/find_tests_without_prints.py
+++ b/find_tests_without_prints.py
@@ -1,0 +1,30 @@
+import ast
+from pathlib import Path
+
+
+def file_has_print(path: Path) -> bool:
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except Exception:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == 'print':
+                return True
+    return False
+
+
+def main():
+    tests_dir = Path('tests')
+    missing = []
+    for path in sorted(tests_dir.glob('test_*.py')):
+        if not file_has_print(path):
+            missing.append(path)
+    for path in missing:
+        print(path)
+    print(f"Total: {len(missing)} tests without prints.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_3d_printer_sim_bed_tilt.py
+++ b/tests/test_3d_printer_sim_bed_tilt.py
@@ -42,6 +42,7 @@ class TestBedTiltConfig(unittest.TestCase):
             tmp.write(text)
             tmp.flush()
             cfg = load_config(tmp.name)
+        print("bed tilt angles:", cfg.bed_tilt.x, cfg.bed_tilt.y)
         self.assertAlmostEqual(cfg.bed_tilt.x, 1)
         self.assertAlmostEqual(cfg.bed_tilt.y, 2)
 
@@ -55,6 +56,7 @@ class TestBedTiltConfig(unittest.TestCase):
             tmp.flush()
             cfg = load_config(tmp.name)
         expected = math.degrees(math.atan2(1, 100))
+        print("computed screw tilt:", cfg.bed_tilt.x, cfg.bed_tilt.y, "expected", expected)
         self.assertAlmostEqual(cfg.bed_tilt.x, expected)
         self.assertAlmostEqual(cfg.bed_tilt.y, 0.0)
 
@@ -67,10 +69,12 @@ class TestBedTiltSimulation(unittest.TestCase):
         sim.z_motor.position = 10
         sim.update(0.1)
         x, y, z = sim.visualizer.extruder.position
+        print("extruder pos:", x, y, z)
         self.assertAlmostEqual(x, 0.0, places=5)
         self.assertAlmostEqual(y, -10.0, places=5)
         self.assertAlmostEqual(z, 0.0, places=5)
         gx, gy, gz = sim.gravity
+        print("gravity:", gx, gy, gz)
         self.assertAlmostEqual(gx, 0.0, places=5)
         self.assertAlmostEqual(gy, -9.81, places=2)
         self.assertAlmostEqual(gz, 0.0, places=5)

--- a/tests/test_3d_printer_sim_config.py
+++ b/tests/test_3d_printer_sim_config.py
@@ -19,6 +19,7 @@ parse_simple_yaml = module.parse_simple_yaml
 class TestPrinterConfig(unittest.TestCase):
     def test_load_config(self) -> None:
         cfg = load_config("3d_printer_sim/config.yaml")
+        print("extruders:", len(cfg.extruders), "volume_z:", cfg.build_volume.z)
         self.assertEqual(len(cfg.extruders), 2)
         self.assertEqual(cfg.build_volume.z, 250)
         self.assertIn("PETG", cfg.filament_types)
@@ -39,6 +40,7 @@ class TestPrinterConfig(unittest.TestCase):
             tmp.flush()
             with self.assertRaises(ValueError):
                 load_config(tmp.name)
+        print("missing section raised ValueError as expected")
 
     def test_empty_extruders_list(self) -> None:
         text = (
@@ -53,6 +55,7 @@ class TestPrinterConfig(unittest.TestCase):
             tmp.flush()
             with self.assertRaises(ValueError):
                 load_config(tmp.name)
+        print("empty extruders raised ValueError")
 
     def test_negative_axis_value(self) -> None:
         text = (
@@ -67,15 +70,18 @@ class TestPrinterConfig(unittest.TestCase):
             tmp.flush()
             with self.assertRaises(ValueError):
                 load_config(tmp.name)
+        print("negative axis raised ValueError")
 
     def test_parse_simple_yaml_basic(self) -> None:
         data = parse_simple_yaml("a: 1\nb:\n  - 2\n  - 3\n")
+        print("parsed:", data)
         self.assertEqual(data, {"a": 1, "b": [2, 3]})
 
     def test_example_configs_parse(self) -> None:
         examples = pathlib.Path("3d_printer_sim/examples")
         for path in examples.glob("*.yaml"):
             cfg = load_config(str(path))
+            print(path.name, "extruders", len(cfg.extruders))
             self.assertGreater(len(cfg.extruders), 0)
 
 

--- a/tests/test_3d_printer_sim_extrusion.py
+++ b/tests/test_3d_printer_sim_extrusion.py
@@ -31,6 +31,7 @@ class TestExtruder(unittest.TestCase):
         extruder = Extruder(motor, steps_per_mm=100, filament_diameter=1.75)
         extruder.set_target_velocity(100)  # steps per second
         extruder.update(1.0)
+        print("length and volume:", extruder.extruded_length, extruder.deposited_volume)
         self.assertAlmostEqual(extruder.extruded_length, 1.0)
         expected_volume = math.pi * (1.75 / 2) ** 2 * 1.0
         self.assertAlmostEqual(extruder.deposited_volume, expected_volume)
@@ -53,7 +54,7 @@ class TestExtruder(unittest.TestCase):
         extruder.update(1.0)
         high_eff = extruder.last_flow_efficiency
         high_vol = extruder.deposited_volume
-
+        print("flow eff/vol:", low_eff, low_vol, high_eff, high_vol)
         self.assertGreater(high_eff, low_eff)
         self.assertGreater(high_vol, low_vol)
 

--- a/tests/test_3d_printer_sim_filament_physics.py
+++ b/tests/test_3d_printer_sim_filament_physics.py
@@ -31,7 +31,7 @@ class TestFilamentPhysics(unittest.TestCase):
         sim_fan.update(0.1)
         sim_fan.update(1.0)
         temp_fan = sim_fan.segments[0].temperature
-
+        print("temps fan/no_fan:", temp_fan, temp_no_fan)
         self.assertLess(temp_fan, temp_no_fan)
 
     def test_shrinkage_after_cooling(self) -> None:
@@ -42,6 +42,7 @@ class TestFilamentPhysics(unittest.TestCase):
         initial_radius = sim.segments[0].radius
         for _ in range(20):
             sim.update(1.0)
+        print("radius initial/final:", initial_radius, sim.segments[0].radius)
         self.assertTrue(sim.segments[0].solid)
         self.assertLess(sim.segments[0].radius, initial_radius)
 
@@ -57,7 +58,7 @@ class TestFilamentPhysics(unittest.TestCase):
         sim_tilt.set_extrusion_velocity(100)
         sim_tilt.update(0.1)
         width_tilt = sim_tilt.extrusion_width
-
+        print("widths flat/tilt:", width_flat, width_tilt)
         self.assertGreater(width_tilt, width_flat)
 
 

--- a/tests/test_3d_printer_sim_marlin_integration.py
+++ b/tests/test_3d_printer_sim_marlin_integration.py
@@ -48,6 +48,7 @@ class TestMarlinIntegration(unittest.TestCase):
             firmware = MarlinFirmware(pathlib.Path(src))
             # Using a no-op command that succeeds
             firmware.compile(pathlib.Path(build), compile_cmd=["true"])
+            print("compile run completed")
 
     def test_send_gcode_forwarding(self) -> None:
         mc = Microcontroller()
@@ -56,6 +57,7 @@ class TestMarlinIntegration(unittest.TestCase):
         mc.attach_usb(usb)
         firmware = MarlinFirmware(pathlib.Path("."))
         firmware.send_gcode(mc, "G28")
+        print("usb host buffer:", usb.host_buffer)
         self.assertEqual(usb.host_buffer, [b"G28\n"])
 
     def test_sd_card_mount(self) -> None:
@@ -63,8 +65,10 @@ class TestMarlinIntegration(unittest.TestCase):
         card = VirtualSDCard()
         mc.attach_sd_card(card)
         mc.mount_sd_card()
+        print("card mounted:", card.mounted)
         self.assertTrue(card.mounted)
         mc.unmount_sd_card()
+        print("card mounted after unmount:", card.mounted)
         self.assertFalse(card.mounted)
 
     def test_feed_sensor_data(self) -> None:
@@ -77,6 +81,7 @@ class TestMarlinIntegration(unittest.TestCase):
         firmware = MarlinFirmware(pathlib.Path("."))
         firmware.feed_sensor_data(mc)
         sent = usb.device_buffer[0].decode("ascii")
+        print("sensor data sent:", sent)
         self.assertIn("D1:1", sent)
         self.assertIn("A2:3.3", sent)
 

--- a/tests/test_3d_printer_sim_microcontroller.py
+++ b/tests/test_3d_printer_sim_microcontroller.py
@@ -17,14 +17,20 @@ class TestMicrocontroller(unittest.TestCase):
     def test_digital_io(self) -> None:
         mc = Microcontroller()
         mc.set_digital(13, 1)
-        self.assertEqual(mc.read_digital(13), 1)
-        self.assertEqual(mc.read_digital(12), 0)
+        val13 = mc.read_digital(13)
+        val12 = mc.read_digital(12)
+        print("digital pins:", val13, val12)
+        self.assertEqual(val13, 1)
+        self.assertEqual(val12, 0)
 
     def test_analog_io(self) -> None:
         mc = Microcontroller()
         mc.set_analog(0, 3.3)
-        self.assertAlmostEqual(mc.read_analog(0), 3.3)
-        self.assertEqual(mc.read_analog(1), 0.0)
+        val0 = mc.read_analog(0)
+        val1 = mc.read_analog(1)
+        print("analog pins:", val0, val1)
+        self.assertAlmostEqual(val0, 3.3)
+        self.assertEqual(val1, 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_3d_printer_sim_nozzle_distance.py
+++ b/tests/test_3d_printer_sim_nozzle_distance.py
@@ -20,6 +20,7 @@ class TestNozzleDistance(unittest.TestCase):
         sim.z_motor.position = 0.2
         sim.set_extrusion_velocity(100)
         sim.update(0.1)
+        print("height/width/adhesion:", sim.nozzle_height, sim.extrusion_width, sim.adhesion)
         self.assertAlmostEqual(sim.nozzle_height, 0.2)
         self.assertAlmostEqual(sim.extrusion_width, sim.nozzle_diameter)
         self.assertAlmostEqual(sim.adhesion, 1.0)
@@ -31,6 +32,7 @@ class TestNozzleDistance(unittest.TestCase):
         sim.set_axis_velocities(2, 0, 0)
         sim.set_extrusion_velocity(100)
         sim.update(0.1)
+        print("collision/damage/detached:", sim.collision, sim.surface_damage, sim.part_detached)
         self.assertTrue(sim.collision)
         self.assertGreater(sim.surface_damage, 0)
         self.assertTrue(sim.part_detached)
@@ -42,6 +44,7 @@ class TestNozzleDistance(unittest.TestCase):
         sim.z_motor.position = 0.5
         sim.set_extrusion_velocity(100)
         sim.update(0.1)
+        print("high clearance adhesion:", sim.adhesion)
         self.assertEqual(sim.adhesion, 0.0)
         self.assertEqual(len(sim.visualizer.filament), 1)
         self.assertFalse(sim.segments[0].supported)

--- a/tests/test_3d_printer_sim_pinmap.py
+++ b/tests/test_3d_printer_sim_pinmap.py
@@ -45,23 +45,29 @@ class TestPinMapping(unittest.TestCase):
     def test_sensor_auto_maps(self) -> None:
         mc = Microcontroller()
         sensor = TemperatureSensor(mc=mc, pin=0, value=25.0)
-        self.assertIs(mc.get_mapped_component(0), sensor)
+        mapped = mc.get_mapped_component(0)
+        print("sensor mapped to pin 0:", mapped)
+        self.assertIs(mapped, sensor)
 
     def test_manual_and_interface_mapping(self) -> None:
         mc = Microcontroller()
         mc.map_pin(13, "led")
+        print("pin13 mapped:", mc.get_mapped_component(13))
         self.assertEqual(mc.get_mapped_component(13), "led")
         mc.unmap_pin(13)
+        print("pin13 after unmap:", mc.get_mapped_component(13))
         self.assertIsNone(mc.get_mapped_component(13))
 
         usb = VirtualUSB()
         usb.connect()
         mc.attach_usb(usb, pins=[1, 2])
+        print("USB mapped pins:", mc.get_mapped_component(1))
         self.assertIs(mc.get_mapped_component(1), usb)
 
         card = VirtualSDCard()
         card.mount()
         mc.attach_sd_card(card, pins=[10])
+        print("SD card mapped pin:", mc.get_mapped_component(10))
         self.assertIs(mc.get_mapped_component(10), card)
 
 

--- a/tests/test_3d_printer_sim_sdcard.py
+++ b/tests/test_3d_printer_sim_sdcard.py
@@ -27,9 +27,11 @@ class TestSDCard(unittest.TestCase):
         card = VirtualSDCard()
         card.mount()
         card.write_file("test.gcode", b"G1 X10")
+        print("files after write:", card.list_files())
         self.assertEqual(card.read_file("test.gcode"), b"G1 X10")
         self.assertEqual(card.list_files(), ["test.gcode"])
         card.delete_file("test.gcode")
+        print("files after delete:", card.list_files())
         self.assertEqual(card.list_files(), [])
 
     def test_microcontroller_sd_interface(self) -> None:
@@ -38,6 +40,7 @@ class TestSDCard(unittest.TestCase):
         card.mount()
         mc.attach_sd_card(card)
         mc.sd_write_file("a.txt", b"abc")
+        print("mc sd files:", mc.sd_list_files())
         self.assertEqual(mc.sd_read_file("a.txt"), b"abc")
         self.assertEqual(mc.sd_list_files(), ["a.txt"])
 

--- a/tests/test_3d_printer_sim_sensors.py
+++ b/tests/test_3d_printer_sim_sensors.py
@@ -26,8 +26,10 @@ class TestSensors(unittest.TestCase):
     def test_temperature_sensor_updates_pin(self) -> None:
         mc = Microcontroller()
         sensor = TemperatureSensor(mc=mc, pin=0, value=25.0)
+        print("initial temp:", mc.read_analog(0))
         self.assertAlmostEqual(mc.read_analog(0), 25.0)
         sensor.set_temperature(200.0)
+        print("updated temp:", mc.read_analog(0))
         self.assertAlmostEqual(mc.read_analog(0), 200.0)
 
 

--- a/tests/test_3d_printer_sim_simulation.py
+++ b/tests/test_3d_printer_sim_simulation.py
@@ -23,6 +23,7 @@ class TestSimulation(unittest.TestCase):
         sim.set_extrusion_velocity(100)  # 1 mm/s with steps_per_mm=100
         sim.update(1.0)
         # Visualizer should track axis positions
+        print("extruder pos and filament:", list(sim.visualizer.extruder.position), len(sim.visualizer.filament))
         self.assertEqual(list(sim.visualizer.extruder.position), [1, 2, 0.2])
         # A filament segment should have been added due to sufficient adhesion
         self.assertEqual(len(sim.visualizer.filament), 1)
@@ -38,12 +39,14 @@ class TestSimulation(unittest.TestCase):
 
         # First second: jerk limits acceleration
         sim.update(1.0)
+        print("step1 accel/vel/pos:", sim.x_motor.acceleration, sim.x_motor.velocity, sim.x_motor.position)
         self.assertAlmostEqual(sim.x_motor.acceleration, 5)
         self.assertAlmostEqual(sim.x_motor.velocity, 5)
         self.assertAlmostEqual(sim.x_motor.position, 5)
 
         # Second second: acceleration reaches limit
         sim.update(1.0)
+        print("step2 accel/vel/pos:", sim.x_motor.acceleration, sim.x_motor.velocity, sim.x_motor.position)
         self.assertAlmostEqual(sim.x_motor.acceleration, 10)
         self.assertAlmostEqual(sim.x_motor.velocity, 15)
         self.assertAlmostEqual(sim.x_motor.position, 20)

--- a/tests/test_3d_printer_sim_stepper.py
+++ b/tests/test_3d_printer_sim_stepper.py
@@ -25,10 +25,12 @@ class TestStepperMotor(unittest.TestCase):
         motor = StepperMotor(max_acceleration=10, max_jerk=5)
         motor.set_target_velocity(100)
         motor.update(1.0)
+        print("step1 accel/vel/pos:", motor.acceleration, motor.velocity, motor.position)
         self.assertAlmostEqual(motor.acceleration, 5)
         self.assertAlmostEqual(motor.velocity, 5)
         self.assertAlmostEqual(motor.position, 5)
         motor.update(1.0)
+        print("step2 accel/vel/pos:", motor.acceleration, motor.velocity, motor.position)
         self.assertAlmostEqual(motor.acceleration, 10)
         self.assertAlmostEqual(motor.velocity, 15)
         self.assertAlmostEqual(motor.position, 20)
@@ -37,14 +39,17 @@ class TestStepperMotor(unittest.TestCase):
         motor = StepperMotor(max_acceleration=50, max_jerk=2)
         motor.set_target_velocity(100)
         motor.update(1.0)
+        print("jerk step1 accel:", motor.acceleration)
         self.assertAlmostEqual(motor.acceleration, 2)
         motor.update(1.0)
+        print("jerk step2 accel:", motor.acceleration)
         self.assertAlmostEqual(motor.acceleration, 4)
 
     def test_pin_mapping(self) -> None:
         mcu = Microcontroller()
         motor = StepperMotor(max_acceleration=10, max_jerk=5)
         mcu.map_pin(1, motor)
+        print("mapped component:", mcu.get_mapped_component(1))
         self.assertIs(mcu.get_mapped_component(1), motor)
 
 

--- a/tests/test_3d_printer_sim_supports.py
+++ b/tests/test_3d_printer_sim_supports.py
@@ -18,8 +18,10 @@ class TestSupportsAndBrims(unittest.TestCase):
     def test_brim_generation(self) -> None:
         sim = PrinterSimulation()
         sim.generate_brim(radius=2, segments=4)
+        print("brim segments:", len(sim.segments))
         self.assertEqual(len(sim.segments), 4)
         for seg in sim.segments:
+            print("brim seg adhesion/removal:", seg.adhesion_strength, seg.removal_force)
             self.assertEqual(seg.kind, "brim")
             self.assertGreater(seg.adhesion_strength, 1.0)
             self.assertLess(seg.removal_force, 1.0)
@@ -31,9 +33,12 @@ class TestSupportsAndBrims(unittest.TestCase):
         sim.set_extrusion_velocity(100)
         sim.update(1.0)
         kinds = [seg.kind for seg in sim.segments]
+        print("segment kinds:", kinds)
         self.assertIn("support", kinds)
         self.assertIn("normal", kinds)
         support_segments = [seg for seg in sim.segments if seg.kind == "support"]
+        for seg in support_segments:
+            print("support adhesion/removal:", seg.adhesion_strength, seg.removal_force)
         self.assertTrue(all(abs(seg.adhesion_strength - 0.5) < 1e-6 for seg in support_segments))
         self.assertTrue(all(abs(seg.removal_force - 0.5) < 1e-6 for seg in support_segments))
 

--- a/tests/test_3d_printer_sim_thermal.py
+++ b/tests/test_3d_printer_sim_thermal.py
@@ -31,12 +31,14 @@ class TestThermal(unittest.TestCase):
         bed.set_target_temperature(100)
         bed.update(1.0)
         expected = 25.0 + (100.0 - 25.0) * (1 - math.exp(-0.5))
+        print("heated temp:", sensor.read_temperature())
         self.assertAlmostEqual(sensor.read_temperature(), expected)
         with self.assertRaises(ValueError):
             bed.set_target_temperature(200)
         bed.set_target_temperature(50)
         bed.update(1.0)
         expected_cool = expected + (50.0 - expected) * (1 - math.exp(-0.25))
+        print("cooled temp:", sensor.read_temperature())
         self.assertAlmostEqual(sensor.read_temperature(), expected_cool)
 
 

--- a/tests/test_3d_printer_sim_usb.py
+++ b/tests/test_3d_printer_sim_usb.py
@@ -27,8 +27,10 @@ class TestVirtualUSB(unittest.TestCase):
         usb = VirtualUSB()
         usb.connect()
         usb.send_from_host(b"hi")
+        print("host->device:", usb.read_from_host())
         self.assertEqual(usb.read_from_host(), b"hi")
         usb.send_from_device(b"ok")
+        print("device->host:", usb.read_from_device())
         self.assertEqual(usb.read_from_device(), b"ok")
 
     def test_attach_to_microcontroller(self):
@@ -37,8 +39,10 @@ class TestVirtualUSB(unittest.TestCase):
         mcu = Microcontroller()
         mcu.attach_usb(usb)
         mcu.usb_send(b"data")
+        print("mcu->host:", usb.read_from_device())
         self.assertEqual(usb.read_from_device(), b"data")
         usb.send_from_host(b"host")
+        print("host->mcu:", mcu.usb_receive())
         self.assertEqual(mcu.usb_receive(), b"host")
 
 

--- a/tests/test_3d_printer_sim_visualization.py
+++ b/tests/test_3d_printer_sim_visualization.py
@@ -17,18 +17,21 @@ class TestVisualization(unittest.TestCase):
     def test_scene_components(self):
         viz = PrinterVisualizer()
         # bed and extruder should be present in the scene
+        print("scene children count:", len(viz.scene.children))
         self.assertIn(viz.bed, viz.scene.children)
         self.assertIn(viz.extruder, viz.scene.children)
 
     def test_position_update(self):
         viz = PrinterVisualizer()
         viz.update_extruder_position(10, 20, 30)
+        print("extruder position:", list(viz.extruder.position))
         self.assertEqual(list(viz.extruder.position), [10, 20, 30])
 
     def test_filament_segment_added(self):
         viz = PrinterVisualizer()
         before = len(viz.scene.children)
         viz.add_filament_segment(0, 0, 0)
+        print("children before/after:", before, len(viz.scene.children))
         self.assertGreater(len(viz.scene.children), before)
 
 

--- a/tests/test_advanced_neuron_plugins.py
+++ b/tests/test_advanced_neuron_plugins.py
@@ -51,6 +51,7 @@ class AdvancedNeuronPluginTests(unittest.TestCase):
             n._plugin_state["wanderer"] = w
             plug = _NEURON_TYPES[name]
             plug.forward(n, input_value=[0.0])
+            print("plugin", name, "learnables", list(w._learnables.keys()))
             for p in params:
                 self.assertIn(p, w._learnables)
 

--- a/tests/test_autolobeplugin.py
+++ b/tests/test_autolobeplugin.py
@@ -19,8 +19,8 @@ class TestAutoLobePlugin(unittest.TestCase):
         self.assertIn("autolobe_low", b.lobes)
         self.assertIn("autolobe_high", b.lobes)
         self.assertIn("autolobe_threshold", w._learnables)
-
         report("tests/autolobe", "done", {"lobes": list(b.lobes.keys())}, "tests")
+        print("lobes created:", list(b.lobes.keys()))
 
 
 if __name__ == "__main__":

--- a/tests/test_autoneuron.py
+++ b/tests/test_autoneuron.py
@@ -22,6 +22,7 @@ class TestAutoNeuron(unittest.TestCase):
         w.ensure_learnable_param("autoneuron_bias_fail", 10.0)
         w.ensure_learnable_param("autoneuron_bias_base", -10.0)
         res = w.walk(max_steps=1, start=n, lr=0.0)
+        print("walk result:", res)
         self.assertIn("loss", res)
         self.assertEqual(n.type_name, "autoneuron")
 
@@ -48,6 +49,7 @@ class TestAutoNeuron(unittest.TestCase):
         w.ensure_learnable_param("autoneuron_bias_fail2", 10.0)
         w.ensure_learnable_param("autoneuron_bias_base", -10.0)
         res = w.walk(max_steps=1, start=n, lr=0.0)
+        print("walk result:", res, "fail calls:", fail_impl.calls)
         self.assertIn("loss", res)
         self.assertEqual(fail_impl.calls, 0)
 

--- a/tests/test_autoplugin_exclude.py
+++ b/tests/test_autoplugin_exclude.py
@@ -19,8 +19,10 @@ class TestAutoPluginExclude(unittest.TestCase):
         w = Wanderer(b, type_name="epsilongreedy,autoplugin_no_eps", neuroplasticity_type="base", seed=0)
 
         # The excluded plugin should not be present in the wanderer stack
+        plugins = [p.__class__.__name__ for p in w._wplugins]
+        print("plugins:", plugins)
         self.assertFalse(
-            any("EpsilonGreedyChooserPlugin" == p.__class__.__name__ for p in w._wplugins)
+            any("EpsilonGreedyChooserPlugin" == name for name in plugins)
         )
 
 

--- a/tests/test_autoplugin_explicit.py
+++ b/tests/test_autoplugin_explicit.py
@@ -18,10 +18,12 @@ class TestAutoPluginExplicit(unittest.TestCase):
         )
         w.ensure_learnable_param("autoplugin_bias_EpsilonGreedyChooserPlugin", -10.0)
         auto = next(p for p in w._wplugins if isinstance(p, AutoPlugin))
-        self.assertTrue(auto.is_active(w, "EpsilonGreedyChooserPlugin", None))
-        self.assertTrue(
-            any(isinstance(p, EpsilonGreedyChooserPlugin) for p in w._wplugins)
-        )
+        active = auto.is_active(w, "EpsilonGreedyChooserPlugin", None)
+        print("plugin active:", active)
+        self.assertTrue(active)
+        present = any(isinstance(p, EpsilonGreedyChooserPlugin) for p in w._wplugins)
+        print("plugin present:", present)
+        self.assertTrue(present)
 
 
 if __name__ == "__main__":

--- a/tests/test_batch_training_plugin.py
+++ b/tests/test_batch_training_plugin.py
@@ -27,6 +27,7 @@ class TestBatchTrainingPlugin(unittest.TestCase):
             pred = float(out[0])
         else:
             pred = float(out)
+        print("prediction:", pred)
         self.assertAlmostEqual(pred, 4.0, delta=3.0)
 
 

--- a/tests/test_earlystop_plugin.py
+++ b/tests/test_earlystop_plugin.py
@@ -21,6 +21,7 @@ class TestEarlyStopPlugin(unittest.TestCase):
         w.walk = types.MethodType(constant_walk, w)
         res = brain.train(w, num_walks=10, max_steps=1, lr=0.1, type_name="earlystop")
         report("tests", "earlystop", {"history_len": len(res["history"])}, "plugin")
+        print("history len and early stopped:", len(res["history"]), res.get("early_stopped"))
         self.assertLessEqual(len(res["history"]), 4)
         self.assertTrue(res.get("early_stopped"))
 

--- a/tests/test_latent_and_synthetic_plugins.py
+++ b/tests/test_latent_and_synthetic_plugins.py
@@ -17,6 +17,7 @@ class TestLatentAndSyntheticPlugins(unittest.TestCase):
         w.walk(max_steps=1, lr=1e-2)
         lv = w.get_learnable_param_tensor("latent_vector")
         report("tests", "latent_shape", {"shape": list(lv.shape)}, "plugins")
+        print("latent shape:", list(lv.shape))
         self.assertTrue(lv.numel() >= 1)
 
     def test_synthetic_training_plugin_runs(self) -> None:
@@ -25,6 +26,7 @@ class TestLatentAndSyntheticPlugins(unittest.TestCase):
         w.walk(max_steps=1, lr=1e-2)
         done = getattr(w, "_synthetic_trained", False)
         report("tests", "synthetic_done", {"done": bool(done)}, "plugins")
+        print("synthetic done:", done)
         self.assertTrue(done)
 
 

--- a/tests/test_learnable_params.py
+++ b/tests/test_learnable_params.py
@@ -53,7 +53,11 @@ class LearnableParamTests(unittest.TestCase):
         w._update_learnables()
         brain._update_learnables()
         sa._update_learnables(w)
-
+        print(
+            "params before/after:",
+            a_before.tolist(),
+            w.get_learnable_param_tensor("a").tolist(),
+        )
         self.assertFalse(torch.equal(a_before, w.get_learnable_param_tensor("a")))
         self.assertFalse(torch.equal(wp_before, w.get_learnable_param_tensor("wp")))
         self.assertFalse(torch.equal(bp_before, brain.get_learnable_param_tensor("bp")))

--- a/tests/test_lobe_training.py
+++ b/tests/test_lobe_training.py
@@ -28,6 +28,7 @@ class LobeTrainingTests(unittest.TestCase):
             loss=lambda outs: outs[0].sum(),
             lobe=lobe1,
         )
+        print("plugins after lobe1:", res1["history"][0]["plugins"])
         self.assertIn("EpsilonGreedyChooserPlugin", res1["history"][0]["plugins"])
         self.assertNotEqual(w0_before, float(n0.weight))
         self.assertEqual(w2_before, float(n2.weight))
@@ -49,6 +50,7 @@ class LobeTrainingTests(unittest.TestCase):
             loss=lambda outs: outs[0].sum(),
             lobe=lobe2,
         )
+        print("plugins after lobe2:", res2["history"][0]["plugins"])
         self.assertIn("WanderAlongSynapseWeightsPlugin", res2["history"][0]["plugins"])
         self.assertNotIn("EpsilonGreedyChooserPlugin", res2["history"][0]["plugins"])
 

--- a/tests/test_new_wanderer_plugins.py
+++ b/tests/test_new_wanderer_plugins.py
@@ -25,6 +25,7 @@ class TestNewWandererPlugins(unittest.TestCase):
                 b = self.make_brain()
                 w = Wanderer(b, type_name=name, seed=1)
                 w.walk(max_steps=1, lr=0.0)
+                print("plugin", name, "params", list(w._learnables.keys()))
                 self.assertIn(param, w._learnables)
 
 

--- a/tests/test_plugin_stacking.py
+++ b/tests/test_plugin_stacking.py
@@ -26,6 +26,7 @@ class TestPluginStacking(unittest.TestCase):
         b.connect(idx1, idx2, direction="uni")
         w = Wanderer(b)
         res = b.train(w, num_walks=1, max_steps=5, lr=0.01, type_name="p1,p2", start_selector=lambda brain: start)
+        print("history and current_lr:", res["history"], getattr(w, "current_lr", 0.0))
         self.assertEqual(len(res["history"]), 1)
         self.assertEqual(res["history"][0]["steps"], 1)  # p1 applied
         # current_lr recorded on wanderer after walk (from p2)

--- a/tests/test_quantumtype_plugin.py
+++ b/tests/test_quantumtype_plugin.py
@@ -49,8 +49,8 @@ class TestQuantumTypeNeuron(unittest.TestCase):
             val = float(out)
 
         REPORTER.item[("output", "quantum")] = val
-
         expected = (0.2689414213699951 * (2.0 * 3.0) + 0.7310585786300049 * (-1.0 * 3.0))
+        print("quantum output vs expected:", val, expected)
         self.assertAlmostEqual(val, expected, places=5)
 
 

--- a/tests/test_synapse_plugins.py
+++ b/tests/test_synapse_plugins.py
@@ -30,6 +30,7 @@ class TestAdvancedSynapsePlugins(unittest.TestCase):
         for name, params in plugin_params.items():
             brain = self._build_brain_with_plugin(name)
             w = self._walk_and_collect(brain)
+            print("synapse plugin", name, "learnables", list(w._learnables.keys()))
             for p in params:
                 self.assertIn(p, w._learnables, f"{name} missing {p}")
 

--- a/tests/test_wanderer_bestpath_weights.py
+++ b/tests/test_wanderer_bestpath_weights.py
@@ -29,6 +29,7 @@ class TestWandererBestPathAndWeights(unittest.TestCase):
         sb.weight = 2.0
         w = self.Wanderer(b, type_name="wanderalongsynapseweights")
         res = w.walk(max_steps=2, start=s, lr=1e-2)
+        print("visited after weights:", getattr(w, "_visited", []))
         # After one step, visited should include the target of sb (bnode)
         self.assertIn(bnode, getattr(w, "_visited", []))
 
@@ -41,9 +42,11 @@ class TestWandererBestPathAndWeights(unittest.TestCase):
         # Stack plugins: bestlosspath runs first, weights chooser last
         w = self.Wanderer(b, type_name="bestlosspath,wanderalongsynapseweights")
         res = w.walk(max_steps=2, start=s, lr=1e-2)
+        print("weights after best path:", sa.weight, sb.weight)
         # best path is via 'a' (lower loss), so sa weight should be boosted above sb
         self.assertGreater(sa.weight, sb.weight)
         # And the visited should include 'a'
+        print("visited after best path:", getattr(w, "_visited", []))
         self.assertIn(a, getattr(w, "_visited", []))
 
 


### PR DESCRIPTION
## Summary
- script to detect tests missing print statements
- add informative prints across tests for analysis

## Testing
- `python -m py_compile tests/test_*.py`
- `python find_tests_without_prints.py`


------
https://chatgpt.com/codex/tasks/task_e_68b20ce6e1288327a2af7e46bf136768