### PR TITLE
Fix HF dataset loader and image quality example

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -86,9 +86,11 @@ def main(epochs: int = 1) -> None:
         "Rapidata/Imagen-4-ultra-24-7-25_t2i_human_preference",
         split="train",
         streaming=True,
-        trust_remote_code=True,
         codec=codec,
     )
+    # Consumed fields: prompt, image1, image2, weighted_results_image1_preference,
+    # weighted_results_image2_preference, weighted_results_image1_alignment,
+    # weighted_results_image2_alignment
     brain = Brain(
         2,
         size=32,
@@ -103,7 +105,7 @@ def main(epochs: int = 1) -> None:
     sa = SelfAttention(
         routines=[
             QualityAwareRoutine(window=8),
-            AdaptiveGradClipRoutine(threshold_ratio=1.3, max_norm=1.0),
+            AdaptiveGradClipRoutine(),
             FindBestNeuronTypeRoutine(),
             ContextAwareNoiseRoutine(),
         ]

--- a/marble/hf_utils.py
+++ b/marble/hf_utils.py
@@ -156,7 +156,18 @@ def load_hf_streaming_dataset(
     if ds_mod is None:
         raise RuntimeError("datasets is not installed. Please install 'datasets'.")
     used_codec = codec if codec is not None else make_default_codec()
-    ds = ds_mod.load_dataset(path, name=name, split=split, streaming=streaming, trust_remote_code=trust_remote_code, **kwargs)
+    import inspect
+
+    ds_kwargs: Dict[str, Any] = {
+        "path": path,
+        "name": name,
+        "split": split,
+        "streaming": streaming,
+        **kwargs,
+    }
+    if "trust_remote_code" in inspect.signature(ds_mod.load_dataset).parameters:
+        ds_kwargs["trust_remote_code"] = trust_remote_code
+    ds = ds_mod.load_dataset(**ds_kwargs)
     try:
         report("huggingface", "load_dataset", {"path": path, "name": name, "split": split, "streaming": bool(streaming)}, "dataset")
     except Exception:


### PR DESCRIPTION
## Summary
- Update HF streaming dataset loader to handle removed `trust_remote_code` argument gracefully
- Simplify `run_hf_image_quality` example and document consumed dataset fields

## Testing
- `python -m pytest tests/test_codec.py::TestUniversalTensorCodec::test_package_import -q`
- `python - <<'PY'
from examples.run_hf_image_quality import main
main(epochs=0)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b35cef057c8327bcdb1b27824c4a3e