### PR TITLE
feat: add experimental neuron plugin suite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -535,6 +535,10 @@ Convenience
 
 New Additive Plugins (this change)
 
+- Neuron plugins `quantum_tunnel`, `fractal_logistic`, `hyperbolic_blend`,
+  `oscillating_decay` and `echo_mix`: experimental activations exploring
+  tunneling effects, chaotic logistic iterations, hyperbolic mixes,
+  damped oscillations and short-term echo memory.
 - Synapse plugin `noisy`: Adds zero-mean Gaussian noise during `transmit`. Configure per-synapse via `syn._plugin_state['sigma']` (default `0.01`). Runs on CUDA when available; otherwise falls back to Python lists. Registered by name `"noisy"`.
 - Synapse plugin `dropout`: Zeroes transmissions with learnable probability `dropout_p`, allowing stochastic pruning of paths during training.
 - Synapse plugin `hebbian`: Online Hebbian rule updating `synapse.weight` by `hebb_rate` and decaying via `hebb_decay`, both learnable.

--- a/marble/plugins/echo_mix.py
+++ b/marble/plugins/echo_mix.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Echo mix neuron plugin.
+
+Blends the current input with a decaying echo of the previous output,
+creating a simple memory effect controlled by a learnable ``memory``
+coefficient.
+"""
+
+from typing import Any, Tuple
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class EchoMixNeuronPlugin:
+    """Mix current input with a stored echo."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer: "Wanderer", *, echo_memory: float = 0.5) -> Tuple[Any]:
+        return (echo_memory,)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        mem = 0.5
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                (mem,) = self._params(wanderer)
+            except Exception:
+                pass
+
+        prev = neuron._plugin_state.get("echo_prev")
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            prev_t = (
+                prev
+                if prev is not None and neuron._is_torch_tensor(prev)
+                else torch.zeros_like(x)
+            )
+            y = (1 - mem) * x + mem * prev_t
+            neuron._plugin_state["echo_prev"] = y.detach()
+            try:
+                report(
+                    "neuron",
+                    "echo_mix_forward",
+                    {"memory": float(mem.detach().to("cpu").item()) if hasattr(mem, "detach") else float(mem)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        prev_list = (
+            prev if isinstance(prev, list) else [float(prev)] if prev is not None else [0.0]
+        )
+        mem_f = float(mem.detach().to("cpu").item()) if hasattr(mem, "detach") else float(mem)
+        out = [
+            (1 - mem_f) * xv + mem_f * pv
+            for xv, pv in zip(x_list, prev_list + [0.0] * (len(x_list) - len(prev_list)))
+        ]
+        neuron._plugin_state["echo_prev"] = out if len(out) != 1 else out[0]
+        try:
+            report("neuron", "echo_mix_forward", {"memory": mem_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["EchoMixNeuronPlugin"]
+

--- a/marble/plugins/fractal_logistic.py
+++ b/marble/plugins/fractal_logistic.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Fractal logistic neuron plugin.
+
+Iteratively applies the logistic map to the input, creating fractal-like
+behaviour controlled by learnable ``r`` and iteration count parameters.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class FractalLogisticNeuronPlugin:
+    """Logistic map activation with learnable chaos parameters."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer", *, fractal_r: float = 3.5, fractal_iters: float = 3.0
+    ) -> Tuple[Any, Any]:
+        return (fractal_r, fractal_iters)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        r = 3.5
+        iters = 3.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                r, iters = self._params(wanderer)
+            except Exception:
+                pass
+
+        iters_i = int(
+            iters.detach().to("cpu").item() if hasattr(iters, "detach") else iters
+        )
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            v = torch.sigmoid(x)
+            for _ in range(max(0, iters_i)):
+                v = r * v * (1 - v)
+            try:
+                report(
+                    "neuron",
+                    "fractal_logistic_forward",
+                    {
+                        "r": float(r.detach().to("cpu").item()) if hasattr(r, "detach") else float(r),
+                        "iters": iters_i,
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return v
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        r_f = float(r.detach().to("cpu").item()) if hasattr(r, "detach") else float(r)
+        out = []
+        for xv in x_list:
+            v = 1.0 / (1.0 + math.exp(-xv))
+            for _ in range(max(0, iters_i)):
+                v = r_f * v * (1.0 - v)
+            out.append(v)
+        try:
+            report(
+                "neuron",
+                "fractal_logistic_forward",
+                {"r": r_f, "iters": iters_i},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["FractalLogisticNeuronPlugin"]
+

--- a/marble/plugins/hyperbolic_blend.py
+++ b/marble/plugins/hyperbolic_blend.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Hyperbolic blend neuron plugin.
+
+Combines hyperbolic tangent and secant functions to create an activation
+with both saturating and sharpening behaviour controlled by a learnable
+``alpha`` parameter.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class HyperbolicBlendNeuronPlugin:
+    """Mix tanh and sech responses via a learnable scale."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer: "Wanderer", *, hyper_alpha: float = 1.0) -> Tuple[Any]:
+        return (hyper_alpha,)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        alpha = 1.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                (alpha,) = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = torch.tanh(alpha * x) + torch.cosh(x).reciprocal()
+            try:
+                report(
+                    "neuron",
+                    "hyperbolic_blend_forward",
+                    {"alpha": float(alpha.detach().to("cpu").item()) if hasattr(alpha, "detach") else float(alpha)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        alpha_f = float(alpha.detach().to("cpu").item()) if hasattr(alpha, "detach") else float(alpha)
+        out = [math.tanh(alpha_f * v) + 1.0 / math.cosh(v) for v in x_list]
+        try:
+            report("neuron", "hyperbolic_blend_forward", {"alpha": alpha_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["HyperbolicBlendNeuronPlugin"]
+

--- a/marble/plugins/oscillating_decay.py
+++ b/marble/plugins/oscillating_decay.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Oscillating decay neuron plugin.
+
+Generates damped oscillations by combining sinusoidal responses with an
+exponential decay envelope. Both frequency and decay rate are learnable.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class OscillatingDecayNeuronPlugin:
+    """Damped sinusoidal activation with learnable parameters."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer", *, osc_freq: float = 1.0, osc_decay: float = 0.1
+    ) -> Tuple[Any, Any]:
+        return (osc_freq, osc_decay)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        freq = 1.0
+        decay = 0.1
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                freq, decay = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = x * torch.exp(-decay * torch.abs(x)) * torch.sin(freq * x)
+            try:
+                report(
+                    "neuron",
+                    "oscillating_decay_forward",
+                    {
+                        "freq": float(freq.detach().to("cpu").item()) if hasattr(freq, "detach") else float(freq),
+                        "decay": float(decay.detach().to("cpu").item()) if hasattr(decay, "detach") else float(decay),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        freq_f = float(freq.detach().to("cpu").item()) if hasattr(freq, "detach") else float(freq)
+        decay_f = float(decay.detach().to("cpu").item()) if hasattr(decay, "detach") else float(decay)
+        out = [v * math.exp(-decay_f * abs(v)) * math.sin(freq_f * v) for v in x_list]
+        try:
+            report(
+                "neuron",
+                "oscillating_decay_forward",
+                {"freq": freq_f, "decay": decay_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["OscillatingDecayNeuronPlugin"]
+

--- a/marble/plugins/quantum_tunnel.py
+++ b/marble/plugins/quantum_tunnel.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Quantum tunnel style neuron plugin.
+
+This highly experimental activation mimics quantum tunneling by
+exponentially damping values based on a learnable barrier height.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class QuantumTunnelNeuronPlugin:
+    """Apply exponential damping with a learnable barrier."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer: "Wanderer", *, qt_barrier: float = 1.0) -> Tuple[Any]:
+        return (qt_barrier,)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        barrier = 1.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                (barrier,) = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = x * torch.exp(-barrier * torch.abs(x))
+            try:
+                report(
+                    "neuron",
+                    "quantum_tunnel_forward",
+                    {"barrier": float(barrier.detach().to("cpu").item()) if hasattr(barrier, "detach") else float(barrier)},
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        barrier_f = (
+            float(barrier.detach().to("cpu").item()) if hasattr(barrier, "detach") else float(barrier)
+        )
+        out = [v * math.exp(-barrier_f * abs(v)) for v in x_list]
+        try:
+            report("neuron", "quantum_tunnel_forward", {"barrier": barrier_f}, "plugins")
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["QuantumTunnelNeuronPlugin"]
+

--- a/tests/test_new_neuron_plugins.py
+++ b/tests/test_new_neuron_plugins.py
@@ -1,0 +1,33 @@
+import unittest
+
+
+class TestNewNeuronPlugins(unittest.TestCase):
+    def test_registration_and_params(self) -> None:
+        from marble.marblemain import Brain, Wanderer, _NEURON_TYPES
+
+        plugins = {
+            "quantum_tunnel": ["qt_barrier"],
+            "fractal_logistic": ["fractal_r", "fractal_iters"],
+            "hyperbolic_blend": ["hyper_alpha"],
+            "oscillating_decay": ["osc_freq", "osc_decay"],
+            "echo_mix": ["echo_memory"],
+        }
+
+        for name, params in plugins.items():
+            self.assertIn(name, _NEURON_TYPES)
+            brain = Brain(1, size=1)
+            w = Wanderer(brain)
+            n = brain.add_neuron(
+                brain.available_indices()[0], tensor=[0.0], type_name=name
+            )
+            n._plugin_state["wanderer"] = w
+            plug = _NEURON_TYPES[name]
+            plug.forward(n, input_value=[0.0])
+            print("plugin", name, "learnables", list(w._learnables.keys()))
+            for p in params:
+                self.assertIn(p, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add five experimental neuron plugins exploring tunneling, chaos, hyperbolic mixing, damped oscillations, and echo memory
- document new neuron plugin suite in architecture guide
- cover plugins with registration/learnable parameter tests

## Testing
- `python -m unittest -v tests.test_new_neuron_plugins`


------
https://chatgpt.com/codex/tasks/task_e_68b229b2e2e48327ba98b390f50ef734