### PR TITLE
Mark pending tests complete

### DIFF
--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -76,27 +76,27 @@ enforced strictly through `Lock` primitives.
 # Pending tests
 
 The following test modules still need to be run and outputs analyzed:
-- tests/test_new_wanderer_plugins.py
+- tests/test_new_wanderer_plugins.py [complete]
 - tests/test_parallel.py [complete]
-- tests/test_plugin_stacking.py
-- tests/test_quantumtype_plugin.py
-- tests/test_reporter.py
-- tests/test_reporter_clear.py
-- tests/test_reporter_subgroups.py
+- tests/test_plugin_stacking.py [complete]
+- tests/test_quantumtype_plugin.py [complete]
+- tests/test_reporter.py [complete]
+- tests/test_reporter_clear.py [complete]
+- tests/test_reporter_subgroups.py [complete]
 - tests/test_selfattention_conv1d.py [complete]
-- tests/test_super_advanced_neuron_plugins.py
-- tests/test_synapse_plugins.py
+- tests/test_super_advanced_neuron_plugins.py [complete]
+- tests/test_synapse_plugins.py [complete]
 - tests/test_training_with_datapairs.py [complete]
-- tests/test_triple_contrast_plugin.py
-- tests/test_ultra_brain_train_plugins.py
-- tests/test_ultra_neuron_plugins.py
-- tests/test_ultra_neuroplasticity_plugins.py
-- tests/test_ultra_selfattention_plugins.py
-- tests/test_ultra_synapse_plugins.py
-- tests/test_ultra_wanderer_plugins.py
-- tests/test_unfold_fold_unpool_improvement.py
-- tests/test_wanderer.py
-- tests/test_wanderer_alternate_paths_creator.py
-- tests/test_wanderer_bestpath_weights.py
-- tests/test_wanderer_walk_summary.py
-- tests/test_wanderer_wayfinder_plugin.py
+- tests/test_triple_contrast_plugin.py [complete]
+- tests/test_ultra_brain_train_plugins.py [complete]
+- tests/test_ultra_neuron_plugins.py [complete]
+- tests/test_ultra_neuroplasticity_plugins.py [complete]
+- tests/test_ultra_selfattention_plugins.py [complete]
+- tests/test_ultra_synapse_plugins.py [complete]
+- tests/test_ultra_wanderer_plugins.py [complete]
+- tests/test_unfold_fold_unpool_improvement.py [complete]
+- tests/test_wanderer.py [complete]
+- tests/test_wanderer_alternate_paths_creator.py [complete]
+- tests/test_wanderer_bestpath_weights.py [complete]
+- tests/test_wanderer_walk_summary.py [complete]
+- tests/test_wanderer_wayfinder_plugin.py [complete]


### PR DESCRIPTION
## Summary
- Marked all pending test modules in DOTHISFIRST.md as complete after running each individually

## Testing
- `python -m unittest -v tests.test_new_wanderer_plugins`
- `python -m unittest -v tests.test_plugin_stacking`
- `python -m unittest -v tests.test_quantumtype_plugin`
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_super_advanced_neuron_plugins`
- `python -m unittest -v tests.test_synapse_plugins`
- `python -m unittest -v tests.test_triple_contrast_plugin`
- `python -m unittest -v tests.test_ultra_brain_train_plugins`
- `python -m unittest -v tests.test_ultra_neuron_plugins`
- `python -m unittest -v tests.test_ultra_neuroplasticity_plugins`
- `python -m unittest -v tests.test_ultra_selfattention_plugins`
- `python -m unittest -v tests.test_ultra_synapse_plugins`
- `python -m unittest -v tests.test_ultra_wanderer_plugins`
- `python -m unittest -v tests.test_unfold_fold_unpool_improvement`
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_walk_summary`
- `python -m unittest -v tests.test_wanderer_wayfinder_plugin`
- `python -m unittest -v tests.test_parallel`
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_training_with_datapairs`


------
https://chatgpt.com/codex/tasks/task_e_68b416b69f0c8327895d9db85148530e