### PR TITLE
Expand self-attention with ten new routines

### DIFF
--- a/marble/graph.py
+++ b/marble/graph.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 
+import torch
+
 from .codec import TensorLike
 from .reporter import report
 
@@ -168,8 +170,12 @@ class Neuron(_DeviceHelper):
     def describe_for_selfattention(self) -> Dict[str, Any]:
         """Return core attributes for SelfAttention consumption."""
         pos = getattr(self, "position", None)
+        try:
+            weight = float(self.weight.detach().to("cpu").item())
+        except Exception:
+            weight = float(self.weight)
         return {
-            "weight": float(self.weight),
+            "weight": weight,
             "type_name": self.type_name,
             "position": pos,
         }

--- a/marble/plugins/selfattention_activation_boost_lr.py
+++ b/marble/plugins/selfattention_activation_boost_lr.py
@@ -1,0 +1,53 @@
+"""ActivationBoostLRRoutine increases learning rate when activations are low."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _act_boost_params(wanderer, threshold: float = 0.1, boost: float = 2.0):
+    return threshold, boost
+
+
+class ActivationBoostLRRoutine:
+    """Boost ``lr_override`` if avg activation < ``threshold``."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        thr_t, boost_t = _act_boost_params(wanderer)
+        try:
+            thr = float(thr_t.detach().to("cpu").item())
+        except Exception:
+            thr = 0.1
+        try:
+            boost = float(boost_t.detach().to("cpu").item())
+        except Exception:
+            boost = 2.0
+        acts: List[float] = []
+        for n in list(getattr(wanderer.brain, "neurons", {}).values()):
+            info = selfattention.get_neuron_report(n)
+            val = info.get("activation")
+            if val is not None:
+                try:
+                    acts.append(abs(float(val)))
+                except Exception:
+                    pass
+        if acts and sum(acts) / len(acts) < thr:
+            cur = float(selfattention.get_param("lr_override", 0.0) or 0.0)
+            selfattention.set_param("lr_override", cur * boost if cur else boost)
+            report("selfattention", "activation_boost_lr", {"step": step_index, "avg": sum(acts) / len(acts)}, "events")
+        return None
+
+
+__all__ = ["ActivationBoostLRRoutine"]

--- a/marble/plugins/selfattention_age_prune.py
+++ b/marble/plugins/selfattention_age_prune.py
@@ -1,0 +1,53 @@
+"""AgePruneRoutine cools temperature when old neurons dominate."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _age_prune_params(wanderer, max_age: float = 100.0, cool_temp: float = 0.2):
+    return max_age, cool_temp
+
+
+class AgePruneRoutine:
+    """Lower temperature if any neuron age exceeds ``max_age``."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        max_t, cool_t = _age_prune_params(wanderer)
+        try:
+            max_age = float(max_t.detach().to("cpu").item())
+        except Exception:
+            max_age = 100.0
+        try:
+            cool_temp = float(cool_t.detach().to("cpu").item())
+        except Exception:
+            cool_temp = 0.2
+        for n in list(getattr(wanderer.brain, "neurons", {}).values()):
+            info = selfattention.get_neuron_report(n)
+            try:
+                age = float(info.get("age", 0.0))
+            except Exception:
+                continue
+            if age > max_age:
+                try:
+                    selfattention.set_param("temperature", cool_temp)
+                except Exception:
+                    pass
+                report("selfattention", "age_prune", {"step": step_index, "age": age}, "events")
+                break
+        return None
+
+
+__all__ = ["AgePruneRoutine"]

--- a/marble/plugins/selfattention_loss_center_lr.py
+++ b/marble/plugins/selfattention_loss_center_lr.py
@@ -1,0 +1,51 @@
+"""LossCenterLRRoutine steers learning rate toward a target loss."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _loss_center_params(wanderer, target_loss: float = 0.1, scale: float = 0.5):
+    return target_loss, scale
+
+
+class LossCenterLRRoutine:
+    """Adjust ``lr_override`` based on distance from ``target_loss``."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        tl_t, sc_t = _loss_center_params(wanderer)
+        try:
+            target = float(tl_t.detach().to("cpu").item())
+        except Exception:
+            target = 0.1
+        try:
+            scale = float(sc_t.detach().to("cpu").item())
+        except Exception:
+            scale = 0.5
+        loss_tensor = ctx.get("cur_loss_tensor")
+        if loss_tensor is None:
+            return None
+        try:
+            cur = float(loss_tensor.detach().to("cpu").item())
+        except Exception:
+            return None
+        diff = abs(cur - target)
+        lr = float(selfattention.get_param("lr_override", 0.0) or 0.0)
+        selfattention.set_param("lr_override", lr + diff * scale if lr else diff * scale)
+        report("selfattention", "loss_center_lr", {"step": step_index, "diff": diff}, "events")
+        return None
+
+
+__all__ = ["LossCenterLRRoutine"]

--- a/marble/plugins/selfattention_loss_variance_temp.py
+++ b/marble/plugins/selfattention_loss_variance_temp.py
@@ -1,0 +1,56 @@
+"""LossVarianceTemperatureRoutine scales temperature by recent loss variance."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _loss_var_params(wanderer, window: float = 5.0, factor: float = 0.1):
+    return window, factor
+
+
+class LossVarianceTemperatureRoutine:
+    """Adjust temperature using variance of recent losses."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        w_t, f_t = _loss_var_params(wanderer)
+        try:
+            window = max(1, int(float(w_t.detach().to("cpu").item())))
+        except Exception:
+            window = 5
+        try:
+            factor = float(f_t.detach().to("cpu").item())
+        except Exception:
+            factor = 0.1
+        losses = []
+        for i in range(max(0, step_index - window), step_index):
+            try:
+                item = reporter_ro.item(f"step_{i}", "wanderer_steps", "logs")
+                if isinstance(item, dict) and ("current_loss" in item):
+                    losses.append(float(item["current_loss"]))
+            except Exception:
+                pass
+        if losses:
+            var = float(torch.var(torch.tensor(losses)).detach().to("cpu").item())
+            try:
+                base = float(selfattention.get_param("temperature", 1.0))
+                selfattention.set_param("temperature", base * (1.0 + factor * var))
+            except Exception:
+                pass
+            report("selfattention", "loss_variance_temp", {"step": step_index, "var": var}, "events")
+        return None
+
+
+__all__ = ["LossVarianceTemperatureRoutine"]

--- a/marble/plugins/selfattention_neuron_swap.py
+++ b/marble/plugins/selfattention_neuron_swap.py
@@ -1,0 +1,42 @@
+"""NeuronSwapRoutine swaps tensors of random neuron pairs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _swap_param(wanderer, swap_prob: float = 0.1):
+    return swap_prob
+
+
+class NeuronSwapRoutine:
+    """Randomly swap neuron tensors with probability ``swap_prob``."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        sp_t = _swap_param(wanderer)
+        try:
+            prob = float(sp_t.detach().to("cpu").item())
+        except Exception:
+            prob = 0.1
+        neurons = list(getattr(wanderer.brain, "neurons", {}).values())
+        if len(neurons) >= 2 and torch.rand(1).item() < prob:
+            idxs = torch.randint(0, len(neurons), (2,))
+            a, b = neurons[int(idxs[0])], neurons[int(idxs[1])]
+            a.tensor, b.tensor = b.tensor, a.tensor
+            report("selfattention", "neuron_swap", {"step": step_index}, "events")
+        return None
+
+
+__all__ = ["NeuronSwapRoutine"]

--- a/marble/plugins/selfattention_step_fader.py
+++ b/marble/plugins/selfattention_step_fader.py
@@ -1,0 +1,43 @@
+"""StepFaderRoutine gradually lowers temperature with every step."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _step_fader_params(wanderer, slope: float = 0.01):
+    return slope
+
+
+class StepFaderRoutine:
+    """Linearly decrease temperature by ``slope`` each step."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        s_t = _step_fader_params(wanderer)
+        try:
+            slope = float(s_t.detach().to("cpu").item())
+        except Exception:
+            slope = 0.01
+        try:
+            base = float(selfattention.get_param("temperature", 1.0))
+            new_temp = max(0.0, base - slope * float(step_index))
+            selfattention.set_param("temperature", new_temp)
+        except Exception:
+            new_temp = float("nan")
+        report("selfattention", "step_fader", {"step": step_index, "temp": new_temp}, "events")
+        return None
+
+
+__all__ = ["StepFaderRoutine"]

--- a/marble/plugins/selfattention_synapse_noise.py
+++ b/marble/plugins/selfattention_synapse_noise.py
@@ -1,0 +1,43 @@
+"""SynapseNoiseRoutine injects Gaussian noise into synapse weights."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _noise_param(wanderer, noise_std: float = 0.01):
+    return noise_std
+
+
+class SynapseNoiseRoutine:
+    """Add random noise with std ``noise_std`` to synapse weights."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        ns_t = _noise_param(wanderer)
+        try:
+            std = float(ns_t.detach().to("cpu").item())
+        except Exception:
+            std = 0.01
+        noise = torch.randn(1).item() * std
+        for syn in list(getattr(wanderer.brain, "synapses", [])):
+            w = getattr(syn, "weight", None)
+            if w is None:
+                continue
+            syn.weight = float(torch.tensor([float(w) + noise]).detach().to("cpu").item())
+        report("selfattention", "synapse_noise", {"step": step_index, "std": std}, "events")
+        return None
+
+
+__all__ = ["SynapseNoiseRoutine"]

--- a/marble/plugins/selfattention_synapse_renorm.py
+++ b/marble/plugins/selfattention_synapse_renorm.py
@@ -1,0 +1,48 @@
+"""SynapseRenormRoutine enforces a target weight norm on synapses."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _renorm_param(wanderer, target_norm: float = 1.0):
+    return target_norm
+
+
+class SynapseRenormRoutine:
+    """Renormalize synapse weights to ``target_norm`` L2 norm."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        tn_t = _renorm_param(wanderer)
+        try:
+            target = float(tn_t.detach().to("cpu").item())
+        except Exception:
+            target = 1.0
+        for syn in list(getattr(wanderer.brain, "synapses", [])):
+            w = getattr(syn, "weight", None)
+            if w is None:
+                continue
+            try:
+                wt = torch.tensor([float(w)], dtype=torch.float32)
+                norm = torch.norm(wt)
+                if norm > 0:
+                    syn.weight = float((wt / norm * target).detach().to("cpu").item())
+            except Exception:
+                pass
+        report("selfattention", "synapse_renorm", {"step": step_index}, "events")
+        return None
+
+
+__all__ = ["SynapseRenormRoutine"]

--- a/marble/plugins/selfattention_time_gate_temp.py
+++ b/marble/plugins/selfattention_time_gate_temp.py
@@ -1,0 +1,46 @@
+"""TimeGateTemperatureRoutine applies a gated temperature schedule."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _time_gate_params(wanderer, interval: float = 5.0, gated_temp: float = 0.5):
+    return interval, gated_temp
+
+
+class TimeGateTemperatureRoutine:
+    """Set temperature to ``gated_temp`` every ``interval`` steps."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        it_t, gt_t = _time_gate_params(wanderer)
+        try:
+            interval = max(1, int(float(it_t.detach().to("cpu").item())))
+        except Exception:
+            interval = 5
+        try:
+            gated_temp = float(gt_t.detach().to("cpu").item())
+        except Exception:
+            gated_temp = 0.5
+        if step_index % interval == 0:
+            try:
+                selfattention.set_param("temperature", gated_temp)
+            except Exception:
+                pass
+            report("selfattention", "time_gate_temp", {"step": step_index, "temp": gated_temp}, "events")
+        return None
+
+
+__all__ = ["TimeGateTemperatureRoutine"]

--- a/marble/plugins/selfattention_weight_decay.py
+++ b/marble/plugins/selfattention_weight_decay.py
@@ -1,0 +1,46 @@
+"""WeightDecayRoutine multiplies synapse weights by a decay factor."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+import torch
+
+from ..wanderer import expose_learnable_params
+from ..reporter import report
+
+
+@expose_learnable_params
+def _decay_param(wanderer, decay: float = 0.01):
+    return decay
+
+
+class WeightDecayRoutine:
+    """Apply ``decay`` to all synapse weights each step."""
+
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
+        d_t = _decay_param(wanderer)
+        try:
+            decay = float(d_t.detach().to("cpu").item())
+        except Exception:
+            decay = 0.01
+        for syn in list(getattr(wanderer.brain, "synapses", [])):
+            w = getattr(syn, "weight", None)
+            if w is None:
+                continue
+            try:
+                wt = torch.tensor([float(w)], dtype=torch.float32)
+                syn.weight = float((wt * (1.0 - decay)).detach().to("cpu").item())
+            except Exception:
+                pass
+        report("selfattention", "weight_decay", {"step": step_index, "decay": decay}, "events")
+        return None
+
+
+__all__ = ["WeightDecayRoutine"]

--- a/tests/test_more_selfattention_plugins.py
+++ b/tests/test_more_selfattention_plugins.py
@@ -1,0 +1,44 @@
+import unittest
+
+
+class MoreSelfAttentionPluginTests(unittest.TestCase):
+    def make_brain(self):
+        from marble.marblemain import Brain
+        b = Brain(1, size=2)
+        idxs = list(b.available_indices())
+        b.add_neuron(idxs[0], tensor=[0.0])
+        if len(idxs) > 1:
+            b.add_neuron(idxs[1], tensor=[0.0])
+            b.connect(idxs[0], idxs[1], direction="bi")
+        return b
+
+    def test_plugins_register_learnables(self):
+        from marble.marblemain import Wanderer, SelfAttention, attach_selfattention, REPORTER
+        REPORTER.clear_group("selfattention")
+        plugins = {
+            "step_fader": ["slope"],
+            "loss_variance_temp": ["window", "factor"],
+            "synapse_renorm": ["target_norm"],
+            "neuron_swap": ["swap_prob"],
+            "time_gate_temp": ["interval", "gated_temp"],
+            "age_prune": ["max_age", "cool_temp"],
+            "activation_boost_lr": ["threshold", "boost"],
+            "weight_decay": ["decay"],
+            "synapse_noise": ["noise_std"],
+            "loss_center_lr": ["target_loss", "scale"],
+        }
+        for name, params in plugins.items():
+            with self.subTest(name=name):
+                b = self.make_brain()
+                w = Wanderer(b, seed=1)
+                sa = SelfAttention(type_name=name)
+                attach_selfattention(w, sa)
+                w.walk(max_steps=1, lr=0.0)
+                learnables = getattr(w, "_learnables", {})
+                print("selfattention plugin", name, "learnables", list(learnables.keys()))
+                for p in params:
+                    self.assertIn(p, learnables)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add ten experimental self-attention routines exploring temperature schedules, synapse operations, loss-aware LR tweaks, and more
- fix neuron reporting to detach weights before scalar conversion
- cover new routines with registration test

## Testing
- `python - <<'PY'
import yaml, os, sys, re
from pathlib import Path
cfg_path = Path('3d_printer_sim/config.yaml')
if cfg_path.exists():
    data = yaml.safe_load(cfg_path.read_text()) or {}
    keys = []
    def rec(d, prefix=''):
        if isinstance(d, dict):
            for k, v in d.items():
                keys.append(prefix+k)
                rec(v, prefix+k+'.')
    rec(data)
    unused = []
    for k in keys:
        pattern = re.escape(k.split('.')[-1])
        found = False
        for path in Path('.').rglob('*.py'):
            if path == cfg_path:
                continue
            try:
                if re.search(pattern, path.read_text()):
                    found = True
                    break
            except Exception:
                pass
        if not found:
            unused.append(k)
    print('Unused keys:' if unused else 'All keys used')
    for k in unused:
        print(' ', k)
else:
    print('No config.yaml found')
PY`
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest -v tests.test_more_selfattention_plugins`

------
https://chatgpt.com/codex/tasks/task_e_68b418ec5df4832785b74eab3d074144