### PR TITLE
Add per-brain training locks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,7 +74,7 @@ Core Components
   - `quick_train_on_pairs`: builds a minimal 2D `Brain` with configurable `grid_size`, creates a default codec if not provided, and calls `run_training_with_datapairs` with the supplied hyperparameters (`steps_per_pair`, `lr`, `seed`, `wanderer_type`, `train_type`, `neuro_config`, `gradient_clip`, optional `selfattention`). Logs summary under `training/quick`.
   - `run_wanderers_parallel`: orchestrates multiple datasets with thread-based concurrency (process mode intentionally unimplemented).
   - `run_wine_hello_world`: convenience that loads scikit-learn’s Wine dataset, runs training with neuroplasticity active, and writes per-step wanderer logs to a JSONL file.
-  - All helpers reuse the original `Brain` and `Graph` instances; a per-brain `threading.Lock` (`brain._train_lock`) ensures that concurrent training calls serialize instead of copying the structures. `Brain`, `Neuron`, and `Synapse` explicitly disallow `copy` and `deepcopy` to guarantee immutability during training.
+  - All helpers, including `run_wanderer_training`, reuse the original `Brain` and `Graph` instances; a per-brain `threading.Lock` (`brain._train_lock`) ensures that concurrent training calls serialize instead of copying the structures. `Brain`, `Neuron`, and `Synapse` explicitly disallow `copy` and `deepcopy` to guarantee immutability during training.
   - The lock is a simple, non-reentrant guard; nested training helpers must coordinate externally to avoid deadlocks.
 
 - Reporter: Global `REPORTER` instance to record structured data. Convenience functions `report`, `report_group`, `report_dir`, and `clear_report_group` provide ergonomic logging, querying, and cleanup. Tests and core flows record key metrics and events for auditability.

--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -65,28 +65,28 @@ enforced strictly through `Lock` primitives.
 ## Steps
 1. Audit `marble/training.py`, `marble/graph.py`, and all plugin modules for
    any use of `copy`, `deepcopy`, or cloning of brain and graph objects during
-   training. Replace such patterns with direct references.
+   training. Replace such patterns with direct references. [complete]
 2. Introduce explicit `threading.Lock` guards around training sections that
-   require thread safety, removing any copy-based safety mechanisms.
+   require thread safety, removing any copy-based safety mechanisms. [complete]
 3. Extend tests to assert object identity for brain and graph instances before
-   and after training steps to detect accidental copies.
+   and after training steps to detect accidental copies. [complete]
 4. Document the lock-only policy and immutability guarantees in
-   `ARCHITECTURE.md` and update tutorials if necessary.
+   `ARCHITECTURE.md` and update tutorials if necessary. [complete]
 
 # Pending tests
 
 The following test modules still need to be run and outputs analyzed:
 - tests/test_new_wanderer_plugins.py
-- tests/test_parallel.py
+- tests/test_parallel.py [complete]
 - tests/test_plugin_stacking.py
 - tests/test_quantumtype_plugin.py
 - tests/test_reporter.py
 - tests/test_reporter_clear.py
 - tests/test_reporter_subgroups.py
-- tests/test_selfattention_conv1d.py (currently failing)
+- tests/test_selfattention_conv1d.py [complete]
 - tests/test_super_advanced_neuron_plugins.py
 - tests/test_synapse_plugins.py
-- tests/test_training_with_datapairs.py
+- tests/test_training_with_datapairs.py [complete]
 - tests/test_triple_contrast_plugin.py
 - tests/test_ultra_brain_train_plugins.py
 - tests/test_ultra_neuron_plugins.py

--- a/marble/training.py
+++ b/marble/training.py
@@ -75,8 +75,12 @@ def run_wanderer_training(
             pass
         return out
 
-    # Locking occurs within run_training_with_datapairs; no external lock to avoid deadlocks
-    return _inner()
+    lock = getattr(brain, "_train_lock", None)
+    if not isinstance(lock, LockType):
+        lock = Lock()
+        setattr(brain, "_train_lock", lock)
+    with lock:
+        return _inner()
 
 
 def create_start_neuron(brain: "Brain", encoded_input: Union[TensorLike, Sequence[float], float, int]) -> "Neuron":


### PR DESCRIPTION
## Summary
- ensure run_wanderer_training serializes training with a per-brain threading lock
- document that all training helpers reuse brain/graph instances under a shared lock
- mark thread-safety refactor and related tests as complete in the development plan

## Testing
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_selfattention_conv1d`

------
https://chatgpt.com/codex/tasks/task_e_68b4153c7004832793bb5c9bd507bdd5