### PR TITLE
feat: add logging options for auto plugins

### DIFF
--- a/tests/test_autoneuron_logging.py
+++ b/tests/test_autoneuron_logging.py
@@ -1,0 +1,32 @@
+import os
+import os
+import tempfile
+import unittest
+
+import marble.plugins  # ensure plugin discovery
+from marble.marblemain import Brain, Wanderer, register_neuron_type
+from marble.plugins.autoneuron import AutoNeuronPlugin
+
+
+class TestAutoNeuronLogging(unittest.TestCase):
+    def test_logging_occurs(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        auto_n = AutoNeuronPlugin(log_path=tmp.name)
+        register_neuron_type("autoneuron_logger", auto_n)
+        b = Brain(1, size=(1,))
+        idx = b.available_indices()[0]
+        n = b.add_neuron(idx, tensor=[1.0], type_name="autoneuron_logger")
+        w = Wanderer(b, seed=0, neuroplasticity_type="base")
+        for _ in range(4):
+            w.walk(max_steps=20, start=n, lr=0.01)
+        auto_n.finalize_logs(w)
+        with open(tmp.name, "r", encoding="utf-8") as fh:
+            data = fh.read()
+        print("neuron log:\n" + data)
+        os.unlink(tmp.name)
+        self.assertTrue(data.strip())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)

--- a/tests/test_autoplugin_logging.py
+++ b/tests/test_autoplugin_logging.py
@@ -1,0 +1,31 @@
+import os
+import tempfile
+import unittest
+
+import marble.plugins  # ensure plugin discovery
+from marble.marblemain import Brain, Wanderer, register_wanderer_type
+from marble.plugins.wanderer_autoplugin import AutoPlugin
+
+
+class TestAutoPluginLogging(unittest.TestCase):
+    def test_logging_occurs(self):
+        tmp = tempfile.NamedTemporaryFile(delete=False)
+        tmp.close()
+        register_wanderer_type("autoplugin_logger", AutoPlugin(log_path=tmp.name))
+        b = Brain(1, size=(1,))
+        idx = b.available_indices()[0]
+        n = b.add_neuron(idx, tensor=[1.0], type_name="autoneuron")
+        w = Wanderer(b, type_name="autoplugin_logger", neuroplasticity_type="base", seed=0)
+        auto = next(p for p in w._wplugins if isinstance(p, AutoPlugin))
+        for _ in range(4):
+            w.walk(max_steps=20, start=n, lr=0.01)
+        auto.finalize_logs(w)
+        with open(tmp.name, "r", encoding="utf-8") as fh:
+            data = fh.read()
+        print("auto log:\n" + data)
+        os.unlink(tmp.name)
+        self.assertTrue(data.strip())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add optional action logging for AutoPlugin and AutoNeuron
- record plugin activation durations, steps, and totals
- verify logging through new tests performing multiple walks

## Testing
- `python -m unittest tests.test_autoplugin_logging -v`
- `python -m unittest tests.test_autoneuron_logging -v`


------
https://chatgpt.com/codex/tasks/task_e_68b3533468f88327a038dd079d3d176d