### PR TITLE
feat: add building block plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,3 +436,23 @@ Rule: Plugins must register solely through automatic discovery. Adding a module 
 Context: Ensures a consistent, zero-boilerplate plugin workflow.
 Benefit: Simplifies extension and eliminates manual registry bookkeeping.
 Rollback Plan: Remove this rule if manual registration ever becomes necessary again.
+
+# BuildingBlock Plugins
+
+Small "BuildingBlock" plugins provide atomic graph operations and can be freely
+combined into larger DynamicPlugins. Modules prefixed with `buildingblock_`
+are auto-registered. Available blocks include:
+
+- `move_neuron`
+- `change_neuron_weight`
+- `change_neuron_bias`
+- `create_neuron`
+- `change_neuron_type`
+- `move_synapse`
+- `change_synapse_weight`
+- `change_synapse_bias`
+- `create_synapse`
+- `change_synapse_type`
+
+Each block has unrestricted read/write access to the graph, neurons, and
+synapses (create, edit, move, change type/weight/bias).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -146,6 +146,7 @@ Convenience APIs
 - Helpers: `make_default_codec` creates a default `UniversalTensorCodec` and logs under `codec/helpers`.
 - Data: `DataPair`, `make_datapair`, `encode_datapair`, `decode_datapair`.
 - Graph: `Neuron`, `Synapse`, `register_neuron_type`, `register_synapse_type`.
+- Building Blocks: `register_buildingblock_type`, `get_buildingblock_type`, `BuildingBlock`.
 - Space: `Brain` with grid/sparse modes; `Brain.train` for walk orchestration.
 - Wandering: `Wanderer`, `register_wanderer_type`, `register_neuroplasticity_type`.
   - SelfAttention: `SelfAttention` class plus `register_selfattention_type` and `attach_selfattention`. Routines (plugins) receive a read-only Reporter view and can propose setting updates via `set_param`, applied at the next step. `get_param` allows reading Wanderer public settings. The Wanderer applies queued updates at the start of the next step and logs what was applied.

--- a/marble/buildingblock.py
+++ b/marble/buildingblock.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Registry and base class for BuildingBlock plugins.
+
+BuildingBlocks are tiny plugins that perform atomic graph manipulations.
+They can be combined freely to assemble higher level dynamic plugins.
+"""
+
+from typing import Any, Dict
+
+from .graph import _DeviceHelper
+
+_BUILDINGBLOCK_TYPES: Dict[str, Any] = {}
+
+
+def register_buildingblock_type(name: str, plugin: Any) -> None:
+    if not isinstance(name, str) or not name:
+        raise ValueError("BuildingBlock type name must be a non-empty string")
+    mod = getattr(getattr(plugin, "__class__", object), "__module__", "")
+    if not isinstance(mod, str):
+        mod = str(mod)
+    if mod.startswith("marble.") and not mod.startswith("marble.plugins."):
+        raise ValueError(
+            f"BuildingBlock plugin '{name}' must live under marble.plugins.*; got module '{mod}'"
+        )
+    _BUILDINGBLOCK_TYPES[name] = plugin
+
+
+class BuildingBlock(_DeviceHelper):
+    """Base class for all BuildingBlock plugins."""
+
+    def apply(self, brain: "Brain", *args: Any, **kwargs: Any) -> Any:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+def get_buildingblock_type(name: str) -> Any:
+    return _BUILDINGBLOCK_TYPES.get(name)
+
+
+__all__ = [
+    "register_buildingblock_type",
+    "get_buildingblock_type",
+    "BuildingBlock",
+]
+

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -86,6 +86,11 @@ from .graph import (
     Neuron,
     Synapse,
 )
+from .buildingblock import (
+    register_buildingblock_type,
+    get_buildingblock_type,
+    BuildingBlock,
+)
 
 from .lobe import Lobe
 
@@ -97,6 +102,9 @@ __all__ += [
     "register_synapse_type",
     "Neuron",
     "Synapse",
+    "register_buildingblock_type",
+    "get_buildingblock_type",
+    "BuildingBlock",
     "Lobe",
 ]
 

--- a/marble/plugins/__init__.py
+++ b/marble/plugins/__init__.py
@@ -18,6 +18,7 @@ from ..graph import register_neuron_type, register_synapse_type
 from ..wanderer import register_wanderer_type, register_neuroplasticity_type
 from ..selfattention import register_selfattention_type
 from ..marblemain import register_brain_train_type
+from ..buildingblock import register_buildingblock_type
 
 
 def _find_plugin_class(module: Any) -> Optional[Type[Any]]:
@@ -55,6 +56,9 @@ for mod in pkgutil.iter_modules(__path__):
     elif name.startswith("brain_train_"):
         base = name[len("brain_train_") :]
         register_brain_train_type(plugin_name or base, cls())
+    elif name.startswith("buildingblock_"):
+        base = name[len("buildingblock_") :]
+        register_buildingblock_type(plugin_name or base, cls())
     else:
         # Default to neuron plugin registration
         register_neuron_type(plugin_name or name, cls())

--- a/marble/plugins/buildingblock_change_neuron_bias.py
+++ b/marble/plugins/buildingblock_change_neuron_bias.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""BuildingBlock: change neuron bias."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+
+
+class ChangeNeuronBiasPlugin(BuildingBlock):
+    def apply(self, brain, index: Sequence[int], bias: float):
+        neuron = brain.get_neuron(index)
+        if neuron is None:
+            raise ValueError("Neuron not found")
+        neuron.bias = float(bias)
+        return neuron.bias
+
+
+__all__ = ["ChangeNeuronBiasPlugin"]

--- a/marble/plugins/buildingblock_change_neuron_type.py
+++ b/marble/plugins/buildingblock_change_neuron_type.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""BuildingBlock: change neuron type."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..graph import _NEURON_TYPES
+
+
+class ChangeNeuronTypePlugin(BuildingBlock):
+    def apply(self, brain, index: Sequence[int], type_name: str):
+        neuron = brain.get_neuron(index)
+        if neuron is None:
+            raise ValueError("Neuron not found")
+        neuron.type_name = type_name
+        plugin = _NEURON_TYPES.get(type_name)
+        if plugin is not None and hasattr(plugin, "on_init"):
+            plugin.on_init(neuron)  # type: ignore[attr-defined]
+        return neuron.type_name
+
+
+__all__ = ["ChangeNeuronTypePlugin"]

--- a/marble/plugins/buildingblock_change_neuron_weight.py
+++ b/marble/plugins/buildingblock_change_neuron_weight.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+"""BuildingBlock: change neuron weight."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+
+
+class ChangeNeuronWeightPlugin(BuildingBlock):
+    def apply(self, brain, index: Sequence[int], weight: float):
+        neuron = brain.get_neuron(index)
+        if neuron is None:
+            raise ValueError("Neuron not found")
+        neuron.weight = float(weight)
+        return neuron.weight
+
+
+__all__ = ["ChangeNeuronWeightPlugin"]

--- a/marble/plugins/buildingblock_change_synapse_bias.py
+++ b/marble/plugins/buildingblock_change_synapse_bias.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""BuildingBlock: change synapse bias."""
+
+from ..buildingblock import BuildingBlock
+from ..graph import Synapse
+
+
+class ChangeSynapseBiasPlugin(BuildingBlock):
+    def apply(self, brain, synapse: Synapse, bias: float):
+        synapse.bias = float(bias)
+        return synapse.bias
+
+
+__all__ = ["ChangeSynapseBiasPlugin"]

--- a/marble/plugins/buildingblock_change_synapse_type.py
+++ b/marble/plugins/buildingblock_change_synapse_type.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+"""BuildingBlock: change synapse type."""
+
+from ..buildingblock import BuildingBlock
+from ..graph import _SYNAPSE_TYPES, Synapse
+
+
+class ChangeSynapseTypePlugin(BuildingBlock):
+    def apply(self, brain, synapse: Synapse, type_name: str):
+        synapse.type_name = type_name
+        plugin = _SYNAPSE_TYPES.get(type_name)
+        if plugin is not None and hasattr(plugin, "on_init"):
+            plugin.on_init(synapse)  # type: ignore[attr-defined]
+        return synapse.type_name
+
+
+__all__ = ["ChangeSynapseTypePlugin"]

--- a/marble/plugins/buildingblock_change_synapse_weight.py
+++ b/marble/plugins/buildingblock_change_synapse_weight.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""BuildingBlock: change synapse weight."""
+
+from ..buildingblock import BuildingBlock
+from ..graph import Synapse
+
+
+class ChangeSynapseWeightPlugin(BuildingBlock):
+    def apply(self, brain, synapse: Synapse, weight: float):
+        synapse.weight = float(weight)
+        return synapse.weight
+
+
+__all__ = ["ChangeSynapseWeightPlugin"]

--- a/marble/plugins/buildingblock_create_neuron.py
+++ b/marble/plugins/buildingblock_create_neuron.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""BuildingBlock: create a neuron."""
+
+from typing import Any, Sequence
+
+from ..buildingblock import BuildingBlock
+
+
+class CreateNeuronPlugin(BuildingBlock):
+    def apply(
+        self,
+        brain,
+        index: Sequence[int],
+        tensor: Any,
+        *,
+        weight: float = 1.0,
+        bias: float = 0.0,
+        type_name: str | None = None,
+    ):
+        return brain.add_neuron(index, tensor=tensor, weight=weight, bias=bias, type_name=type_name)
+
+
+__all__ = ["CreateNeuronPlugin"]

--- a/marble/plugins/buildingblock_create_synapse.py
+++ b/marble/plugins/buildingblock_create_synapse.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+"""BuildingBlock: create a synapse."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+
+
+class CreateSynapsePlugin(BuildingBlock):
+    def apply(
+        self,
+        brain,
+        src_index: Sequence[int],
+        dst_index: Sequence[int],
+        *,
+        direction: str = "uni",
+        weight: float = 1.0,
+        bias: float = 0.0,
+        type_name: str | None = None,
+    ):
+        return brain.connect(src_index, dst_index, direction=direction, weight=weight, bias=bias, type_name=type_name)
+
+
+__all__ = ["CreateSynapsePlugin"]

--- a/marble/plugins/buildingblock_move_neuron.py
+++ b/marble/plugins/buildingblock_move_neuron.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""BuildingBlock: move a neuron to a new index."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+
+
+class MoveNeuronPlugin(BuildingBlock):
+    def _key(self, brain, index: Sequence[int]):
+        if brain.mode == "grid":
+            return tuple(int(i) for i in index)
+        return tuple(float(i) for i in index)
+
+    def apply(self, brain, old_index: Sequence[int], new_index: Sequence[int]):
+        old_key = self._key(brain, old_index)
+        new_key = self._key(brain, new_index)
+        if new_key in brain.neurons:
+            raise ValueError("Destination already occupied")
+        neuron = brain.neurons.pop(old_key)
+        setattr(neuron, "position", new_key)
+        brain.neurons[new_key] = neuron
+        return neuron
+
+
+__all__ = ["MoveNeuronPlugin"]

--- a/marble/plugins/buildingblock_move_synapse.py
+++ b/marble/plugins/buildingblock_move_synapse.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+"""BuildingBlock: move a synapse to new source/target neurons."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..graph import Neuron, Synapse
+
+
+class MoveSynapsePlugin(BuildingBlock):
+    def _detach(self, syn: Synapse) -> None:
+        src = syn.source
+        dst = syn.target
+        if isinstance(src, Neuron):
+            try:
+                src.outgoing.remove(syn)
+            except Exception:
+                pass
+            if syn.direction == "bi":
+                try:
+                    src.incoming.remove(syn)
+                except Exception:
+                    pass
+        else:
+            try:
+                src.outgoing_synapses.remove(syn)
+            except Exception:
+                pass
+            if syn.direction == "bi":
+                try:
+                    src.incoming_synapses.remove(syn)
+                except Exception:
+                    pass
+        if isinstance(dst, Neuron):
+            try:
+                dst.incoming.remove(syn)
+            except Exception:
+                pass
+            if syn.direction == "bi":
+                try:
+                    dst.outgoing.remove(syn)
+                except Exception:
+                    pass
+        else:
+            try:
+                dst.incoming_synapses.remove(syn)
+            except Exception:
+                pass
+            if syn.direction == "bi":
+                try:
+                    dst.outgoing_synapses.remove(syn)
+                except Exception:
+                    pass
+
+    def apply(self, brain, synapse: Synapse, new_source_index: Sequence[int], new_target_index: Sequence[int]):
+        new_src = brain.get_neuron(new_source_index)
+        new_dst = brain.get_neuron(new_target_index)
+        if new_src is None or new_dst is None:
+            raise ValueError("New source and target neurons must exist")
+        self._detach(synapse)
+        synapse.source = new_src
+        synapse.target = new_dst
+        new_src.outgoing.append(synapse)
+        new_dst.incoming.append(synapse)
+        if synapse.direction == "bi":
+            new_src.incoming.append(synapse)
+            new_dst.outgoing.append(synapse)
+        return synapse
+
+
+__all__ = ["MoveSynapsePlugin"]

--- a/tests/test_building_blocks.py
+++ b/tests/test_building_blocks.py
@@ -1,0 +1,45 @@
+import unittest
+
+import marble.plugins  # noqa: F401 - ensure plugins load
+from marble.marblemain import Brain
+from marble.buildingblock import get_buildingblock_type
+
+
+class TestBuildingBlocks(unittest.TestCase):
+    def test_neuron_blocks(self):
+        brain = Brain(1, size=2)
+        create = get_buildingblock_type("create_neuron")
+        neuron = create.apply(brain, (0,), [0.0])
+        weight = get_buildingblock_type("change_neuron_weight")
+        weight.apply(brain, (0,), 2.0)
+        bias = get_buildingblock_type("change_neuron_bias")
+        bias.apply(brain, (0,), 1.5)
+        move = get_buildingblock_type("move_neuron")
+        move.apply(brain, (0,), (1,))
+        ntype = get_buildingblock_type("change_neuron_type")
+        ntype.apply(brain, (1,), "sigmoid")
+        print("neuron", neuron.weight, neuron.bias, neuron.type_name, neuron.position)
+        self.assertEqual(brain.get_neuron((1,)), neuron)
+
+    def test_synapse_blocks(self):
+        brain = Brain(1, size=2)
+        create = get_buildingblock_type("create_neuron")
+        n0 = create.apply(brain, (0,), [0.0])
+        n1 = create.apply(brain, (1,), [0.0])
+        cs = get_buildingblock_type("create_synapse")
+        syn = cs.apply(brain, (0,), (1,), weight=1.0, bias=0.5)
+        w = get_buildingblock_type("change_synapse_weight")
+        w.apply(brain, syn, 2.5)
+        b = get_buildingblock_type("change_synapse_bias")
+        b.apply(brain, syn, 1.0)
+        mv = get_buildingblock_type("move_synapse")
+        mv.apply(brain, syn, (1,), (0,))
+        st = get_buildingblock_type("change_synapse_type")
+        st.apply(brain, syn, "delay")
+        print("synapse", syn.weight, syn.bias, syn.type_name, syn.source.position, syn.target.position)
+        self.assertEqual(syn.source, n1)
+        self.assertEqual(syn.target, n0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add BuildingBlock registry for atomic graph operations
- wire plugin loader and export hooks
- implement neuron and synapse building block plugins and enable synapse bias
- document BuildingBlock system in AGENTS and ARCHITECTURE

## Testing
- `python -m unittest -v tests.test_building_blocks`


------
https://chatgpt.com/codex/tasks/task_e_68b2bdb65b1c83279550b1dcb477aad1