### PR TITLE
feat: expose neuron state for selfattention

### DIFF
--- a/marble/selfattention.py
+++ b/marble/selfattention.py
@@ -88,6 +88,27 @@ class SelfAttention:
         except Exception:
             pass
 
+    # Neuron state reporting
+    def _receive_neuron_report(self, neuron: "Neuron", info: Dict[str, Any]) -> None:
+        """Internal hook used by Neuron.report_to_selfattention."""
+        try:
+            report("selfattention", "neuron_report", {"neuron": id(neuron), **info}, "builder")
+        except Exception:
+            pass
+
+    def get_neuron_report(self, neuron: "Neuron") -> Dict[str, Any]:
+        """Query a neuron's core attributes for analysis routines."""
+        if hasattr(neuron, "describe_for_selfattention"):
+            info = neuron.describe_for_selfattention()  # type: ignore[attr-defined]
+        else:
+            info = {
+                "weight": float(getattr(neuron, "weight", 1.0)),
+                "type_name": getattr(neuron, "type_name", None),
+                "position": getattr(neuron, "position", None),
+            }
+        self._receive_neuron_report(neuron, info)
+        return info
+
     # Internal wiring
     def _bind(self, wanderer: "Wanderer") -> None:
         self._owner = wanderer

--- a/tests/test_neuron_selfattention_report.py
+++ b/tests/test_neuron_selfattention_report.py
@@ -1,0 +1,22 @@
+import unittest
+
+
+class TestNeuronSelfAttentionReport(unittest.TestCase):
+    def setUp(self):
+        from marble.marblemain import Brain, SelfAttention
+        self.Brain = Brain
+        self.SelfAttention = SelfAttention
+
+    def test_neuron_report(self):
+        b = self.Brain(1, size=(3,))
+        n = b.add_neuron((0,), weight=1.5, type_name="sigmoid")
+        sa = self.SelfAttention()
+        info = sa.get_neuron_report(n)
+        print("neuron report:", info)
+        self.assertEqual(info["weight"], 1.5)
+        self.assertEqual(info["type_name"], "sigmoid")
+        self.assertEqual(info["position"], (0,))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- allow neurons to provide weight, type, and position info to SelfAttention
- let SelfAttention query neurons and log their reports
- cover neuron reporting with a dedicated unit test

## Testing
- `python -m unittest tests.test_graph -v`
- `python -m unittest tests.test_neuron_selfattention_report -v`
- `python -m unittest tests.test_selfattention_conv1d -v`


------
https://chatgpt.com/codex/tasks/task_e_68b33ce714448327968ae97b34cbce5c