### PR TITLE
Add advanced synapse plugin suite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -550,6 +550,17 @@ New Additive Plugins (this change)
 - Synapse plugin `resonant`: Damped harmonic filter maintaining internal state with learnable `res_freq` and `res_damp` parameters.
 - Synapse plugin `delay`: Exponential moving average over past outputs blended by learnable `delay_alpha`.
 - Synapse plugin `spike_gate`: Logistic gate that passes values above learnable `gate_thresh` with sharpness `gate_sharp`.
+- Synapse plugin `echo_chamber`: Recursively mixes current signals with a
+  decaying memory of prior transmissions via learnable `echo_decay` and
+  `echo_depth`.
+- Synapse plugin `quantum_flip`: Flips transmission sign with learnable
+  probability `flip_prob`, mimicking stochastic quantum parity changes.
+- Synapse plugin `nonlocal_tunnel`: Injects a persistent random offset scaled
+  by learnable `tunnel_strength`, suggesting a shortcut through hidden space.
+- Synapse plugin `fractal_enhance`: Applies repeated sinusoidal boosts
+  controlled by `fract_depth` and `fract_scale` to carve fractal-like patterns.
+- Synapse plugin `phase_noise`: Adds a drifting sinusoidal perturbation whose
+  frequency and amplitude are governed by `noise_freq` and `noise_amp`.
 - Wanderer plugin `l2_weight_penalty`: Contributes an L2 penalty term over the visited neurons’ autograd parameters (weights and biases). Lambda read from `wanderer._neuro_cfg['l2_lambda']` (default `0.0`). Registered as `"l2_weight_penalty"` and composes additively with other loss plugins.
 - SelfAttention routine `adaptive_grad_clip`: Observes per-step loss via the reporter and, when a step loss spikes by a configurable ratio, sets gradient clipping on the owning `Wanderer` for the next step (`method='norm'`, configurable `max_norm`). Constructor defaults: `threshold_ratio=1.5`, `max_norm=1.0`, `cooldown=5`. Registered via `register_selfattention_type("adaptive_grad_clip", ...)`.
 - SelfAttention routine `context_noise_profiler`: Exposes learnable `noise_variance` and `spatial_factor` parameters via `expose_learnable_params`, computes a per-step noise score, and nudges learning rate to compensate for sensor artifacts. Registered as `"context_noise_profiler"`.

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -24,7 +24,7 @@ in current ML literature.
 ## Steps
 1. Enumerate existing plugin types in the repository. [complete]
 2. Implement advanced neuron plugin suite. [complete]
-3. Implement advanced synapse plugin suite.
+3. Implement advanced synapse plugin suite. [complete]
 4. Implement advanced wanderer plugin suite.
 5. Implement advanced brain_train plugin suite.
 6. Implement advanced selfattention plugin suite.

--- a/marble/plugins/synapse_echo_chamber.py
+++ b/marble/plugins/synapse_echo_chamber.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Echo chamber synapse plugin.
+
+Creates a decaying echo of past transmissions so current values are
+interwoven with memory of earlier signals. Two learnable parameters control
+the decay rate and the effective depth of the echo.
+"""
+
+from typing import Any, List
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class EchoChamberSynapsePlugin:
+    """Applies a recursive echo to transmissions."""
+
+    def __init__(self) -> None:
+        self._echo = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        echo_decay: float = 0.5,
+        echo_depth: float = 3.0,
+    ) -> Any:
+        return (echo_decay, echo_depth)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        decay, depth = 0.5, 3.0
+        if wanderer is not None:
+            decay, depth = self._params(wanderer)
+        decay_f = float(decay.detach().to("cpu").item()) if hasattr(decay, "detach") else float(decay)
+        depth_i = int(
+            float(depth.detach().to("cpu").item()) if hasattr(depth, "detach") else float(depth)
+        )
+
+        prev = self._echo.get(id(syn), 0.0)
+        vals = self._to_list(value)
+        out_vals: List[float] = []
+        for v in vals:
+            h = prev
+            for _ in range(max(1, depth_i)):
+                h = v + h * decay_f
+            prev = h
+            out_vals.append(h)
+        self._echo[id(syn)] = prev
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "echo_step",
+                {"decay": decay_f, "depth": depth_i},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["EchoChamberSynapsePlugin"]
+

--- a/marble/plugins/synapse_fractal_enhance.py
+++ b/marble/plugins/synapse_fractal_enhance.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Fractal enhance synapse plugin.
+
+Iteratively perturbs transmissions using a sinusoidal function to create a
+fractal-like cascade. Depth and scale of the perturbation are learnable,
+allowing the synapse to sculpt intricate responses.
+"""
+
+import math
+from typing import Any, List
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class FractalEnhanceSynapsePlugin:
+    """Applies repeated sinusoidal boosts to signals."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        fract_depth: float = 2.0,
+        fract_scale: float = 0.5,
+    ) -> Any:
+        return (fract_depth, fract_scale)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        depth, scale = 2.0, 0.5
+        if wanderer is not None:
+            depth, scale = self._params(wanderer)
+        depth_i = int(
+            float(depth.detach().to("cpu").item()) if hasattr(depth, "detach") else float(depth)
+        )
+        scale_f = float(scale.detach().to("cpu").item()) if hasattr(scale, "detach") else float(scale)
+
+        vals = self._to_list(value)
+        out_vals: List[float] = []
+        for v in vals:
+            x = v
+            for _ in range(max(1, depth_i)):
+                x = x + math.sin(x * scale_f)
+            out_vals.append(x)
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "fractal_enhance",
+                {"depth": depth_i, "scale": scale_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["FractalEnhanceSynapsePlugin"]
+

--- a/marble/plugins/synapse_nonlocal_tunnel.py
+++ b/marble/plugins/synapse_nonlocal_tunnel.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Nonlocal tunnel synapse plugin.
+
+Adds a persistent random offset to every transmission, modelling a
+nonlocal shortcut that shifts signals through an imagined tunnel. The
+strength of the tunnel effect is learnable.
+"""
+
+import random
+from typing import Any, List
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class NonlocalTunnelSynapsePlugin:
+    """Injects a fixed random offset into transmissions."""
+
+    def __init__(self) -> None:
+        self._offsets = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, tunnel_strength: float = 0.1) -> Any:
+        return (tunnel_strength,)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        strength = 0.1
+        if wanderer is not None:
+            (strength,) = self._params(wanderer)
+        strength_f = (
+            float(strength.detach().to("cpu").item()) if hasattr(strength, "detach") else float(strength)
+        )
+
+        off = self._offsets.setdefault(id(syn), random.uniform(-1.0, 1.0))
+        vals = self._to_list(value)
+        out_vals = [v + off * strength_f for v in vals]
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "nonlocal_shift",
+                {"strength": strength_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["NonlocalTunnelSynapsePlugin"]
+

--- a/marble/plugins/synapse_phase_noise.py
+++ b/marble/plugins/synapse_phase_noise.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+"""Phase noise synapse plugin.
+
+Superimposes a sinusoidal perturbation whose phase advances each
+transmission, akin to a drifting interference pattern. Both frequency and
+amplitude of the noise are learnable.
+"""
+
+import math
+from typing import Any, List
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class PhaseNoiseSynapsePlugin:
+    """Adds progressive phase noise to transmissions."""
+
+    def __init__(self) -> None:
+        self._phase = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        noise_freq: float = 1.0,
+        noise_amp: float = 0.1,
+    ) -> Any:
+        return (noise_freq, noise_amp)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        freq, amp = 1.0, 0.1
+        if wanderer is not None:
+            freq, amp = self._params(wanderer)
+        freq_f = float(freq.detach().to("cpu").item()) if hasattr(freq, "detach") else float(freq)
+        amp_f = float(amp.detach().to("cpu").item()) if hasattr(amp, "detach") else float(amp)
+
+        ph = self._phase.get(id(syn), 0.0)
+        vals = self._to_list(value)
+        out_vals: List[float] = []
+        for v in vals:
+            ph += freq_f
+            out_vals.append(v + math.sin(ph) * amp_f)
+        self._phase[id(syn)] = ph
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "phase_noise",
+                {"freq": freq_f, "amp": amp_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["PhaseNoiseSynapsePlugin"]
+

--- a/marble/plugins/synapse_quantum_flip.py
+++ b/marble/plugins/synapse_quantum_flip.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Quantum flip synapse plugin.
+
+Applies a sign flip to transmissions with a learnable probability. The effect
+resembles a measurement collapsing a quantum state, introducing stochastic
+parity changes along connections.
+"""
+
+import random
+from typing import Any, List
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class QuantumFlipSynapsePlugin:
+    """Randomly flips the sign of transmitted values."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, flip_prob: float = 0.5) -> Any:
+        return (flip_prob,)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        prob = 0.5
+        if wanderer is not None:
+            (prob,) = self._params(wanderer)
+        prob_f = float(prob.detach().to("cpu").item()) if hasattr(prob, "detach") else float(prob)
+
+        torch = getattr(syn, "_torch", None)
+        dev = getattr(syn, "_device", "cpu")
+        if torch is not None:
+            vt = value
+            if not (hasattr(vt, "detach") and hasattr(vt, "to")):
+                vt = torch.tensor(self._to_list(value), dtype=torch.float32, device=dev)
+            mask = torch.where(torch.rand_like(vt) < prob_f, -1.0, 1.0)
+            out = vt * mask
+        else:
+            vals = self._to_list(value)
+            out = [(-v if random.random() < prob_f else v) for v in vals]
+            if len(out) == 1:
+                out = out[0]
+
+        try:
+            report(
+                "synapse",
+                "quantum_flip",
+                {"p": prob_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["QuantumFlipSynapsePlugin"]
+

--- a/tests/test_advanced_synapse_plugins.py
+++ b/tests/test_advanced_synapse_plugins.py
@@ -1,0 +1,40 @@
+import unittest
+
+
+class AdvancedSynapsePluginSuiteTests(unittest.TestCase):
+    def _build_brain_with_plugin(self, plugin_name: str):
+        from marble.marblemain import Brain
+
+        b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.add_neuron((1.0, 0.0), tensor=[0.0], weight=1.0, bias=0.0)
+        b.connect((0.0, 0.0), (1.0, 0.0), direction="uni", type_name=plugin_name)
+        return b
+
+    def _walk_and_collect(self, brain):
+        from marble.marblemain import Wanderer
+
+        w = Wanderer(brain, seed=1)
+        start = brain.get_neuron((0.0, 0.0))
+        w.walk(max_steps=1, lr=1e-2, start=start)
+        return w
+
+    def test_advanced_synapse_plugins_register_learnables(self):
+        plugin_params = {
+            "echo_chamber": ["echo_decay", "echo_depth"],
+            "quantum_flip": ["flip_prob"],
+            "nonlocal_tunnel": ["tunnel_strength"],
+            "fractal_enhance": ["fract_depth", "fract_scale"],
+            "phase_noise": ["noise_freq", "noise_amp"],
+        }
+        for name, params in plugin_params.items():
+            brain = self._build_brain_with_plugin(name)
+            w = self._walk_and_collect(brain)
+            print("advanced synapse plugin", name, "learnables", list(w._learnables.keys()))
+            for p in params:
+                self.assertIn(p, w._learnables, f"{name} missing {p}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add five experimental synapse plugins (echo_chamber, quantum_flip, nonlocal_tunnel, fractal_enhance, phase_noise)
- document new synapse suite in architecture and mark roadmap step complete
- test plugin registration and learnable parameters

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest tests.test_synapse_plugins -v`
- `python -m unittest tests.test_advanced_synapse_plugins -v`


------
https://chatgpt.com/codex/tasks/task_e_68b22f18466c8327ab4aadce8479ac5c