### PR TITLE
Handle simple batches without mixed precision on CPU

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -60,7 +60,7 @@ Core Components
     - `AutoPlugin` meta-plugin learns to enable or disable other Wanderer/neuroplasticity plugins per step and accepts `disabled_plugins=[...]` to completely remove certain plugins from the stack.
   - Gradient clipping: configurable per `Wanderer` via `gradient_clip` dict (`method`: `norm` or `value`, with `max_norm`/`norm_type` or `clip_value`). Applied after `loss.backward()` and before parameter updates.
   - Progress reporting: `Wanderer.walk` now emits a `tqdm` progress bar (or `tqdm.notebook` in IPython) updated each step with epoch/walk counts, neuron and synapse totals, brain size, step speed, path count, and loss metrics. `tqdm` is an explicit dependency.
-  - Mixed precision: `MixedPrecisionPlugin` uses `torch.amp.GradScaler` with automatic CUDA detection, avoiding warnings when GPUs are absent.
+  - Mixed precision: `MixedPrecisionPlugin` now activates only on CUDA-enabled devices. It uses `torch.amp.GradScaler` when GPUs are available and is a no-op on CPU to avoid precision loss.
 
 - Training Helpers: High-level flows to run Wanderer training:
   - `run_wanderer_training`: single-wanderer multi-walk loop. Accepts an optional `lobe` so only a subset of the Brain is traversed, with plugin stacks inherited or overridden per lobe.

--- a/marble/plugins/wanderer_batchtrainer.py
+++ b/marble/plugins/wanderer_batchtrainer.py
@@ -18,15 +18,9 @@ class BatchTrainingPlugin:
         setattr(wanderer, "_batch_size", bs)
 
     def loss(self, wanderer: "Wanderer", outputs: list[Any]):  # noqa: D401
+        """No additional loss; base Wanderer loss already handles batches."""
         torch = getattr(wanderer, "_torch", None)
-        if torch is None or not outputs:
-            return 0.0 if torch is None else torch.tensor(0.0, device=getattr(wanderer, "_device", "cpu"))
-        yt = outputs[-1].float()
-        tgt = wanderer._target_provider(outputs[-1])  # type: ignore[attr-defined]
-        if not hasattr(tgt, "float"):
-            tgt = torch.tensor(tgt, dtype=torch.float32, device=getattr(wanderer, "_device", "cpu"))
-        tgt = tgt.view_as(yt)
-        return torch.nn.functional.mse_loss(yt, tgt)
+        return 0.0 if torch is None else torch.tensor(0.0, device=getattr(wanderer, "_device", "cpu"))
 
 
 __all__ = ["BatchTrainingPlugin"]

--- a/marble/plugins/wanderer_mixedprecision.py
+++ b/marble/plugins/wanderer_mixedprecision.py
@@ -4,18 +4,17 @@ from typing import Any
 import torch
 
 
-
-
 class MixedPrecisionPlugin:
     """Enable mixed precision training for Wanderer walks."""
 
     def before_walk(self, wanderer: "Wanderer", start: "Neuron") -> None:  # noqa: D401
+        # Only enable mixed precision on CUDA devices to avoid CPU precision issues
+        if not torch.cuda.is_available() or not str(getattr(wanderer, "_device", "cpu")).startswith("cuda"):
+            return
         setattr(wanderer, "_use_mixed_precision", True)
         if not hasattr(wanderer, "_amp_scaler") or getattr(wanderer, "_amp_scaler", None) is None:
             try:
-                scaler = torch.amp.GradScaler(
-                    device_type="cuda", enabled=torch.cuda.is_available()
-                )
+                scaler = torch.amp.GradScaler(device_type="cuda", enabled=True)
             except Exception:
                 scaler = None
             setattr(wanderer, "_amp_scaler", scaler)


### PR DESCRIPTION
## Summary
- Skip mixed precision wanderer plugin on CPU-only runs
- Encode simple numeric datapairs directly and scale learning rate by batch size
- Simplify batch trainer plugin to defer loss to Wanderer

## Testing
- `python -m unittest -v tests.test_3d_printer_sim_config`
- `python -m unittest -v tests.test_3d_printer_sim_bed_tilt`
- `python -m unittest -v tests.test_batch_training_plugin`
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_brain_sparse`
- `python -m unittest -v tests.test_brain_sparse_io`
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_conv2d_conv3d_improvement`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_conv_transpose_improvement`


------
https://chatgpt.com/codex/tasks/task_e_68b214281f1c83278b0ad2ead1d6da93