### PR TITLE
Add experimental brain train plugin suite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -54,6 +54,7 @@ Core Components
   - `after_walk` executed for all.
   - `on_end` dicts merged; later trainers win on conflicts.
   - Built-in: `curriculum` trainer increases `max_steps` across walks. Config: `start_steps` (default 1), `step_increment` (default 1), optional `max_cap`.
+  - Advanced suite: `meta_optimizer`, `entropy_gate`, `gradient_memory`, `temporal_mix`, and `sync_shift` plugins. Each exposes learnable parameters via `expose_learnable_params` to influence learning rate, walk length, loss memory, temporal pacing, or start-neuron selection.
 
   - `Wanderer`: Autograd-based traversal across the graph. At each step, computes outputs from visited neurons using their (learnable) `weight`/`bias` (via temporary autograd parameters), accumulates loss, and performs SGD-style updates. Plugin registry (`register_wanderer_type`) allows custom step choice and loss definitions. Neuroplasticity registry (`register_neuroplasticity_type`) includes a default `BaseNeuroplasticityPlugin` that can grow/prune graph edges and adjust neuron parameters based on walk outcomes.
     - `dynamicdimensions` plugin periodically adds a new dimension to the `Brain`, observes neuron growth, and removes the dimension if it doesn't improve loss.

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -26,7 +26,7 @@ in current ML literature.
 2. Implement advanced neuron plugin suite. [complete]
 3. Implement advanced synapse plugin suite. [complete]
 4. Implement advanced wanderer plugin suite. [complete]
-5. Implement advanced brain_train plugin suite.
+5. Implement advanced brain_train plugin suite. [complete]
 6. Implement advanced selfattention plugin suite.
 7. Implement advanced neuroplasticity plugin suite.
 

--- a/marble/plugins/brain_train_entropy_gate.py
+++ b/marble/plugins/brain_train_entropy_gate.py
@@ -1,0 +1,39 @@
+"""EntropyGateTrainPlugin perturbs walk length using a learnable gate.
+
+The plugin introduces a ``entropy_gate`` parameter exposed via
+``expose_learnable_params``. The parameter scales an entropy-like bonus to the
+``max_steps`` for each walk, encouraging dynamic exploration of the graph.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _entropy_param(wanderer, entropy_gate: float = 0.5):
+    return entropy_gate
+
+
+class EntropyGateTrainPlugin:
+    """Brain-train plugin that alters walk steps based on a learnable gate."""
+
+    def on_init(self, brain: "Brain", wanderer: "Wanderer", config: Dict[str, Any]) -> None:  # noqa: D401
+        report("training", "entropy_gate_init", {}, "brain")
+
+    def before_walk(self, brain: "Brain", wanderer: "Wanderer", i: int) -> Dict[str, Any]:
+        gate_t = _entropy_param(wanderer)
+        try:
+            gate = float(gate_t.detach().to("cpu").item())
+        except Exception:
+            gate = 0.0
+        bonus = int(abs(gate) * ((i % 3) + 1))
+        report("training", "entropy_gate_before", {"walk": i, "bonus": bonus}, "brain")
+        return {"max_steps": bonus + 1}
+
+
+__all__ = ["EntropyGateTrainPlugin"]
+

--- a/marble/plugins/brain_train_gradient_memory.py
+++ b/marble/plugins/brain_train_gradient_memory.py
@@ -1,0 +1,46 @@
+"""GradientMemoryTrainPlugin adapts learning rate based on loss history.
+
+The plugin exposes a ``memory_decay`` parameter controlling how quickly the
+historical loss influence fades. After each walk, the plugin updates an internal
+moving average of the losses and lowers the learning rate if the average grows.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _memory_param(wanderer, memory_decay: float = 0.9):
+    return memory_decay
+
+
+class GradientMemoryTrainPlugin:
+    """Brain-train plugin tracking an exponential loss memory."""
+
+    def __init__(self) -> None:
+        self.avg: float = 0.0
+
+    def on_init(self, brain: "Brain", wanderer: "Wanderer", config: Dict[str, Any]) -> None:  # noqa: D401
+        self.avg = 0.0
+
+    def after_walk(self, brain: "Brain", wanderer: "Wanderer", i: int, stats: Dict[str, Any]) -> None:
+        decay_t = _memory_param(wanderer)
+        try:
+            decay = float(decay_t.detach().to("cpu").item())
+        except Exception:
+            decay = 0.9
+        loss = float(stats.get("loss", 0.0))
+        self.avg = decay * self.avg + (1 - decay) * loss
+        report("training", "gradmem_after", {"walk": i, "avg": self.avg}, "brain")
+        if self.avg > loss:
+            # reduce LR slightly if losses trend upward
+            lr = max(1e-6, getattr(wanderer, "_neuro_cfg", {}).get("lr", 1e-3) * 0.9)
+            wanderer._neuro_cfg["lr"] = lr
+
+
+__all__ = ["GradientMemoryTrainPlugin"]
+

--- a/marble/plugins/brain_train_meta_optimizer.py
+++ b/marble/plugins/brain_train_meta_optimizer.py
@@ -1,0 +1,46 @@
+"""MetaOptimizerTrainPlugin adjusts learning rate via a learnable scale.
+
+The plugin exposes a single ``meta_lr`` parameter through
+``expose_learnable_params``. Before every walk, the provided learning rate is
+multiplied by this meta parameter, allowing the training loop itself to learn
+how aggressively it should update weights.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _meta_params(wanderer, meta_lr: float = 1.0):
+    """Return a learnable scaling for the base learning rate."""
+    return meta_lr
+
+
+class MetaOptimizerTrainPlugin:
+    """Brain-train plugin that learns a global LR multiplier."""
+
+    def on_init(self, brain: "Brain", wanderer: "Wanderer", config: Dict[str, Any]) -> None:  # noqa: D401
+        report("training", "meta_optimizer_init", {}, "brain")
+
+    def before_walk(self, brain: "Brain", wanderer: "Wanderer", i: int) -> Dict[str, Any]:
+        meta_lr_t = _meta_params(wanderer)
+        try:
+            scale = float(meta_lr_t.detach().to("cpu").item())
+        except Exception:
+            scale = 1.0
+        base = getattr(wanderer, "_neuro_cfg", {}).get("lr", 1e-3)
+        try:
+            base = float(base)
+        except Exception:
+            base = 1e-3
+        lr = base * scale
+        report("training", "meta_optimizer_before", {"walk": i, "lr": lr}, "brain")
+        return {"lr": float(lr)}
+
+
+__all__ = ["MetaOptimizerTrainPlugin"]
+

--- a/marble/plugins/brain_train_sync_shift.py
+++ b/marble/plugins/brain_train_sync_shift.py
@@ -1,0 +1,40 @@
+"""SyncShiftTrainPlugin offsets start neuron using a learnable phase shift.
+
+The ``phase_shift`` parameter, exposed via ``expose_learnable_params``,
+determines how many indices to rotate when choosing the starting neuron for a
+walk. This introduces a deterministic yet learnable curriculum over available
+neurons.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _phase_param(wanderer, phase_shift: float = 0.0):
+    return phase_shift
+
+
+class SyncShiftTrainPlugin:
+    """Brain-train plugin selecting start neuron via learnable phase shift."""
+
+    def choose_start(self, brain: "Brain", wanderer: "Wanderer", i: int):
+        phase_t = _phase_param(wanderer)
+        try:
+            phase = int(float(phase_t.detach().to("cpu").item()))
+        except Exception:
+            phase = 0
+        avail = list(brain.available_indices())
+        if not avail:
+            return None
+        idx = avail[(phase + i) % len(avail)]
+        report("training", "sync_shift_choose", {"walk": i, "index": idx}, "brain")
+        return brain.neurons.get(idx)
+
+
+__all__ = ["SyncShiftTrainPlugin"]
+

--- a/marble/plugins/brain_train_temporal_mix.py
+++ b/marble/plugins/brain_train_temporal_mix.py
@@ -1,0 +1,36 @@
+"""TemporalMixTrainPlugin blends walk indices into step counts.
+
+Using a learnable ``mix_ratio`` parameter, the plugin scales the current walk
+index and mixes it with a base of one step to compute ``max_steps``. This allows
+the training process itself to discover an optimal pacing across walks.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _mix_param(wanderer, mix_ratio: float = 0.5):
+    return mix_ratio
+
+
+class TemporalMixTrainPlugin:
+    """Brain-train plugin computing steps from a learnable walk mix."""
+
+    def before_walk(self, brain: "Brain", wanderer: "Wanderer", i: int) -> Dict[str, Any]:
+        mix_t = _mix_param(wanderer)
+        try:
+            mix = float(mix_t.detach().to("cpu").item())
+        except Exception:
+            mix = 0.5
+        steps = 1 + int(abs(mix) * (i + 1))
+        report("training", "temporal_mix_steps", {"walk": i, "steps": steps}, "brain")
+        return {"max_steps": steps}
+
+
+__all__ = ["TemporalMixTrainPlugin"]
+

--- a/tests/test_advanced_brain_train_plugins.py
+++ b/tests/test_advanced_brain_train_plugins.py
@@ -1,0 +1,40 @@
+import unittest
+
+
+class AdvancedBrainTrainPluginTests(unittest.TestCase):
+    def _brain_and_wanderer(self):
+        from marble.marblemain import Brain, Wanderer
+
+        b = Brain(2, size=(4, 4))
+        it = iter(b.available_indices())
+        i1 = next(it)
+        i2 = next(it)
+        n1 = b.add_neuron(i1, tensor=0.0)
+        n2 = b.add_neuron(i2, tensor=0.0)
+        b.connect(i1, i2, direction="uni")
+        w = Wanderer(b)
+        return b, w, n1
+
+    def test_plugins_register_and_expose_params(self) -> None:
+        from marble.marblemain import _BRAIN_TRAIN_TYPES
+
+        plugins = {
+            "meta_optimizer": ["meta_lr"],
+            "entropy_gate": ["entropy_gate"],
+            "gradient_memory": ["memory_decay"],
+            "temporal_mix": ["mix_ratio"],
+            "sync_shift": ["phase_shift"],
+        }
+
+        for name, params in plugins.items():
+            self.assertIn(name, _BRAIN_TRAIN_TYPES)
+            b, w, start = self._brain_and_wanderer()
+            b.train(w, num_walks=1, max_steps=1, lr=1e-3, type_name=name, start_selector=lambda brain: start)
+            print("brain_train plugin", name, "learnables", list(w._learnables.keys()))
+            for p in params:
+                self.assertIn(p, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add five highly experimental brain_train plugins with learnable parameters
- document advanced brain_train plugin suite in architecture
- cover new plugins with dedicated unit test

## Testing
- `python -m unittest -v tests.test_advanced_brain_train_plugins`
- `python -m unittest -v tests.test_curriculum_and_temp_plugins`
- `python -m unittest -v tests.test_plugin_stacking`


------
https://chatgpt.com/codex/tasks/task_e_68b23273a1a48327a2cc436c44cec49d