### PR TITLE
Add ultra wanderer plugin suite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -578,6 +578,7 @@ New Additive Plugins (this change)
 - Wanderer plugin `momentum`: Maintains an exponential moving average of previous weights via a learnable coefficient and biases selection by this momentum term.
 - Wanderer plugin `temporaldecay`: Starts with high exploration that exponentially decays over steps according to a learnable rate, transitioning from exploration to exploitation.
 - Wanderer plugin `entropyaware`: Computes the entropy of available synapse weights and forces random exploration while entropy remains below a learnable threshold.
+- Ultra wanderer plugins `dimensionalshift`, `timewarp`, `echochaser`, `shadowclone` and `curvaturedrive`: each exposes a unique learnable parameter to bias navigation toward high-dimensional neurons, repeat prior steps, reinforce frequently used paths, flip traversal direction, or smooth curvature of walks.
 
 All additions remain fully additive; existing behavior and APIs are preserved. Each plugin/routine logs concise events to `REPORTER` under logical groups (`plugins`, `selfattention`, `training/brain`).
 

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -46,7 +46,7 @@ literature.
 ## Steps
 1. Implement ultra neuron plugin suite. [complete]
 2. Implement ultra synapse plugin suite. [complete]
-3. Implement ultra wanderer plugin suite.
+3. Implement ultra wanderer plugin suite. [complete]
 4. Implement ultra brain_train plugin suite.
 5. Implement ultra selfattention plugin suite.
 6. Implement ultra neuroplasticity plugin suite.

--- a/marble/plugins/wanderer_curvaturedrive.py
+++ b/marble/plugins/wanderer_curvaturedrive.py
@@ -1,0 +1,55 @@
+"""Curvature-driven wanderer plugin."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import random
+
+from ..reporter import report
+from ..wanderer import expose_learnable_params
+
+
+class CurvatureDrivePlugin:
+    """Encourage smooth paths based on recent movement curvature."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, curve_factor: float = 1.0):
+        return (curve_factor,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        visited = getattr(wanderer, "_visited", [])
+        (factor_t,) = self._params(wanderer)
+        torch = getattr(wanderer, "_torch", None)
+        device = getattr(wanderer, "_device", "cpu")
+        if torch is not None and len(visited) >= 2:
+            prev = visited[-1]
+            prev2 = visited[-2]
+            pv = torch.tensor(
+                [float(a) - float(b) for a, b in zip(getattr(prev, "position", (0,)), getattr(prev2, "position", (0,)))],
+                dtype=torch.float32,
+                device=device,
+            )
+            scores = []
+            for syn, direction in choices:
+                target = syn.target if direction == "forward" else syn.source
+                tv = torch.tensor(
+                    [float(a) - float(b) for a, b in zip(getattr(target, "position", (0,)), getattr(prev, "position", (0,)))],
+                    dtype=torch.float32,
+                    device=device,
+                )
+                sc = -torch.norm(pv - tv) * factor_t
+                scores.append(sc)
+            weights = torch.softmax(torch.stack(scores), dim=0)
+            idx = int(torch.multinomial(weights, 1).item())
+        else:
+            idx = random.randrange(len(choices))
+        report("wanderer", "curvature_drive", {"choice": idx}, "plugins")
+        return choices[idx]
+
+
+__all__ = ["CurvatureDrivePlugin"]
+

--- a/marble/plugins/wanderer_dimensionalshift.py
+++ b/marble/plugins/wanderer_dimensionalshift.py
@@ -1,0 +1,57 @@
+"""Wanderer plugin that prefers higher-dimensional targets."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import math
+import random
+
+from ..reporter import report
+from ..wanderer import expose_learnable_params
+
+
+class DimensionalShiftPlugin:
+    """Bias selection toward synapses whose target has many coordinates.
+
+    A single learnable bias term influences the softmax weighting so the
+    wanderer can learn whether to favour or avoid high-dimensional regions.
+    """
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, shift_bias: float = 0.0):
+        return (shift_bias,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (bias_t,) = self._params(wanderer)
+        torch = getattr(wanderer, "_torch", None)
+        device = getattr(wanderer, "_device", "cpu")
+        dims: List[float] = []
+        for syn, direction in choices:
+            target = syn.target if direction == "forward" else syn.source
+            pos = getattr(target, "position", ()) or ()
+            dims.append(float(len(pos)))
+        if torch is not None:
+            t_dims = torch.tensor(dims, dtype=torch.float32, device=device)
+            weights = torch.softmax(t_dims + bias_t, dim=0)
+            idx = int(torch.multinomial(weights, 1).item())
+        else:
+            exps = [math.exp(d + float(bias_t)) for d in dims]
+            total = sum(exps)
+            r = random.random() * total
+            upto = 0.0
+            idx = 0
+            for i, e in enumerate(exps):
+                upto += e
+                if upto >= r:
+                    idx = i
+                    break
+        report("wanderer", "dimensional_shift", {"choice": idx}, "plugins")
+        return choices[idx]
+
+
+__all__ = ["DimensionalShiftPlugin"]
+

--- a/marble/plugins/wanderer_echochaser.py
+++ b/marble/plugins/wanderer_echochaser.py
@@ -1,0 +1,56 @@
+"""Wanderer plugin that chases echoes of prior choices."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import math
+import random
+
+from ..reporter import report
+from ..wanderer import expose_learnable_params
+
+
+class EchoChaserPlugin:
+    """Reinforces frequently chosen synapses with an exponential gain."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, echo_gain: float = 1.0):
+        return (echo_gain,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        state = wanderer._plugin_state.setdefault("echo_counts", {})
+        (gain_t,) = self._params(wanderer)
+        torch = getattr(wanderer, "_torch", None)
+        device = getattr(wanderer, "_device", "cpu")
+        if torch is not None:
+            counts = torch.tensor(
+                [state.get(id(c[0]), 0) for c in choices],
+                dtype=torch.float32,
+                device=device,
+            )
+            weights = torch.exp(counts * gain_t)
+            probs = weights / torch.sum(weights)
+            idx = int(torch.multinomial(probs, 1).item())
+        else:
+            weights = [math.exp(state.get(id(c[0]), 0) * float(gain_t)) for c in choices]
+            total = sum(weights)
+            r = random.random() * total
+            upto = 0.0
+            idx = 0
+            for i, w in enumerate(weights):
+                upto += w
+                if upto >= r:
+                    idx = i
+                    break
+        syn, direction = choices[idx]
+        state[id(syn)] = state.get(id(syn), 0) + 1
+        report("wanderer", "echo_chaser", {"choice": idx}, "plugins")
+        return syn, direction
+
+
+__all__ = ["EchoChaserPlugin"]
+

--- a/marble/plugins/wanderer_shadowclone.py
+++ b/marble/plugins/wanderer_shadowclone.py
@@ -1,0 +1,40 @@
+"""Shadow clone wanderer plugin."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import math
+import random
+
+from ..reporter import report
+from ..wanderer import expose_learnable_params
+
+
+class ShadowClonePlugin:
+    """Randomly flip direction creating a 'shadow' path."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, clone_bias: float = 0.0):
+        return (clone_bias,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (bias_t,) = self._params(wanderer)
+        torch = getattr(wanderer, "_torch", None)
+        if torch is not None:
+            prob = float(torch.sigmoid(bias_t).detach().to("cpu").item())
+        else:
+            prob = 1.0 / (1.0 + math.exp(-float(bias_t)))
+        idx = random.randrange(len(choices))
+        syn, direction = choices[idx]
+        if random.random() < prob:
+            direction = "backward" if direction == "forward" else "forward"
+        report("wanderer", "shadow_clone", {"choice": idx, "dir": direction}, "plugins")
+        return syn, direction
+
+
+__all__ = ["ShadowClonePlugin"]
+

--- a/marble/plugins/wanderer_timewarp.py
+++ b/marble/plugins/wanderer_timewarp.py
@@ -1,0 +1,42 @@
+"""Temporal distortion wanderer plugin."""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import math
+import random
+
+from ..reporter import report
+from ..wanderer import expose_learnable_params
+
+
+class TimeWarpPlugin:
+    """Occasionally repeat the previous choice based on a learnable strength."""
+
+    @staticmethod
+    @expose_learnable_params
+    def _params(wanderer, *, warp_strength: float = 0.0):
+        return (warp_strength,)
+
+    def choose_next(self, wanderer, current, choices: List[Tuple["Synapse", str]]):
+        if not choices:
+            return None, "forward"
+        (strength_t,) = self._params(wanderer)
+        torch = getattr(wanderer, "_torch", None)
+        if torch is not None:
+            prob = float(torch.sigmoid(strength_t).detach().to("cpu").item())
+        else:
+            prob = 1.0 / (1.0 + math.exp(-float(strength_t)))
+        prev = wanderer._plugin_state.get("timewarp_prev") if hasattr(wanderer, "_plugin_state") else None
+        if prev is not None and prev < len(choices) and random.random() < prob:
+            idx = int(prev)
+        else:
+            idx = random.randrange(len(choices))
+        wanderer._plugin_state["timewarp_prev"] = idx
+        report("wanderer", "timewarp", {"choice": idx}, "plugins")
+        return choices[idx]
+
+
+__all__ = ["TimeWarpPlugin"]
+

--- a/tests/test_ultra_wanderer_plugins.py
+++ b/tests/test_ultra_wanderer_plugins.py
@@ -1,0 +1,33 @@
+import unittest
+
+from marble.marblemain import Brain, Wanderer
+
+
+class UltraWandererPluginSuiteTests(unittest.TestCase):
+    def make_brain(self):
+        b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
+        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
+        return b
+
+    def test_ultra_wanderer_plugins_register_learnables(self):
+        plugins = {
+            "dimensionalshift": "shift_bias",
+            "timewarp": "warp_strength",
+            "echochaser": "echo_gain",
+            "shadowclone": "clone_bias",
+            "curvaturedrive": "curve_factor",
+        }
+        for name, param in plugins.items():
+            with self.subTest(name=name):
+                b = self.make_brain()
+                w = Wanderer(b, type_name=name, seed=1)
+                w.walk(max_steps=1, lr=0.0)
+                print("ultra wanderer plugin", name, "learnables", list(w._learnables.keys()))
+                self.assertIn(param, w._learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add five ultra experimental Wanderer plugins exposing novel learnable parameters
- document ultra wanderer suite in architecture and mark plan step complete
- add tests ensuring new plugins register and surface learnables

## Testing
- `python -m unittest -v tests.test_ultra_wanderer_plugins`


------
https://chatgpt.com/codex/tasks/task_e_68b270602f8c83278645360483252d98