### PR TITLE
Add self-attention reporting plugins and autoplugin integration

### DIFF
--- a/marble/plugins/selfattention_age_temperature.py
+++ b/marble/plugins/selfattention_age_temperature.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _age_temp_params(
+    wanderer,
+    num_neurons: float = 3.0,
+    start_index: float = 0.0,
+    age_threshold: float = 1.0,
+    young_temp: float = 2.0,
+    old_temp: float = 0.5,
+):
+    return num_neurons, start_index, age_threshold, young_temp, old_temp
+
+
+class AgeTemperatureRoutine:
+    """Route temperature based on average neuron age."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        n_t, s_t, thr_t, y_t, o_t = _age_temp_params(wanderer)
+        try:
+            count = max(1, int(n_t.detach().to("cpu").item()))
+            start = int(s_t.detach().to("cpu").item())
+            thr = float(thr_t.detach().to("cpu").item())
+            ytemp = float(y_t.detach().to("cpu").item())
+            otemp = float(o_t.detach().to("cpu").item())
+        except Exception:
+            count, start, thr, ytemp, otemp = 3, 0, 1.0, 2.0, 0.5
+        neurons = list(getattr(wanderer.brain, "neurons", {}).values())
+        if not neurons:
+            return None
+        neurons.sort(key=lambda n: (getattr(n, "position", ()), id(n)))
+        start = start % len(neurons)
+        chosen: List[Any] = [neurons[(start + i) % len(neurons)] for i in range(count)]
+        ages: List[float] = []
+        for n in chosen:
+            info = selfattention.get_neuron_report(n)
+            try:
+                ages.append(float(info.get("age", 0.0)))
+            except Exception:
+                pass
+        if not ages:
+            return None
+        avg = sum(ages) / len(ages)
+        try:
+            report("selfattention", "age_temperature", {"step": step_index, "avg": avg}, "events")
+        except Exception:
+            pass
+        if avg < thr:
+            selfattention.set_param("temperature", ytemp)
+        else:
+            selfattention.set_param("temperature", otemp)
+        return None
+
+
+__all__ = ["AgeTemperatureRoutine"]
+

--- a/marble/plugins/selfattention_bias_temperature.py
+++ b/marble/plugins/selfattention_bias_temperature.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _bias_temp_params(
+    wanderer,
+    num_neurons: float = 3.0,
+    start_index: float = 0.0,
+    bias_threshold: float = 0.0,
+    high_temp: float = 2.0,
+    low_temp: float = 0.5,
+):
+    return num_neurons, start_index, bias_threshold, high_temp, low_temp
+
+
+class BiasTemperatureRoutine:
+    """Adjust attention temperature based on average neuron bias."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        n_t, s_t, thr_t, hi_t, lo_t = _bias_temp_params(wanderer)
+        try:
+            count = max(1, int(n_t.detach().to("cpu").item()))
+            start = int(s_t.detach().to("cpu").item())
+            thr = float(thr_t.detach().to("cpu").item())
+            hi = float(hi_t.detach().to("cpu").item())
+            lo = float(lo_t.detach().to("cpu").item())
+        except Exception:
+            count, start, thr, hi, lo = 3, 0, 0.0, 2.0, 0.5
+        neurons = list(getattr(wanderer.brain, "neurons", {}).values())
+        if not neurons:
+            return None
+        neurons.sort(key=lambda n: (getattr(n, "position", ()), id(n)))
+        start = start % len(neurons)
+        chosen: List[Any] = [neurons[(start + i) % len(neurons)] for i in range(count)]
+        biases: List[float] = []
+        for n in chosen:
+            info = selfattention.get_neuron_report(n)
+            try:
+                biases.append(float(info.get("bias", 0.0)))
+            except Exception:
+                pass
+        if not biases:
+            return None
+        avg = sum(biases) / len(biases)
+        try:
+            report("selfattention", "bias_temperature", {"step": step_index, "avg": avg}, "events")
+        except Exception:
+            pass
+        if avg > thr:
+            selfattention.set_param("temperature", hi)
+        else:
+            selfattention.set_param("temperature", lo)
+        return None
+
+
+__all__ = ["BiasTemperatureRoutine"]
+

--- a/marble/plugins/selfattention_position_lr.py
+++ b/marble/plugins/selfattention_position_lr.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import math
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _pos_lr_params(
+    wanderer,
+    num_neurons: float = 3.0,
+    start_index: float = 0.0,
+    scale: float = 1.0,
+):
+    return num_neurons, start_index, scale
+
+
+class PositionLRRoutine:
+    """Scale learning rate based on average neuron position norm."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        n_t, s_t, sc_t = _pos_lr_params(wanderer)
+        try:
+            count = max(1, int(n_t.detach().to("cpu").item()))
+            start = int(s_t.detach().to("cpu").item())
+            scale = float(sc_t.detach().to("cpu").item())
+        except Exception:
+            count, start, scale = 3, 0, 1.0
+        neurons = list(getattr(wanderer.brain, "neurons", {}).values())
+        if not neurons:
+            return None
+        neurons.sort(key=lambda n: (getattr(n, "position", ()), id(n)))
+        start = start % len(neurons)
+        chosen: List[Any] = [neurons[(start + i) % len(neurons)] for i in range(count)]
+        norms: List[float] = []
+        for n in chosen:
+            info = selfattention.get_neuron_report(n)
+            pos = info.get("position")
+            if isinstance(pos, (list, tuple)):
+                try:
+                    norms.append(math.sqrt(sum(float(x) ** 2 for x in pos)))
+                except Exception:
+                    pass
+        if not norms:
+            return None
+        avg = sum(norms) / len(norms)
+        try:
+            report("selfattention", "position_lr", {"step": step_index, "avg": avg}, "events")
+        except Exception:
+            pass
+        cur_lr = float(getattr(wanderer, "current_lr", 0.01) or 0.01)
+        new_lr = cur_lr / (1.0 + scale * avg)
+        selfattention.set_param("lr_override", new_lr)
+        return None
+
+
+__all__ = ["PositionLRRoutine"]
+

--- a/marble/plugins/selfattention_type_gradclip.py
+++ b/marble/plugins/selfattention_type_gradclip.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _type_clip_params(
+    wanderer,
+    num_neurons: float = 3.0,
+    start_index: float = 0.0,
+    ratio_threshold: float = 0.5,
+    max_norm: float = 1.0,
+):
+    return num_neurons, start_index, ratio_threshold, max_norm
+
+
+class TypeGradClipRoutine:
+    """Enable gradient clipping when diverse neuron types dominate."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        n_t, s_t, thr_t, m_t = _type_clip_params(wanderer)
+        try:
+            count = max(1, int(n_t.detach().to("cpu").item()))
+            start = int(s_t.detach().to("cpu").item())
+            thr = float(thr_t.detach().to("cpu").item())
+            max_norm = float(m_t.detach().to("cpu").item())
+        except Exception:
+            count, start, thr, max_norm = 3, 0, 0.5, 1.0
+        neurons = list(getattr(wanderer.brain, "neurons", {}).values())
+        if not neurons:
+            return None
+        neurons.sort(key=lambda n: (getattr(n, "position", ()), id(n)))
+        start = start % len(neurons)
+        chosen: List[Any] = [neurons[(start + i) % len(neurons)] for i in range(count)]
+        diverse = 0
+        for n in chosen:
+            info = selfattention.get_neuron_report(n)
+            t = info.get("type_name")
+            if t and t != "base":
+                diverse += 1
+        ratio = diverse / float(len(chosen))
+        try:
+            report("selfattention", "type_ratio", {"step": step_index, "ratio": ratio}, "events")
+        except Exception:
+            pass
+        if ratio > thr:
+            selfattention.set_param("_grad_clip", {"method": "norm", "max_norm": max_norm, "norm_type": 2.0})
+        return None
+
+
+__all__ = ["TypeGradClipRoutine"]
+

--- a/marble/plugins/selfattention_weight_lr.py
+++ b/marble/plugins/selfattention_weight_lr.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _weight_lr_params(
+    wanderer,
+    num_neurons: float = 3.0,
+    start_index: float = 0.0,
+    threshold: float = 1.0,
+    scale: float = 0.5,
+):
+    return num_neurons, start_index, threshold, scale
+
+
+class WeightLRRoutine:
+    """Adjust learning rate based on average absolute neuron weight."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        n_t, s_t, thr_t, sc_t = _weight_lr_params(wanderer)
+        try:
+            count = max(1, int(n_t.detach().to("cpu").item()))
+            start = int(s_t.detach().to("cpu").item())
+            thr = float(thr_t.detach().to("cpu").item())
+            scale = float(sc_t.detach().to("cpu").item())
+        except Exception:
+            count, start, thr, scale = 3, 0, 1.0, 0.5
+        neurons = list(getattr(wanderer.brain, "neurons", {}).values())
+        if not neurons:
+            return None
+        neurons.sort(key=lambda n: (getattr(n, "position", ()), id(n)))
+        start = start % len(neurons)
+        chosen: List[Any] = [neurons[(start + i) % len(neurons)] for i in range(count)]
+        weights: List[float] = []
+        for n in chosen:
+            info = selfattention.get_neuron_report(n)
+            try:
+                weights.append(abs(float(info.get("weight", 0.0))))
+            except Exception:
+                pass
+        if not weights:
+            return None
+        avg = sum(weights) / len(weights)
+        try:
+            report("selfattention", "weight_lr", {"step": step_index, "avg": avg}, "events")
+        except Exception:
+            pass
+        cur_lr = float(getattr(wanderer, "current_lr", 0.01) or 0.01)
+        if avg > thr:
+            selfattention.set_param("lr_override", cur_lr * scale)
+        return None
+
+
+__all__ = ["WeightLRRoutine"]
+


### PR DESCRIPTION
## Summary
- add five neuron-report self-attention routines for learning-rate, temperature and gradient clip control
- expose learnable parameters for all self-attention routines and enable AutoPlugin to gate them
- adapt existing self-attention routines to use expose_learnable_params

## Testing
- `python find_tests_without_prints.py`
- `PYTHONPATH=. pytest tests/test_findbestneurontype_fallback.py -q`
- `PYTHONPATH=. pytest tests/test_advanced_selfattention_plugins.py -q`
- `PYTHONPATH=. pytest tests/test_ultra_selfattention_plugins.py -q`
- `PYTHONPATH=. pytest tests/test_selfattention_conv1d.py -q`
- `PYTHONPATH=. pytest tests/test_autoplugin_buildingblocks.py -q`
- `PYTHONPATH=. pytest tests/test_autoplugin_exclude.py -q`
- `PYTHONPATH=. pytest tests/test_autoplugin_explicit.py -q`
- `PYTHONPATH=. pytest tests/test_neuron_selfattention_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33f0ddc0c8327a8f22fbabb226757