### PR TITLE
feat: add ultra neuron and synapse plugin suites

### DIFF
--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -35,6 +35,26 @@ in current ML literature.
 All listed test modules have been executed and their outputs analyzed for
 logical consistency.
 
+# Add ultra plugin suites
+
+## Goal
+Introduce another wave of five ultra‑experimental plugins for every existing
+plugin type. Each plugin must surface all learnable parameters through
+`expose_learnable_params` and pursue emergent behaviour far beyond current
+literature.
+
+## Steps
+1. Implement ultra neuron plugin suite. [complete]
+2. Implement ultra synapse plugin suite. [complete]
+3. Implement ultra wanderer plugin suite.
+4. Implement ultra brain_train plugin suite.
+5. Implement ultra selfattention plugin suite.
+6. Implement ultra neuroplasticity plugin suite.
+
+## Pending tests
+Run dedicated tests for each ultra plugin suite to confirm registration and
+learnable parameter exposure.
+
 # Lock-based thread safety and immutable training
 
 ## Goal

--- a/marble/plugins/entropy_burst.py
+++ b/marble/plugins/entropy_burst.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Entropy burst neuron plugin.
+
+Amplifies signals logarithmically based on magnitude and injects a bias burst
+representing spontaneous entropy fluctuations."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class EntropyBurstNeuronPlugin:
+    """Create entropy-driven activation bursts."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        burst_intensity: float = 1.0,
+        burst_bias: float = 0.0,
+    ) -> Tuple[Any, Any]:
+        return (burst_intensity, burst_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        inten, bias = 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                inten, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            out = torch.sign(x) * torch.log1p(torch.abs(x) * inten) + bias
+            try:
+                report(
+                    "neuron",
+                    "entropy_burst_forward",
+                    {
+                        "intensity": float(inten.detach().to("cpu").item())
+                        if hasattr(inten, "detach")
+                        else float(inten),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return out
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        inten_f = float(inten.detach().to("cpu").item()) if hasattr(inten, "detach") else float(inten)
+        bias_f = float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        out_vals = [math.copysign(math.log1p(abs(xv) * inten_f), xv) + bias_f for xv in x_list]
+        try:
+            report("neuron", "entropy_burst_forward", {"intensity": inten_f, "bias": bias_f}, "plugins")
+        except Exception:
+            pass
+        return out_vals if len(out_vals) != 1 else out_vals[0]
+
+
+__all__ = ["EntropyBurstNeuronPlugin"]

--- a/marble/plugins/neutrino_field.py
+++ b/marble/plugins/neutrino_field.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Neutrino field neuron plugin.
+
+Applies a hypothetical neutrino field interaction that dampens values based on
+magnitude while injecting directionality to encourage emergent pathways."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class NeutrinoFieldNeuronPlugin:
+    """Interact activations with an imaginary neutrino field."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        field_strength: float = 1.0,
+        field_decay: float = 0.1,
+    ) -> Tuple[Any, Any]:
+        return (field_strength, field_decay)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        strength, decay = 1.0, 0.1
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                strength, decay = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            sign = torch.sign(x)
+            out = sign * strength * torch.exp(-torch.abs(x) * decay)
+            try:
+                report(
+                    "neuron",
+                    "neutrino_field_forward",
+                    {
+                        "strength": float(strength.detach().to("cpu").item())
+                        if hasattr(strength, "detach")
+                        else float(strength),
+                        "decay": float(decay.detach().to("cpu").item())
+                        if hasattr(decay, "detach")
+                        else float(decay),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return out
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        strength_f = float(strength.detach().to("cpu").item()) if hasattr(strength, "detach") else float(strength)
+        decay_f = float(decay.detach().to("cpu").item()) if hasattr(decay, "detach") else float(decay)
+        out_vals = [math.copysign(strength_f * math.exp(-abs(xv) * decay_f), xv) for xv in x_list]
+        try:
+            report("neuron", "neutrino_field_forward", {"strength": strength_f, "decay": decay_f}, "plugins")
+        except Exception:
+            pass
+        return out_vals if len(out_vals) != 1 else out_vals[0]
+
+
+__all__ = ["NeutrinoFieldNeuronPlugin"]

--- a/marble/plugins/phantom_harmonics.py
+++ b/marble/plugins/phantom_harmonics.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Phantom harmonics neuron plugin.
+
+Generates imaginary harmonics that overlay the input creating ghost-like
+resonances intended to foster emergent oscillatory behaviour."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class PhantomHarmonicsNeuronPlugin:
+    """Introduce phantom harmonic interference."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        phantom_scale: float = 1.0,
+        phantom_shift: float = 0.0,
+        phantom_bias: float = 0.0,
+    ) -> Tuple[Any, Any, Any]:
+        return (phantom_scale, phantom_shift, phantom_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        scale, shift, bias = 1.0, 0.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                scale, shift, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            phantom = torch.sin(x * scale + shift) * torch.cos(x * scale - shift)
+            out = x + phantom + bias
+            try:
+                report(
+                    "neuron",
+                    "phantom_harmonics_forward",
+                    {
+                        "scale": float(scale.detach().to("cpu").item())
+                        if hasattr(scale, "detach")
+                        else float(scale),
+                        "shift": float(shift.detach().to("cpu").item())
+                        if hasattr(shift, "detach")
+                        else float(shift),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return out
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        scale_f = float(scale.detach().to("cpu").item()) if hasattr(scale, "detach") else float(scale)
+        shift_f = float(shift.detach().to("cpu").item()) if hasattr(shift, "detach") else float(shift)
+        bias_f = float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        out_vals = [xv + math.sin(xv * scale_f + shift_f) * math.cos(xv * scale_f - shift_f) + bias_f for xv in x_list]
+        try:
+            report(
+                "neuron",
+                "phantom_harmonics_forward",
+                {"scale": scale_f, "shift": shift_f, "bias": bias_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+        return out_vals if len(out_vals) != 1 else out_vals[0]
+
+
+__all__ = ["PhantomHarmonicsNeuronPlugin"]

--- a/marble/plugins/quantum_mirror.py
+++ b/marble/plugins/quantum_mirror.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""Quantum mirror neuron plugin.
+
+Reflects inputs through an imaginary quantum mirror where amplitude and phase
+interfere in a non-classical fashion. Designed to spark emergent behaviour
+through self-interference of signals."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class QuantumMirrorNeuronPlugin:
+    """Apply mirror-like quantum interference."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        mirror_coeff: float = 1.0,
+        mirror_bias: float = 0.0,
+    ) -> Tuple[Any, Any]:
+        return (mirror_coeff, mirror_bias)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        coeff, bias = 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                coeff, bias = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            out = x * torch.cos(coeff * x) - x * torch.sin(coeff * x) + bias
+            try:
+                report(
+                    "neuron",
+                    "quantum_mirror_forward",
+                    {
+                        "coeff": float(coeff.detach().to("cpu").item())
+                        if hasattr(coeff, "detach")
+                        else float(coeff),
+                        "bias": float(bias.detach().to("cpu").item())
+                        if hasattr(bias, "detach")
+                        else float(bias),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return out
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        coeff_f = float(coeff.detach().to("cpu").item()) if hasattr(coeff, "detach") else float(coeff)
+        bias_f = float(bias.detach().to("cpu").item()) if hasattr(bias, "detach") else float(bias)
+        out_vals = [xi * math.cos(coeff_f * xi) - xi * math.sin(coeff_f * xi) + bias_f for xi in x_list]
+        try:
+            report("neuron", "quantum_mirror_forward", {"coeff": coeff_f, "bias": bias_f}, "plugins")
+        except Exception:
+            pass
+        return out_vals if len(out_vals) != 1 else out_vals[0]
+
+
+__all__ = ["QuantumMirrorNeuronPlugin"]

--- a/marble/plugins/synapse_causal_loop.py
+++ b/marble/plugins/synapse_causal_loop.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Causal loop synapse plugin.
+
+Feeds part of the output back into the input as if time folded, allowing
+self-referential signal loops that might drive emergent causality."""
+
+from typing import Any, List
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class CausalLoopSynapsePlugin:
+    """Inject a causal loop into transmission."""
+
+    def __init__(self) -> None:
+        self._last = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        loop_strength: float = 0.3,
+    ):
+        return (loop_strength,)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        strength = 0.3
+        if wanderer is not None:
+            (strength,) = self._params(wanderer)
+        strength_f = float(strength.detach().to("cpu").item()) if hasattr(strength, "detach") else float(strength)
+
+        prev = self._last.get(id(syn), 0.0)
+        vals = self._to_list(value)
+        out_vals = []
+        for v in vals:
+            out = v + prev * strength_f
+            prev = out
+            out_vals.append(out)
+        self._last[id(syn)] = prev
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report("synapse", "causal_loop", {"strength": strength_f}, "plugins")
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["CausalLoopSynapsePlugin"]

--- a/marble/plugins/synapse_dimensional_rift.py
+++ b/marble/plugins/synapse_dimensional_rift.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Dimensional rift synapse plugin.
+
+Creates a temporary rift that alters transmissions depending on a learnable
+rift depth, encouraging emergent cross-dimensional behaviour."""
+
+from typing import Any, List
+import math
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class DimensionalRiftSynapsePlugin:
+    """Warp signals through an abstract dimensional rift."""
+
+    def __init__(self) -> None:
+        self._phase = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        rift_depth: float = 1.0,
+    ):
+        return (rift_depth,)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        depth = 1.0
+        if wanderer is not None:
+            (depth,) = self._params(wanderer)
+        depth_f = float(depth.detach().to("cpu").item()) if hasattr(depth, "detach") else float(depth)
+
+        phase = self._phase.get(id(syn), 0.0) + depth_f
+        self._phase[id(syn)] = phase
+        vals = self._to_list(value)
+        out_vals = [v * math.cos(phase) - v * math.sin(phase) for v in vals]
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report("synapse", "dimensional_rift", {"depth": depth_f}, "plugins")
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["DimensionalRiftSynapsePlugin"]

--- a/marble/plugins/synapse_entropy_lens.py
+++ b/marble/plugins/synapse_entropy_lens.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Entropy lens synapse plugin.
+
+Filters transmissions through an entropy-based lens that sharpens or blurs
+signals according to a learnable focus parameter."""
+
+from typing import Any, List
+import math
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class EntropyLensSynapsePlugin:
+    """Adjust transmission magnitude via entropy lensing."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        lens_focus: float = 0.5,
+    ):
+        return (lens_focus,)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        focus = 0.5
+        if wanderer is not None:
+            (focus,) = self._params(wanderer)
+        focus_f = float(focus.detach().to("cpu").item()) if hasattr(focus, "detach") else float(focus)
+
+        vals = self._to_list(value)
+        out_vals = []
+        for v in vals:
+            mag = abs(v)
+            entropy = -mag * math.log(mag + 1e-6)
+            out_vals.append(v + entropy * focus_f)
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report("synapse", "entropy_lens", {"focus": focus_f}, "plugins")
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["EntropyLensSynapsePlugin"]

--- a/marble/plugins/synapse_membrane_oscillator.py
+++ b/marble/plugins/synapse_membrane_oscillator.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Membrane oscillator synapse plugin.
+
+Simulates an oscillatory membrane between neurons whose frequency and damping
+are learnable, seeking emergent resonance patterns."""
+
+from typing import Any, List
+import math
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class MembraneOscillatorSynapsePlugin:
+    """Oscillate transmissions via a fictive membrane."""
+
+    def __init__(self) -> None:
+        self._state = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        osc_freq: float = 1.0,
+        osc_damp: float = 0.1,
+    ):
+        return (osc_freq, osc_damp)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        freq, damp = 1.0, 0.1
+        if wanderer is not None:
+            freq, damp = self._params(wanderer)
+        freq_f = float(freq.detach().to("cpu").item()) if hasattr(freq, "detach") else float(freq)
+        damp_f = float(damp.detach().to("cpu").item()) if hasattr(damp, "detach") else float(damp)
+
+        phase, amp = self._state.get(id(syn), (0.0, 0.0))
+        vals = self._to_list(value)
+        out_vals = []
+        for v in vals:
+            amp = amp * (1 - damp_f) + v
+            phase += freq_f
+            out_vals.append(amp * math.sin(phase))
+        self._state[id(syn)] = (phase, amp)
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report(
+                "synapse",
+                "membrane_oscillator",
+                {"freq": freq_f, "damp": damp_f},
+                "plugins",
+            )
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["MembraneOscillatorSynapsePlugin"]

--- a/marble/plugins/synapse_superposition_surge.py
+++ b/marble/plugins/synapse_superposition_surge.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Superposition surge synapse plugin.
+
+Combines current and previous transmissions in a superposed surge intended to
+create rich emergent signal interactions."""
+
+from typing import Any, List
+
+from ..graph import Synapse
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class SuperpositionSurgeSynapsePlugin:
+    """Fuse transmissions through superposition and surge memory."""
+
+    def __init__(self) -> None:
+        self._memory = {}
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer,
+        *,
+        surge_alpha: float = 0.5,
+        surge_beta: float = 0.1,
+    ):
+        return (surge_alpha, surge_beta)
+
+    def _to_list(self, value: Any) -> List[float]:
+        if hasattr(value, "detach") and hasattr(value, "tolist"):
+            return [float(v) for v in value.detach().to("cpu").view(-1).tolist()]
+        if isinstance(value, (list, tuple)):
+            return [float(v) for v in value]
+        return [float(value)]
+
+    def transmit(self, syn: "Synapse", value: Any, *, direction: str = "forward") -> Any:
+        wanderer = getattr(getattr(syn.source, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        if wanderer is None:
+            wanderer = getattr(getattr(syn.target, "_plugin_state", {}), "get", lambda *_: None)("wanderer")
+        alpha, beta = 0.5, 0.1
+        if wanderer is not None:
+            alpha, beta = self._params(wanderer)
+        alpha_f = float(alpha.detach().to("cpu").item()) if hasattr(alpha, "detach") else float(alpha)
+        beta_f = float(beta.detach().to("cpu").item()) if hasattr(beta, "detach") else float(beta)
+
+        prev = self._memory.get(id(syn), 0.0)
+        vals = self._to_list(value)
+        out_vals = []
+        for v in vals:
+            surge = alpha_f * v + beta_f * prev
+            prev = surge
+            out_vals.append(surge)
+        self._memory[id(syn)] = prev
+        out = out_vals if len(out_vals) != 1 else out_vals[0]
+
+        try:
+            report("synapse", "superposition_surge", {"alpha": alpha_f, "beta": beta_f}, "plugins")
+        except Exception:
+            pass
+
+        orig = syn.type_name
+        syn.type_name = None
+        try:
+            return Synapse.transmit(syn, out, direction=direction)
+        finally:
+            syn.type_name = orig
+
+
+__all__ = ["SuperpositionSurgeSynapsePlugin"]

--- a/marble/plugins/temporal_fission.py
+++ b/marble/plugins/temporal_fission.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Temporal fission neuron plugin.
+
+Splits the incoming signal into divergent temporal shards whose interplay is
+meant to provoke emergent temporal patterns."""
+
+from typing import Any, Tuple
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+class TemporalFissionNeuronPlugin:
+    """Split activations across fictive time shards."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(
+        wanderer: "Wanderer",
+        *,
+        fiss_amp: float = 1.0,
+        fiss_phase: float = 0.0,
+    ) -> Tuple[Any, Any]:
+        return (fiss_amp, fiss_phase)
+
+    def forward(self, neuron: "Neuron", input_value=None):
+        x = neuron._ensure_tensor(neuron.tensor if input_value is None else input_value)
+
+        amp, phase = 1.0, 0.0
+        wanderer = neuron._plugin_state.get("wanderer")
+        if wanderer is not None:
+            try:
+                amp, phase = self._params(wanderer)
+            except Exception:
+                pass
+
+        torch = getattr(neuron, "_torch", None)
+        if torch is not None and neuron._is_torch_tensor(x):
+            y1 = torch.sin(x + phase) * amp
+            y2 = torch.cos(x - phase) * (2 - amp)
+            out = y1 + y2
+            try:
+                report(
+                    "neuron",
+                    "temporal_fission_forward",
+                    {
+                        "amp": float(amp.detach().to("cpu").item()) if hasattr(amp, "detach") else float(amp),
+                        "phase": float(phase.detach().to("cpu").item())
+                        if hasattr(phase, "detach")
+                        else float(phase),
+                    },
+                    "plugins",
+                )
+            except Exception:
+                pass
+            return out
+
+        x_list = x if isinstance(x, list) else [float(x)]
+        amp_f = float(amp.detach().to("cpu").item()) if hasattr(amp, "detach") else float(amp)
+        phase_f = float(phase.detach().to("cpu").item()) if hasattr(phase, "detach") else float(phase)
+        out_vals = [math.sin(xv + phase_f) * amp_f + math.cos(xv - phase_f) * (2 - amp_f) for xv in x_list]
+        try:
+            report("neuron", "temporal_fission_forward", {"amp": amp_f, "phase": phase_f}, "plugins")
+        except Exception:
+            pass
+        return out_vals if len(out_vals) != 1 else out_vals[0]
+
+
+__all__ = ["TemporalFissionNeuronPlugin"]

--- a/tests/test_ultra_neuron_plugins.py
+++ b/tests/test_ultra_neuron_plugins.py
@@ -1,0 +1,30 @@
+import unittest
+
+
+class UltraNeuronPluginTests(unittest.TestCase):
+    def test_plugins_register_and_expose_params(self) -> None:
+        from marble.marblemain import Brain, Wanderer, _NEURON_TYPES
+
+        plugins = {
+            "quantum_mirror": ["mirror_coeff", "mirror_bias"],
+            "temporal_fission": ["fiss_amp", "fiss_phase"],
+            "phantom_harmonics": ["phantom_scale", "phantom_shift", "phantom_bias"],
+            "neutrino_field": ["field_strength", "field_decay"],
+            "entropy_burst": ["burst_intensity", "burst_bias"],
+        }
+
+        for name, params in plugins.items():
+            self.assertIn(name, _NEURON_TYPES)
+            brain = Brain(1, size=1)
+            w = Wanderer(brain)
+            n = brain.add_neuron(brain.available_indices()[0], tensor=[0.0], type_name=name)
+            n._plugin_state["wanderer"] = w
+            plug = _NEURON_TYPES[name]
+            plug.forward(n, input_value=[0.0])
+            print("ultra neuron plugin", name, "learnables", list(w._learnables.keys()))
+            for p in params:
+                self.assertIn(p, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_ultra_synapse_plugins.py
+++ b/tests/test_ultra_synapse_plugins.py
@@ -1,0 +1,39 @@
+import unittest
+
+
+class UltraSynapsePluginTests(unittest.TestCase):
+    def _build_brain_with_plugin(self, plugin_name: str):
+        from marble.marblemain import Brain
+
+        b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.add_neuron((1.0, 0.0), tensor=[0.0], weight=1.0, bias=0.0)
+        b.connect((0.0, 0.0), (1.0, 0.0), direction="uni", type_name=plugin_name)
+        return b
+
+    def _walk_and_collect(self, brain):
+        from marble.marblemain import Wanderer
+
+        w = Wanderer(brain, seed=1)
+        start = brain.get_neuron((0.0, 0.0))
+        w.walk(max_steps=1, lr=1e-2, start=start)
+        return w
+
+    def test_plugins_register_and_expose_params(self):
+        plugin_params = {
+            "superposition_surge": ["surge_alpha", "surge_beta"],
+            "entropy_lens": ["lens_focus"],
+            "dimensional_rift": ["rift_depth"],
+            "causal_loop": ["loop_strength"],
+            "membrane_oscillator": ["osc_freq", "osc_damp"],
+        }
+        for name, params in plugin_params.items():
+            brain = self._build_brain_with_plugin(name)
+            w = self._walk_and_collect(brain)
+            print("ultra synapse plugin", name, "learnables", list(w._learnables.keys()))
+            for p in params:
+                self.assertIn(p, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- introduce five ultra neuron plugins (quantum_mirror, temporal_fission, phantom_harmonics, neutrino_field, entropy_burst) using `expose_learnable_params`
- add five ultra synapse plugins (superposition_surge, entropy_lens, dimensional_rift, causal_loop, membrane_oscillator)
- cover new plugins with dedicated tests and update DOTHISFIRST for future plugin suites

## Testing
- `python -m unittest tests.test_ultra_neuron_plugins -v`
- `python -m unittest tests.test_ultra_synapse_plugins -v`


------
https://chatgpt.com/codex/tasks/task_e_68b2367663108327a9339b36d21cc190