### PR TITLE
feat: add advanced wanderer plugin suite

### DIFF
--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -25,7 +25,7 @@ in current ML literature.
 1. Enumerate existing plugin types in the repository. [complete]
 2. Implement advanced neuron plugin suite. [complete]
 3. Implement advanced synapse plugin suite. [complete]
-4. Implement advanced wanderer plugin suite.
+4. Implement advanced wanderer plugin suite. [complete]
 5. Implement advanced brain_train plugin suite.
 6. Implement advanced selfattention plugin suite.
 7. Implement advanced neuroplasticity plugin suite.

--- a/marble/plugins/wanderer_chaoswalk.py
+++ b/marble/plugins/wanderer_chaoswalk.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Chaotic logistic-map driven wanderer plugin."""
+
+import math
+import torch
+from typing import List, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class ChaosWalkPlugin:
+    """Selects next synapse via logistic-map chaos sequence."""
+
+    def __init__(self) -> None:
+        self._state = torch.rand(1)
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, chaos_lambda: float = 3.7):
+        return (chaos_lambda,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (lam_t,) = self._params(wanderer)
+        lam = float(lam_t.detach().to("cpu").item()) if hasattr(lam_t, "detach") else float(lam_t)
+        self._state = lam * self._state * (1 - self._state)
+        idx = int(self._state.item() * len(choices)) % len(choices)
+        return choices[idx]
+
+
+__all__ = ["ChaosWalkPlugin"]
+
+PLUGIN_NAME = "chaoswalk"
+

--- a/marble/plugins/wanderer_fractalseed.py
+++ b/marble/plugins/wanderer_fractalseed.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Fractal seed wanderer plugin."""
+
+import torch
+from typing import List, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class FractalSeedPlugin:
+    """Uses fractional components of a sequence to guide exploration."""
+
+    def __init__(self) -> None:
+        self._counter = 0
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, fractal_depth: float = 2.0):
+        return (fractal_depth,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (d_t,) = self._params(wanderer)
+        d = float(d_t.detach().to("cpu").item()) if hasattr(d_t, "detach") else float(d_t)
+        base = torch.arange(len(choices), dtype=torch.float32)
+        self._counter += 1
+        weights = torch.frac(base * d * (self._counter)) + 1e-6
+        probs = weights / weights.sum()
+        idx = int(torch.multinomial(probs, 1).item())
+        return choices[idx]
+
+
+__all__ = ["FractalSeedPlugin"]
+
+PLUGIN_NAME = "fractalseed"
+

--- a/marble/plugins/wanderer_gravitywell.py
+++ b/marble/plugins/wanderer_gravitywell.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Gravity-well biased wanderer plugin."""
+
+import torch
+from typing import List, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class GravityWellPlugin:
+    """Biases selection toward spatially central neurons."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, gravity_strength: float = 1.0):
+        return (gravity_strength,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (g_t,) = self._params(wanderer)
+        g = float(g_t.detach().to("cpu").item()) if hasattr(g_t, "detach") else float(g_t)
+        dists = []
+        for syn, direction in choices:
+            node = syn.target if direction == "forward" else syn.source
+            pos = getattr(node, "position", (0.0,))
+            tensor_pos = torch.tensor(list(pos), dtype=torch.float32)
+            dists.append(torch.norm(tensor_pos))
+        dists_t = torch.stack(dists)
+        weights = torch.exp(-g * dists_t)
+        probs = weights / weights.sum()
+        idx = int(torch.multinomial(probs, 1).item())
+        return choices[idx]
+
+
+__all__ = ["GravityWellPlugin"]
+
+PLUGIN_NAME = "gravitywell"
+

--- a/marble/plugins/wanderer_memorydecay.py
+++ b/marble/plugins/wanderer_memorydecay.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Memory decay wanderer plugin."""
+
+import math
+import torch
+from typing import Dict, List, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class MemoryDecayPlugin:
+    """Avoids recently visited nodes with exponential decay memory."""
+
+    def __init__(self) -> None:
+        self._memory: Dict[object, float] = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, memory_half_life: float = 10.0):
+        return (memory_half_life,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (hl_t,) = self._params(wanderer)
+        hl = float(hl_t.detach().to("cpu").item()) if hasattr(hl_t, "detach") else float(hl_t)
+        decay = math.log(2.0) / max(hl, 1e-6)
+        for k in list(self._memory.keys()):
+            self._memory[k] *= math.exp(-decay)
+        self._memory[current] = self._memory.get(current, 0.0) + 1.0
+        scores = []
+        for syn, direction in choices:
+            node = syn.target if direction == "forward" else syn.source
+            scores.append(self._memory.get(node, 0.0))
+        idx = int(torch.tensor(scores).argmin().item())
+        return choices[idx]
+
+
+__all__ = ["MemoryDecayPlugin"]
+
+PLUGIN_NAME = "memorydecay"
+

--- a/marble/plugins/wanderer_quantumsuper.py
+++ b/marble/plugins/wanderer_quantumsuper.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Quantum-inspired superposition wanderer plugin."""
+
+import random
+import torch
+from typing import List, Tuple
+
+from ..wanderer import expose_learnable_params
+
+
+class QuantumSuperpositionPlugin:
+    """Collapses to random choice with learnable probability."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, collapse_prob: float = 0.1):
+        return (collapse_prob,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (p_t,) = self._params(wanderer)
+        p = float(p_t.detach().to("cpu").item()) if hasattr(p_t, "detach") else float(p_t)
+        if random.random() < p:
+            return random.choice(choices)
+        weights = torch.arange(1, len(choices) + 1, dtype=torch.float32)
+        probs = weights / weights.sum()
+        idx = int(torch.multinomial(probs, 1).item())
+        return choices[idx]
+
+
+__all__ = ["QuantumSuperpositionPlugin"]
+
+PLUGIN_NAME = "quantumsuper"
+

--- a/tests/test_advanced_wanderer_plugins.py
+++ b/tests/test_advanced_wanderer_plugins.py
@@ -1,0 +1,34 @@
+import unittest
+import torch
+
+from marble.marblemain import Brain, Wanderer
+
+
+class AdvancedWandererPluginSuiteTests(unittest.TestCase):
+    def make_brain(self):
+        b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
+        return b
+
+    def test_advanced_wanderer_plugins_register_learnables(self):
+        plugins = {
+            "chaoswalk": "chaos_lambda",
+            "quantumsuper": "collapse_prob",
+            "gravitywell": "gravity_strength",
+            "memorydecay": "memory_half_life",
+            "fractalseed": "fractal_depth",
+        }
+        for name, param in plugins.items():
+            with self.subTest(name=name):
+                b = self.make_brain()
+                w = Wanderer(b, type_name=name, seed=1)
+                w.walk(max_steps=1, lr=0.0)
+                print("advanced wanderer plugin", name, "learnables", list(w._learnables.keys()))
+                self.assertIn(param, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add five experimental wanderer plugins (chaoswalk, quantumsuper, gravitywell, memorydecay, fractalseed)
- exercise and verify new wanderer plugins in dedicated unit tests
- mark wanderer plugin suite step complete in DOTHISFIRST

## Testing
- `python -m unittest -v tests.test_advanced_wanderer_plugins`
- `python -m unittest -v tests.test_new_wanderer_plugins`
- `python -m unittest -v tests.test_wanderer`


------
https://chatgpt.com/codex/tasks/task_e_68b230e530148327864a213e3d211d10