### PR TITLE
Add ultra plugin suites for brain training, self-attention, and neuroplasticity

### DIFF
--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -47,11 +47,11 @@ literature.
 1. Implement ultra neuron plugin suite. [complete]
 2. Implement ultra synapse plugin suite. [complete]
 3. Implement ultra wanderer plugin suite. [complete]
-4. Implement ultra brain_train plugin suite.
-5. Implement ultra selfattention plugin suite.
-6. Implement ultra neuroplasticity plugin suite.
+4. Implement ultra brain_train plugin suite. [complete]
+5. Implement ultra selfattention plugin suite. [complete]
+6. Implement ultra neuroplasticity plugin suite. [complete]
 
-## Pending tests
+## Pending tests [complete]
 Run dedicated tests for each ultra plugin suite to confirm registration and
 learnable parameter exposure.
 

--- a/marble/plugins/brain_train_echo_repeater.py
+++ b/marble/plugins/brain_train_echo_repeater.py
@@ -1,0 +1,39 @@
+"""EchoRepeaterTrainPlugin reuses a learnable index to start each walk.
+
+The ``echo_strength`` parameter determines which neuron to revisit at the
+beginning of every walk, creating a resonant training pattern that may reveal
+subtle basin geometries.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _echo_param(wanderer, echo_strength: float = 0.0):
+    return echo_strength
+
+
+class EchoRepeaterTrainPlugin:
+    """Brain-train plugin reusing a learnable start index."""
+
+    def choose_start(self, brain: "Brain", wanderer: "Wanderer", i: int):
+        echo_t = _echo_param(wanderer)
+        try:
+            echo = int(float(echo_t.detach().to("cpu").item()))
+        except Exception:
+            echo = 0
+        avail = list(brain.available_indices())
+        if not avail:
+            return None
+        idx = avail[echo % len(avail)]
+        report("training", "echo_repeater", {"walk": i, "index": idx}, "brain")
+        return brain.neurons.get(idx)
+
+
+__all__ = ["EchoRepeaterTrainPlugin"]
+

--- a/marble/plugins/brain_train_fractal_steps.py
+++ b/marble/plugins/brain_train_fractal_steps.py
@@ -1,0 +1,36 @@
+"""FractalStepsTrainPlugin derives step counts from a learnable fractal dim.
+
+By exposing ``fractal_dim`` the plugin lets training walks expand or contract
+their length according to a pseudo-fractal scaling, probing erratic pacing
+schemes that classical curricula ignore.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _fract_param(wanderer, fractal_dim: float = 1.0):
+    return fractal_dim
+
+
+class FractalStepsTrainPlugin:
+    """Brain-train plugin computing steps from a learnable fractal dimension."""
+
+    def before_walk(self, brain: "Brain", wanderer: "Wanderer", i: int) -> Dict[str, Any]:
+        fract_t = _fract_param(wanderer)
+        try:
+            fract = float(fract_t.detach().to("cpu").item())
+        except Exception:
+            fract = 1.0
+        steps = int(abs(fract) * (i + 1)) + 1
+        report("training", "fractal_steps", {"walk": i, "steps": steps}, "brain")
+        return {"max_steps": steps}
+
+
+__all__ = ["FractalStepsTrainPlugin"]
+

--- a/marble/plugins/brain_train_gravity_anchor.py
+++ b/marble/plugins/brain_train_gravity_anchor.py
@@ -1,0 +1,37 @@
+"""GravityAnchorTrainPlugin shortens walks with a learnable gravity bias.
+
+The ``gravity_bias`` parameter pulls walk lengths toward a base by inverting
+their magnitude, simulating a gravity well that resists exploration and could
+stabilise chaotic optimisation dynamics.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _gravity_param(wanderer, gravity_bias: float = 0.0):
+    return gravity_bias
+
+
+class GravityAnchorTrainPlugin:
+    """Brain-train plugin adjusting steps via a gravity-like bias."""
+
+    def before_walk(self, brain: "Brain", wanderer: "Wanderer", i: int) -> Dict[str, Any]:
+        g_t = _gravity_param(wanderer)
+        try:
+            g = float(g_t.detach().to("cpu").item())
+        except Exception:
+            g = 0.0
+        scale = 1.0 / (1.0 + abs(g))
+        steps = max(1, int(scale * (i + 1)))
+        report("training", "gravity_anchor", {"walk": i, "steps": steps}, "brain")
+        return {"max_steps": steps}
+
+
+__all__ = ["GravityAnchorTrainPlugin"]
+

--- a/marble/plugins/brain_train_quantum_jitter.py
+++ b/marble/plugins/brain_train_quantum_jitter.py
@@ -1,0 +1,38 @@
+"""QuantumJitterTrainPlugin jitters learning rate with a learnable factor.
+
+The ``jitter_factor`` parameter, surfaced via ``expose_learnable_params``,
+scales the incoming learning rate each walk, allowing the training process to
+explore oscillating schedules far outside conventional optimisation
+strategies.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _jitter_param(wanderer, jitter_factor: float = 0.0):
+    return jitter_factor
+
+
+class QuantumJitterTrainPlugin:
+    """Brain-train plugin applying a learnable jitter to the learning rate."""
+
+    def before_walk(self, brain: "Brain", wanderer: "Wanderer", i: int) -> Dict[str, Any]:
+        jit_t = _jitter_param(wanderer)
+        try:
+            jit = float(jit_t.detach().to("cpu").item())
+        except Exception:
+            jit = 0.0
+        base_lr = float(getattr(wanderer, "lr", 0.0))
+        lr = base_lr * (1.0 + jit)
+        report("training", "quantum_jitter", {"walk": i, "lr": lr}, "brain")
+        return {"lr": lr}
+
+
+__all__ = ["QuantumJitterTrainPlugin"]
+

--- a/marble/plugins/brain_train_time_reverse.py
+++ b/marble/plugins/brain_train_time_reverse.py
@@ -1,0 +1,39 @@
+"""TimeReverseTrainPlugin starts walks from the tail with a learnable bias.
+
+Using ``reverse_bias`` the plugin selects neurons counting backward from the
+end of available indices, effectively reversing temporal order and promoting
+retrograde exploration.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _reverse_param(wanderer, reverse_bias: float = 0.0):
+    return reverse_bias
+
+
+class TimeReverseTrainPlugin:
+    """Brain-train plugin that selects start neurons from the end."""
+
+    def choose_start(self, brain: "Brain", wanderer: "Wanderer", i: int):
+        rev_t = _reverse_param(wanderer)
+        try:
+            rb = int(float(rev_t.detach().to("cpu").item()))
+        except Exception:
+            rb = 0
+        avail = list(brain.available_indices())
+        if not avail:
+            return None
+        idx = avail[-1 - (rb % len(avail))]
+        report("training", "time_reverse", {"walk": i, "index": idx}, "brain")
+        return brain.neurons.get(idx)
+
+
+__all__ = ["TimeReverseTrainPlugin"]
+

--- a/marble/plugins/neuroplasticity_bias_pulse.py
+++ b/marble/plugins/neuroplasticity_bias_pulse.py
@@ -1,0 +1,40 @@
+"""BiasPulsePlugin injects a learnable pulse into neuron bias values."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _pulse_param(wanderer, pulse_intensity: float = 0.1):
+    return pulse_intensity
+
+
+class BiasPulsePlugin:
+    """Add a learnable pulse to neuron bias on each traversal."""
+
+    def on_step(self, wanderer: "Wanderer", current: "Neuron", syn: "Synapse", direction: str, step_index: int, out_value: Any) -> None:
+        p_t = _pulse_param(wanderer)
+        try:
+            pulse = float(p_t.detach().to("cpu").item())
+        except Exception:
+            pulse = 0.0
+        try:
+            if hasattr(current, "bias"):
+                base = getattr(current, "bias", 0.0)
+                if hasattr(base, "detach"):
+                    base = float(base.detach().to("cpu").item())
+                else:
+                    base = float(base)
+                current.bias = base + pulse
+            report("neuroplasticity", "bias_pulse", {"step": int(step_index), "pulse": pulse}, "plugins")
+        except Exception:
+            pass
+        return None
+
+
+__all__ = ["BiasPulsePlugin"]
+

--- a/marble/plugins/neuroplasticity_signal_echo.py
+++ b/marble/plugins/neuroplasticity_signal_echo.py
@@ -1,0 +1,46 @@
+"""SignalEchoPlugin feeds back a fraction of the last output via a learnable strength."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _echo_param(wanderer, echo_strength: float = 0.1):
+    return echo_strength
+
+
+class SignalEchoPlugin:
+    """Add a decaying echo of previous output to the current synapse weight."""
+
+    def __init__(self) -> None:
+        self._last = 0.0
+
+    def on_step(self, wanderer: "Wanderer", current: "Neuron", syn: "Synapse", direction: str, step_index: int, out_value: Any) -> None:
+        es_t = _echo_param(wanderer)
+        try:
+            es = float(es_t.detach().to("cpu").item())
+        except Exception:
+            es = 0.0
+        try:
+            syn.weight = float(getattr(syn, "weight", 0.0)) + self._last * es
+            report("neuroplasticity", "signal_echo", {"step": int(step_index), "echo": es}, "plugins")
+        except Exception:
+            pass
+        try:
+            val = out_value
+            if hasattr(val, "detach"):
+                val = float(val.detach().to("cpu").item())
+            else:
+                val = float(val)
+            self._last = val
+        except Exception:
+            self._last = 0.0
+        return None
+
+
+__all__ = ["SignalEchoPlugin"]
+

--- a/marble/plugins/neuroplasticity_synapse_bounce.py
+++ b/marble/plugins/neuroplasticity_synapse_bounce.py
@@ -1,0 +1,35 @@
+"""SynapseBouncePlugin flips weight sign with a learnable bounce scale."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _bounce_param(wanderer, bounce_scale: float = 1.0):
+    return bounce_scale
+
+
+class SynapseBouncePlugin:
+    """Invert synapse weight sign based on a bounce coefficient."""
+
+    def on_step(self, wanderer: "Wanderer", current: "Neuron", syn: "Synapse", direction: str, step_index: int, out_value: Any) -> None:
+        bs_t = _bounce_param(wanderer)
+        try:
+            bs = float(bs_t.detach().to("cpu").item())
+        except Exception:
+            bs = 1.0
+        try:
+            if bs > 0.5:
+                syn.weight = -float(getattr(syn, "weight", 0.0))
+            report("neuroplasticity", "synapse_bounce", {"step": int(step_index), "scale": bs}, "plugins")
+        except Exception:
+            pass
+        return None
+
+
+__all__ = ["SynapseBouncePlugin"]
+

--- a/marble/plugins/neuroplasticity_threshold_fader.py
+++ b/marble/plugins/neuroplasticity_threshold_fader.py
@@ -1,0 +1,34 @@
+"""ThresholdFaderPlugin attenuates synapse weights with a learnable rate."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _fade_param(wanderer, fade_rate: float = 0.05):
+    return fade_rate
+
+
+class ThresholdFaderPlugin:
+    """Fade synapse weights using an exponential decay."""
+
+    def on_step(self, wanderer: "Wanderer", current: "Neuron", syn: "Synapse", direction: str, step_index: int, out_value: Any) -> None:
+        fr_t = _fade_param(wanderer)
+        try:
+            fr = float(fr_t.detach().to("cpu").item())
+        except Exception:
+            fr = 0.0
+        try:
+            syn.weight = float(getattr(syn, "weight", 1.0)) * (1.0 - fr)
+            report("neuroplasticity", "threshold_fade", {"step": int(step_index), "fade": fr}, "plugins")
+        except Exception:
+            pass
+        return None
+
+
+__all__ = ["ThresholdFaderPlugin"]
+

--- a/marble/plugins/neuroplasticity_weight_shifter.py
+++ b/marble/plugins/neuroplasticity_weight_shifter.py
@@ -1,0 +1,34 @@
+"""WeightShifterPlugin adds a learnable shift to traversed synapse weights."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _shift_param(wanderer, shift_amount: float = 0.0):
+    return shift_amount
+
+
+class WeightShifterPlugin:
+    """Shift synapse weights by a learnable amount on each step."""
+
+    def on_step(self, wanderer: "Wanderer", current: "Neuron", syn: "Synapse", direction: str, step_index: int, out_value: Any) -> None:
+        sh_t = _shift_param(wanderer)
+        try:
+            sh = float(sh_t.detach().to("cpu").item())
+        except Exception:
+            sh = 0.0
+        try:
+            syn.weight = float(getattr(syn, "weight", 0.0)) + sh
+            report("neuroplasticity", "weight_shift", {"step": int(step_index), "shift": sh}, "plugins")
+        except Exception:
+            pass
+        return None
+
+
+__all__ = ["WeightShifterPlugin"]
+

--- a/marble/plugins/selfattention_phase_shift.py
+++ b/marble/plugins/selfattention_phase_shift.py
@@ -1,0 +1,34 @@
+"""PhaseShiftRoutine tweaks attention temperature via a learnable phase shift."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _phase_param(wanderer, phase_shift: float = 0.0):
+    return phase_shift
+
+
+class PhaseShiftRoutine:
+    """Adjust temperature using a learnable phase shift."""
+
+    def after_step(self, selfattention: "SelfAttention", reporter_ro: Any, wanderer: "Wanderer", step_index: int, ctx: Dict[str, Any]):
+        ph_t = _phase_param(wanderer)
+        try:
+            ph = float(ph_t.detach().to("cpu").item())
+        except Exception:
+            ph = 0.0
+        try:
+            selfattention.set_param("temperature", 1.0 + ph)
+        except Exception:
+            pass
+        report("selfattention", "phase_shift", {"step": step_index, "phase": ph}, "events")
+        return None
+
+
+__all__ = ["PhaseShiftRoutine"]
+

--- a/marble/plugins/selfattention_residue_norm.py
+++ b/marble/plugins/selfattention_residue_norm.py
@@ -1,0 +1,35 @@
+"""ResidueNormRoutine nudges temperature toward a bias with learnable residue."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _residue_param(wanderer, residue_bias: float = 0.0):
+    return residue_bias
+
+
+class ResidueNormRoutine:
+    """Slowly push temperature to a learnable residue bias."""
+
+    def after_step(self, selfattention: "SelfAttention", reporter_ro: Any, wanderer: "Wanderer", step_index: int, ctx: Dict[str, Any]):
+        rb_t = _residue_param(wanderer)
+        try:
+            rb = float(rb_t.detach().to("cpu").item())
+        except Exception:
+            rb = 0.0
+        try:
+            cur = float(selfattention.get_param("temperature", 1.0))
+            selfattention.set_param("temperature", cur + rb)
+        except Exception:
+            pass
+        report("selfattention", "residue_norm", {"step": step_index, "bias": rb}, "events")
+        return None
+
+
+__all__ = ["ResidueNormRoutine"]
+

--- a/marble/plugins/selfattention_signal_booster.py
+++ b/marble/plugins/selfattention_signal_booster.py
@@ -1,0 +1,35 @@
+"""SignalBoosterRoutine amplifies temperature with a learnable gain."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _boost_param(wanderer, boost_gain: float = 1.0):
+    return boost_gain
+
+
+class SignalBoosterRoutine:
+    """Boost attention temperature using a gain parameter."""
+
+    def after_step(self, selfattention: "SelfAttention", reporter_ro: Any, wanderer: "Wanderer", step_index: int, ctx: Dict[str, Any]):
+        bg_t = _boost_param(wanderer)
+        try:
+            gain = float(bg_t.detach().to("cpu").item())
+        except Exception:
+            gain = 1.0
+        try:
+            base = float(selfattention.get_param("temperature", 1.0))
+            selfattention.set_param("temperature", base * gain)
+        except Exception:
+            pass
+        report("selfattention", "signal_booster", {"step": step_index, "gain": gain}, "events")
+        return None
+
+
+__all__ = ["SignalBoosterRoutine"]
+

--- a/marble/plugins/selfattention_temporal_echo.py
+++ b/marble/plugins/selfattention_temporal_echo.py
@@ -1,0 +1,35 @@
+"""TemporalEchoRoutine injects decaying echo into attention temperature."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _echo_param(wanderer, echo_decay: float = 0.5):
+    return echo_decay
+
+
+class TemporalEchoRoutine:
+    """Apply a decaying echo to temperature each step."""
+
+    def after_step(self, selfattention: "SelfAttention", reporter_ro: Any, wanderer: "Wanderer", step_index: int, ctx: Dict[str, Any]):
+        ed_t = _echo_param(wanderer)
+        try:
+            ed = float(ed_t.detach().to("cpu").item())
+        except Exception:
+            ed = 0.5
+        try:
+            base = float(selfattention.get_param("temperature", 1.0))
+            selfattention.set_param("temperature", base * (1.0 - abs(ed)))
+        except Exception:
+            pass
+        report("selfattention", "temporal_echo", {"step": step_index, "decay": ed}, "events")
+        return None
+
+
+__all__ = ["TemporalEchoRoutine"]
+

--- a/marble/plugins/selfattention_tunnel_vision.py
+++ b/marble/plugins/selfattention_tunnel_vision.py
@@ -1,0 +1,35 @@
+"""TunnelVisionRoutine narrows temperature based on a focus parameter."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _focus_param(wanderer, tunnel_focus: float = 1.0):
+    return tunnel_focus
+
+
+class TunnelVisionRoutine:
+    """Reduce temperature using a learnable focus strength."""
+
+    def after_step(self, selfattention: "SelfAttention", reporter_ro: Any, wanderer: "Wanderer", step_index: int, ctx: Dict[str, Any]):
+        tf_t = _focus_param(wanderer)
+        try:
+            tf = float(tf_t.detach().to("cpu").item())
+        except Exception:
+            tf = 1.0
+        try:
+            base = float(selfattention.get_param("temperature", 1.0))
+            selfattention.set_param("temperature", base / (1.0 + abs(tf)))
+        except Exception:
+            pass
+        report("selfattention", "tunnel_vision", {"step": step_index, "focus": tf}, "events")
+        return None
+
+
+__all__ = ["TunnelVisionRoutine"]
+

--- a/tests/test_ultra_brain_train_plugins.py
+++ b/tests/test_ultra_brain_train_plugins.py
@@ -1,0 +1,42 @@
+import unittest
+
+
+class UltraBrainTrainPluginTests(unittest.TestCase):
+    def _brain_and_wanderer(self):
+        from marble.marblemain import Brain, Wanderer
+
+        b = Brain(2, size=(4, 4))
+        it = iter(b.available_indices())
+        i1 = next(it)
+        i2 = next(it)
+        b.add_neuron(i1, tensor=0.0)
+        b.add_neuron(i2, tensor=0.0)
+        b.connect(i1, i2, direction="uni")
+        w = Wanderer(b)
+        return b, w, b.neurons.get(i1)
+
+    def test_ultra_brain_train_plugins_register_learnables(self) -> None:
+        from marble.marblemain import _BRAIN_TRAIN_TYPES
+
+        plugins = {
+            "quantum_jitter": ["jitter_factor"],
+            "fractal_steps": ["fractal_dim"],
+            "echo_repeater": ["echo_strength"],
+            "gravity_anchor": ["gravity_bias"],
+            "time_reverse": ["reverse_bias"],
+        }
+
+        for name, params in plugins.items():
+            with self.subTest(name=name):
+                self.assertIn(name, _BRAIN_TRAIN_TYPES)
+                b, w, start = self._brain_and_wanderer()
+                b.train(w, num_walks=1, max_steps=1, lr=1e-3, type_name=name, start_selector=lambda brain: start)
+                learnables = getattr(w, "_learnables", {})
+                print("ultra brain_train plugin", name, "learnables", list(learnables.keys()))
+                for p in params:
+                    self.assertIn(p, learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()
+

--- a/tests/test_ultra_neuroplasticity_plugins.py
+++ b/tests/test_ultra_neuroplasticity_plugins.py
@@ -1,0 +1,38 @@
+import unittest
+
+
+class UltraNeuroplasticityPluginSuiteTests(unittest.TestCase):
+    def make_brain(self):
+        from marble.marblemain import Brain
+
+        b = Brain(2, size=(3, 3))
+        idxs = list(b.available_indices())
+        b.add_neuron(idxs[0], tensor=[0.0])
+        b.add_neuron(idxs[1], tensor=[0.0])
+        b.connect(idxs[0], idxs[1], direction="uni")
+        return b
+
+    def test_ultra_neuroplasticity_plugins_register_learnables(self):
+        from marble.marblemain import Wanderer
+
+        plugins = {
+            "weight_shifter": ["shift_amount"],
+            "bias_pulse": ["pulse_intensity"],
+            "threshold_fader": ["fade_rate"],
+            "synapse_bounce": ["bounce_scale"],
+            "signal_echo": ["echo_strength"],
+        }
+        for name, params in plugins.items():
+            with self.subTest(name=name):
+                b = self.make_brain()
+                w = Wanderer(b, neuroplasticity_type=name)
+                w.walk(max_steps=1, lr=0.0)
+                learnables = getattr(w, "_learnables", {})
+                print("ultra neuroplasticity plugin", name, "learnables", list(learnables.keys()))
+                for p in params:
+                    self.assertIn(p, learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+

--- a/tests/test_ultra_selfattention_plugins.py
+++ b/tests/test_ultra_selfattention_plugins.py
@@ -1,0 +1,42 @@
+import unittest
+
+
+class UltraSelfAttentionPluginSuiteTests(unittest.TestCase):
+    def make_brain(self):
+        from marble.marblemain import Brain
+
+        b = Brain(1, size=2)
+        idxs = list(b.available_indices())
+        b.add_neuron(idxs[0], tensor=[0.0])
+        if len(idxs) > 1:
+            b.add_neuron(idxs[1], tensor=[0.0])
+            b.connect(idxs[0], idxs[1], direction="bi")
+        return b
+
+    def test_ultra_selfattention_plugins_register_learnables(self):
+        from marble.marblemain import Wanderer, SelfAttention, attach_selfattention, REPORTER
+
+        REPORTER.clear_group("selfattention")
+        plugins = {
+            "phase_shift": ["phase_shift"],
+            "signal_booster": ["boost_gain"],
+            "residue_norm": ["residue_bias"],
+            "tunnel_vision": ["tunnel_focus"],
+            "temporal_echo": ["echo_decay"],
+        }
+        for name, params in plugins.items():
+            with self.subTest(name=name):
+                b = self.make_brain()
+                w = Wanderer(b, seed=1)
+                sa = SelfAttention(type_name=name)
+                attach_selfattention(w, sa)
+                w.walk(max_steps=1, lr=0.0)
+                learnables = getattr(w, "_learnables", {})
+                print("ultra selfattention plugin", name, "learnables", list(learnables.keys()))
+                for p in params:
+                    self.assertIn(p, learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+


### PR DESCRIPTION
## Summary
- add five ultra brain-train plugins exploring jittered learning rates, fractal step counts, echo-based starts, gravity anchors, and time-reversed walks
- add five ultra self-attention routines tweaking attention temperature via phase shifts, signal boosts, residue nudges, tunnel vision, and temporal echo decay
- add five ultra neuroplasticity plugins shifting or fading synapse weights, pulsing biases, bouncing connections, and echoing outputs
- document completion of ultra plugin tasks in DOTHISFIRST

## Testing
- `python -m unittest tests.test_ultra_brain_train_plugins -v`
- `python -m unittest tests.test_ultra_selfattention_plugins -v`
- `python -m unittest tests.test_ultra_neuroplasticity_plugins -v`


------
https://chatgpt.com/codex/tasks/task_e_68b29a97598883279da26105d609af94