### PR TITLE
ensure auto plugin decisions are learned

### DIFF
--- a/tests/test_autoplugin_bias.py
+++ b/tests/test_autoplugin_bias.py
@@ -1,11 +1,10 @@
 import unittest
 
 
-class TestAutoPluginExplicit(unittest.TestCase):
-    def test_explicit_plugin_not_deactivated(self):
+class TestAutoPluginBias(unittest.TestCase):
+    def test_bias_deactivates_plugin(self):
         from marble.marblemain import Brain, Wanderer
         from marble.plugins.wanderer_autoplugin import AutoPlugin
-        from marble.plugins.wanderer_epsgreedy import EpsilonGreedyChooserPlugin
 
         b = Brain(1, size=(1,))
         idx = b.available_indices()[0]
@@ -16,16 +15,16 @@ class TestAutoPluginExplicit(unittest.TestCase):
             neuroplasticity_type="base",
             seed=0,
         )
-        w.ensure_learnable_param("autoplugin_bias_EpsilonGreedyChooserPlugin", -10.0)
+        w.ensure_learnable_param("autoplugin_bias_EpsilonGreedyChooserPlugin", 0.0)
+        w.get_learnable_param_tensor("autoplugin_bias_EpsilonGreedyChooserPlugin").data.fill_(-10.0)
         auto = next(p for p in w._wplugins if isinstance(p, AutoPlugin))
         active = auto.is_active(w, "EpsilonGreedyChooserPlugin", None)
+        stack = [getattr(getattr(p, "_plugin", p), "__class__").__name__ for p in w._wplugins]
         print("plugin active:", active)
-        self.assertTrue(active)
-        present = any(isinstance(p, EpsilonGreedyChooserPlugin) for p in w._wplugins)
-        print("plugin present:", present)
-        self.assertTrue(present)
+        print("stack:", stack)
+        self.assertFalse(active)
+        self.assertIn("EpsilonGreedyChooserPlugin", stack)
 
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
-


### PR DESCRIPTION
## Summary
- remove explicit plugin allowlist so AutoPlugin gates every plugin through attention-derived scores
- pick neuron types in AutoNeuron using learned scores even when torch fallback is needed
- test AutoPlugin bias-based gating and track AutoNeuron selection via failing plugin calls

## Testing
- `python -m pytest tests/test_autoplugin_bias.py -q`
- `python -m pytest tests/test_autoplugin_buildingblocks.py -q`
- `python -m pytest tests/test_autoplugin_exclude.py -q`
- `python -m pytest tests/test_autoplugin_logging.py -q`
- `python -m pytest tests/test_autoneuron.py -q`
- `python -m pytest tests/test_autoneuron_logging.py -q`
- `python -m pytest tests/test_3d_printer_sim_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3573b1b988327b8a3173c9e5a3149