### PR TITLE
feat: mirror brain topology into Kuzu graph

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,6 +44,7 @@ Core Components
   - Grid mode: discrete occupancy over an integer index lattice with world-coordinate bounds. Occupancy can be defined by formulas or Mandelbrot functions (`mandelbrot`, `mandelbrot_nd`). Omitting the `size` parameter enables a fully dynamic grid that expands as neurons are added; capacity becomes unbounded.
   - Sparse mode: only track explicit world coordinates within per-dimension bounds supporting open-ended maxima via `None`.
   Provides neuron placement, connections, coordinate mapping, bulk add, and JSON export/import for sparse brains. Includes basic cross-process file-based locks (Windows-friendly) for neurons and synapses. The brain can persist and restore its entire state via single-file snapshots (`save_snapshot`/`load_snapshot`) using the `.marble` extension. When constructed with `store_snapshots=True`, snapshots are automatically written every `snapshot_freq` wanderer walks into `snapshot_path`.
+  Optionally mirrors neurons and synapses into a Kuzu graph database when initialized with `kuzu_path`, keeping the external graph live-updated as the Brain changes.
 
 - `Lobe`: defines a subset of a Brain by selecting specific neurons and synapses. A lobe can be trained independently and may either inherit the active Wanderer plugin stack or supply its own `plugin_types` and `neuro_config` for isolated experimentation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 dependencies = [
   "numpy",
   "tqdm",
+  "kuzu",
 ]
 
 [project.urls]

--- a/tests/test_brain_kuzu.py
+++ b/tests/test_brain_kuzu.py
@@ -1,0 +1,34 @@
+import tempfile
+import kuzu
+import unittest
+from marble.marblemain import Brain
+
+
+class BrainKuzuTest(unittest.TestCase):
+    def test_updates(self):
+        db_path = tempfile.mktemp()
+        brain = Brain(2, size=3, formula="1", kuzu_path=db_path)
+        n1 = brain.add_neuron((0, 0), tensor=0.0)
+        brain.add_neuron((0, 1), tensor=0.0)
+        syn = brain.connect((0, 0), (0, 1))
+        conn = kuzu.Connection(kuzu.Database(db_path))
+        nodes = list(conn.execute("MATCH (n:Neuron) RETURN COUNT(*)"))[0][0]
+        edges = list(conn.execute("MATCH ()-[:Synapse]->() RETURN COUNT(*)"))[0][0]
+        print("initial", nodes, edges)
+        self.assertEqual(nodes, 2)
+        self.assertEqual(edges, 1)
+        brain.remove_synapse(syn)
+        conn = kuzu.Connection(kuzu.Database(db_path))
+        edges_after = list(conn.execute("MATCH ()-[:Synapse]->() RETURN COUNT(*)"))[0][0]
+        print("after_remove_syn", edges_after)
+        self.assertEqual(edges_after, 0)
+        del conn
+        brain.remove_neuron(n1)
+        conn2 = kuzu.Connection(kuzu.Database(db_path))
+        nodes_after = list(conn2.execute("MATCH (n:Neuron) RETURN COUNT(*)"))[0][0]
+        print("after_remove_neuron", nodes_after)
+        self.assertEqual(nodes_after, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow Brain to mirror neurons and synapses into a Kuzu database via `kuzu_path`
- rebuild Kuzu graph whenever topology changes
- document optional Kuzu integration and add dependency

## Testing
- `python -m unittest -v tests.test_brain_kuzu`


------
https://chatgpt.com/codex/tasks/task_e_68b4128d60008327a9cf39f807fc63e1