### PR TITLE
Add super advanced neuron plugin suite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -539,6 +539,11 @@ New Additive Plugins (this change)
   `oscillating_decay` and `echo_mix`: experimental activations exploring
   tunneling effects, chaotic logistic iterations, hyperbolic mixes,
   damped oscillations and short-term echo memory.
+- Additional neuron plugins `chaotic_sine`, `entropic_mixer`, `mirror_tanh`,
+  `spiral_time` and `lattice_resonance`: further experimental activations
+  covering logistic-map sine chaos, entropy-shaping mixes, sign-mirrored
+  tanh responses, logarithmic spiral distortion and modular lattice
+  resonance.
 - Synapse plugin `noisy`: Adds zero-mean Gaussian noise during `transmit`. Configure per-synapse via `syn._plugin_state['sigma']` (default `0.01`). Runs on CUDA when available; otherwise falls back to Python lists. Registered by name `"noisy"`.
 - Synapse plugin `dropout`: Zeroes transmissions with learnable probability `dropout_p`, allowing stochastic pruning of paths during training.
 - Synapse plugin `hebbian`: Online Hebbian rule updating `synapse.weight` by `hebb_rate` and decaying via `hebb_decay`, both learnable.

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -23,7 +23,7 @@ in current ML literature.
 
 ## Steps
 1. Enumerate existing plugin types in the repository. [complete]
-2. Implement advanced neuron plugin suite.
+2. Implement advanced neuron plugin suite. [complete]
 3. Implement advanced synapse plugin suite.
 4. Implement advanced wanderer plugin suite.
 5. Implement advanced brain_train plugin suite.

--- a/marble/plugins/chaotic_sine.py
+++ b/marble/plugins/chaotic_sine.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+"""Chaotic sine neuron plugin.
+
+Iterates a logistic map and feeds the result through a sine function to
+create a simple chaotic oscillation. All parameters are exposed through
+``expose_learnable_params`` so the wanderer can tune the behaviour.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class ChaoticSineNeuronPlugin:
+    """Apply logistic-map driven sine activation."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        chaos_r: float = 3.7,
+        chaos_iters: int = 2,
+        chaos_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any]:
+        return (chaos_r, chaos_iters, chaos_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        r = 3.7
+        iters = 2
+        bias = 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                r, iters, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            v = torch.sigmoid(x)
+            for _ in range(int(iters)):
+                v = r * v * (1 - v)
+            y = torch.sin(2 * math.pi * v) + bias
+            try:
+                report(
+                    "neuron",
+                    "chaotic_sine_forward",
+                    {
+                        "r": float(r.detach().to("cpu").item())
+                        if hasattr(r, "detach")
+                        else float(r),
+                        "iters": int(iters),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        r_f = float(r.detach().to("cpu").item()) if hasattr(r, "detach") else float(r)
+        bias_f = (
+            float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        )
+        out = []
+        for xv in x_list:
+            v = 1.0 / (1.0 + math.exp(-xv))
+            for _ in range(int(iters)):
+                v = r_f * v * (1.0 - v)
+            out.append(math.sin(2 * math.pi * v) + bias_f)
+        try:
+            report(
+                "neuron",
+                "chaotic_sine_forward",
+                {"r": r_f, "iters": int(iters), "bias": bias_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["ChaoticSineNeuronPlugin"]
+

--- a/marble/plugins/entropic_mixer.py
+++ b/marble/plugins/entropic_mixer.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Entropic mixer neuron plugin.
+
+Combines exponential decay with cosine interference to sculpt the entropy
+of activations. All parameters are wanderer-learnable.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class EntropicMixerNeuronPlugin:
+    """Decay input energy and apply cosine mixing."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        ent_alpha: float = 1.0,
+        ent_beta: float = 1.0,
+        ent_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any]:
+        return (ent_alpha, ent_beta, ent_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        alpha = 1.0
+        beta = 1.0
+        bias = 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                alpha, beta, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = torch.exp(-alpha * x * x) * torch.cos(beta * x) * x + bias
+            try:
+                report(
+                    "neuron",
+                    "entropic_mixer_forward",
+                    {
+                        "alpha": float(alpha.detach().to("cpu").item())
+                        if hasattr(alpha, "detach")
+                        else float(alpha),
+                        "beta": float(beta.detach().to("cpu").item())
+                        if hasattr(beta, "detach")
+                        else float(beta),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        alpha_f = (
+            float(alpha.detach().to("cpu").item()) if hasattr(alpha, "detach") else float(alpha)
+        )
+        beta_f = float(beta.detach().to("cpu").item()) if hasattr(beta, "detach") else float(beta)
+        bias_f = float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        out = [
+            math.exp(-alpha_f * xv * xv) * math.cos(beta_f * xv) * xv + bias_f for xv in x_list
+        ]
+        try:
+            report(
+                "neuron",
+                "entropic_mixer_forward",
+                {"alpha": alpha_f, "beta": beta_f, "bias": bias_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["EntropicMixerNeuronPlugin"]
+

--- a/marble/plugins/lattice_resonance.py
+++ b/marble/plugins/lattice_resonance.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Lattice resonance neuron plugin.
+
+Projects the input onto a modular lattice and scales the result. Useful for
+creating repeating patterns with learnable period and scale.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class LatticeResonanceNeuronPlugin:
+    """Apply modular reduction followed by scaling and bias."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        lattice_mod: float = 2.0,
+        lattice_scale: float = 1.0,
+        lattice_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any]:
+        return (lattice_mod, lattice_scale, lattice_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        mod = 2.0
+        scale = 1.0
+        bias = 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                mod, scale, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            v = torch.remainder(x, mod) / mod
+            y = v * scale + bias
+            try:
+                report(
+                    "neuron",
+                    "lattice_resonance_forward",
+                    {
+                        "mod": float(mod.detach().to("cpu").item())
+                        if hasattr(mod, "detach")
+                        else float(mod),
+                        "scale": float(scale.detach().to("cpu").item())
+                        if hasattr(scale, "detach")
+                        else float(scale),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        mod_f = float(mod.detach().to("cpu").item()) if hasattr(mod, "detach") else float(mod)
+        scale_f = (
+            float(scale.detach().to("cpu").item()) if hasattr(scale, "detach") else float(scale)
+        )
+        bias_f = float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        out = [math.fmod(xv, mod_f) / mod_f * scale_f + bias_f for xv in x_list]
+        try:
+            report(
+                "neuron",
+                "lattice_resonance_forward",
+                {"mod": mod_f, "scale": scale_f, "bias": bias_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["LatticeResonanceNeuronPlugin"]
+

--- a/marble/plugins/mirror_tanh.py
+++ b/marble/plugins/mirror_tanh.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+"""Mirror tanh neuron plugin.
+
+Contrasts the response of ``tanh(x)`` with ``tanh(|x|)`` to emphasise
+sign-sensitive deviations. Scale and bias are learnable parameters.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class MirrorTanhNeuronPlugin:
+    """Highlight differences between positive and negative activations."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer", *, mirror_scale: float = 1.0, mirror_bias: float = 0.0
+    ) -> Tuple[Any, Any]:
+        return (mirror_scale, mirror_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        scale = 1.0
+        bias = 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                scale, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = scale * (torch.tanh(x) - torch.tanh(torch.abs(x))) + bias
+            try:
+                report(
+                    "neuron",
+                    "mirror_tanh_forward",
+                    {
+                        "scale": float(scale.detach().to("cpu").item())
+                        if hasattr(scale, "detach")
+                        else float(scale),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        scale_f = (
+            float(scale.detach().to("cpu").item()) if hasattr(scale, "detach") else float(scale)
+        )
+        bias_f = float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        out = [
+            scale_f * (math.tanh(xv) - math.tanh(abs(xv))) + bias_f for xv in x_list
+        ]
+        try:
+            report(
+                "neuron",
+                "mirror_tanh_forward",
+                {"scale": scale_f, "bias": bias_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["MirrorTanhNeuronPlugin"]
+

--- a/marble/plugins/spiral_time.py
+++ b/marble/plugins/spiral_time.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Spiral time neuron plugin.
+
+Applies a logarithmic spiral transform to the input before a sine wave,
+introducing a temporal-like distortion that depends on input magnitude.
+"""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class SpiralTimeNeuronPlugin:
+    """Logarithmic spiral sine activation."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        spiral_freq: float = 1.0,
+        spiral_phase: float = 0.0,
+        spiral_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any]:
+        return (spiral_freq, spiral_phase, spiral_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        freq = 1.0
+        phase = 0.0
+        bias = 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                freq, phase, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y = torch.sin(freq * torch.log1p(torch.abs(x)) + phase) + bias
+            try:
+                report(
+                    "neuron",
+                    "spiral_time_forward",
+                    {
+                        "freq": float(freq.detach().to("cpu").item())
+                        if hasattr(freq, "detach")
+                        else float(freq),
+                        "phase": float(phase.detach().to("cpu").item())
+                        if hasattr(phase, "detach")
+                        else float(phase),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return y
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        freq_f = float(freq.detach().to("cpu").item()) if hasattr(freq, "detach") else float(freq)
+        phase_f = (
+            float(phase.detach().to("cpu").item()) if hasattr(phase, "detach") else float(phase)
+        )
+        bias_f = float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        out = [
+            math.sin(freq_f * math.log1p(abs(xv)) + phase_f) + bias_f for xv in x_list
+        ]
+        try:
+            report(
+                "neuron",
+                "spiral_time_forward",
+                {"freq": freq_f, "phase": phase_f, "bias": bias_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out if len(out) != 1 else out[0]
+
+
+__all__ = ["SpiralTimeNeuronPlugin"]
+

--- a/tests/test_super_advanced_neuron_plugins.py
+++ b/tests/test_super_advanced_neuron_plugins.py
@@ -1,0 +1,31 @@
+import unittest
+
+
+class SuperAdvancedNeuronPluginTests(unittest.TestCase):
+    def test_plugins_register_and_expose_params(self) -> None:
+        from marble.marblemain import Brain, Wanderer, _NEURON_TYPES
+
+        plugins = {
+            "chaotic_sine": ["chaos_r", "chaos_iters", "chaos_bias"],
+            "entropic_mixer": ["ent_alpha", "ent_beta", "ent_bias"],
+            "mirror_tanh": ["mirror_scale", "mirror_bias"],
+            "spiral_time": ["spiral_freq", "spiral_phase", "spiral_bias"],
+            "lattice_resonance": ["lattice_mod", "lattice_scale", "lattice_bias"],
+        }
+
+        for name, params in plugins.items():
+            self.assertIn(name, _NEURON_TYPES)
+            brain = Brain(1, size=1)
+            w = Wanderer(brain)
+            n = brain.add_neuron(brain.available_indices()[0], tensor=[0.0], type_name=name)
+            n._plugin_state["wanderer"] = w
+            plug = _NEURON_TYPES[name]
+            plug.forward(n, input_value=[0.0])
+            print("plugin", name, "learnables", list(w._learnables.keys()))
+            for p in params:
+                self.assertIn(p, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- expand architecture documentation to reflect new plugin locations and features
- mark advanced neuron suite step complete in DOTHISFIRST
- implement five experimental neuron plugins and corresponding tests

## Testing
- `python -m unittest -v tests.test_new_neuron_plugins`
- `python -m unittest -v tests.test_advanced_neuron_plugins`
- `python -m unittest -v tests.test_super_advanced_neuron_plugins`
- `python -m unittest -v tests.test_learnable_params`


------
https://chatgpt.com/codex/tasks/task_e_68b22b1af3a083278d13962cd03523ad