### PR TITLE
fix selfattention conv1d insertion

### DIFF
--- a/marble/plugins/selfattention_conv1d_inserter.py
+++ b/marble/plugins/selfattention_conv1d_inserter.py
@@ -105,10 +105,15 @@ class Conv1DRandomInsertionRoutine:
             dstn = brain.get_neuron(dst)
             if dstn is None:
                 return None
-            conv = brain.add_neuron(self._random_free_index(brain), tensor=[0.0], type_name="conv1d")
-            from ..marblemain import wire_param_synapses
+            conv_idx = self._random_free_index(brain)
+            conv = brain.add_neuron(conv_idx, tensor=[0.0])
+            from ..marblemain import wire_param_synapses, _NEURON_TYPES
             wire_param_synapses(brain, conv, ps)
             brain.connect(getattr(conv, "position"), dst, direction="uni")
+            conv.type_name = "conv1d"
+            plugin = _NEURON_TYPES.get("conv1d")
+            if plugin is not None and hasattr(plugin, "on_init"):
+                plugin.on_init(conv)  # type: ignore[attr-defined]
         except Exception:
             return None
         # No param updates here; leave evaluation/rollback policy to future extensions


### PR DESCRIPTION
## Summary
- ensure SelfAttention conv1d inserter wires parameters before plugin init
- add conv1d neuron using free index and run plugin `on_init`

## Testing
- `python -m unittest -v tests.test_new_wanderer_plugins`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_quantumtype_plugin`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_super_advanced_neuron_plugins`
- `python -m unittest -v tests.test_synapse_plugins`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_triple_contrast_plugin`
- `python -m unittest -v tests.test_ultra_brain_train_plugins`
- `python -m unittest -v tests.test_ultra_neuron_plugins`
- `python -m unittest -v tests.test_ultra_neuroplasticity_plugins`
- `python -m unittest -v tests.test_ultra_selfattention_plugins`
- `python -m unittest -v tests.test_ultra_synapse_plugins`
- `python -m unittest -v tests.test_ultra_wanderer_plugins`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_walk_summary`
- `python -m unittest -v tests.test_wanderer_wayfinder_plugin`


------
https://chatgpt.com/codex/tasks/task_e_68b339f2c518832784966140ff203e49