### PR TITLE
Enhance PhaseShift self-attention with reporter-driven decisions

### DIFF
--- a/marble/plugins/selfattention_phase_shift.py
+++ b/marble/plugins/selfattention_phase_shift.py
@@ -16,17 +16,63 @@ def _phase_param(wanderer, phase_shift: float = 0.0):
 class PhaseShiftRoutine:
     """Adjust temperature using a learnable phase shift."""
 
-    def after_step(self, selfattention: "SelfAttention", reporter_ro: Any, wanderer: "Wanderer", step_index: int, ctx: Dict[str, Any]):
+    def after_step(
+        self,
+        selfattention: "SelfAttention",
+        reporter_ro: Any,
+        wanderer: "Wanderer",
+        step_index: int,
+        ctx: Dict[str, Any],
+    ):
         ph_t = _phase_param(wanderer)
         try:
             ph = float(ph_t.detach().to("cpu").item())
         except Exception:
             ph = 0.0
+
+        # Gather reported state to ground decisions in self-attention context
         try:
-            selfattention.set_param("temperature", 1.0 + ph)
+            cur_loss = float(
+                ctx.get("cur_loss_tensor").detach().to("cpu").item()
+            )
         except Exception:
-            pass
-        report("selfattention", "phase_shift", {"step": step_index, "phase": ph}, "events")
+            cur_loss = None
+
+        prev_loss = None
+        try:
+            last = reporter_ro.item(
+                f"step_{max(1, step_index) - 1}", "wanderer_steps", "logs"
+            )
+            if isinstance(last, dict) and ("current_loss" in last):
+                prev_loss = float(last.get("current_loss"))
+        except Exception:
+            prev_loss = None
+
+        loss_speed = (
+            (cur_loss - prev_loss)
+            if cur_loss is not None and prev_loss is not None
+            else 0.0
+        )
+
+        neuron_count = int(len(getattr(wanderer.brain, "neurons", {})))
+        try:
+            new_temp = 1.0 + ph * (1.0 + loss_speed / max(1.0, float(neuron_count)))
+            selfattention.set_param("temperature", new_temp)
+        except Exception:
+            new_temp = float("nan")
+
+        report(
+            "selfattention",
+            "phase_shift",
+            {
+                "step": step_index,
+                "phase": ph,
+                "loss_speed": loss_speed,
+                "neuron_count": neuron_count,
+                "temperature": new_temp,
+            },
+            "events",
+        )
         return None
 
 

--- a/tests/test_selfattention_phase_shift.py
+++ b/tests/test_selfattention_phase_shift.py
@@ -1,0 +1,59 @@
+import unittest
+
+
+class PhaseShiftRoutineTests(unittest.TestCase):
+    def setUp(self):
+        from marble.marblemain import (
+            Brain,
+            Wanderer,
+            SelfAttention,
+            run_training_with_datapairs,
+            UniversalTensorCodec,
+            REPORTER,
+            clear_report_group,
+        )
+        from marble.plugins.selfattention_phase_shift import PhaseShiftRoutine
+
+        self.Brain = Brain
+        self.Wanderer = Wanderer
+        self.SelfAttention = SelfAttention
+        self.run_training_with_datapairs = run_training_with_datapairs
+        self.PhaseShiftRoutine = PhaseShiftRoutine
+        self.Codec = UniversalTensorCodec
+        self.reporter = REPORTER
+        self.clear = clear_report_group
+
+    def test_phase_shift_reports_metrics(self):
+        # ensure clean reporter state
+        self.clear("selfattention")
+
+        b = self.Brain(1, size=2)
+        idxs = list(b.available_indices())
+        b.add_neuron(idxs[0], tensor=[0.0])
+        if len(idxs) > 1:
+            b.add_neuron(idxs[1], tensor=[0.0])
+            b.connect(idxs[0], idxs[1], direction="bi")
+
+        sa = self.SelfAttention(routines=[self.PhaseShiftRoutine()])
+        codec = self.Codec()
+        datapairs = [(0, 0)]
+
+        res = self.run_training_with_datapairs(
+            b,
+            datapairs,
+            codec,
+            steps_per_pair=2,
+            lr=1e-2,
+            selfattention=sa,
+        )
+        # Access logged event and ensure reported metrics exist
+        events = self.reporter.group("selfattention", "events")
+        log = events.get("phase_shift")
+        print("phase_shift log", log)
+        self.assertIsInstance(log, dict)
+        for key in ("loss_speed", "neuron_count", "temperature"):
+            self.assertIn(key, log)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Ground `PhaseShiftRoutine` decisions in self-attention state, factoring in loss trends and model size when updating Wanderer temperature
- Log loss speed, neuron count and resulting temperature for auditing
- Add regression test ensuring metrics are reported during training

## Testing
- `python -m pytest tests/test_ultra_selfattention_plugins.py -s -q`
- `python -m pytest tests/test_selfattention_phase_shift.py -s -q`


------
https://chatgpt.com/codex/tasks/task_e_68b426958f8c83279425b7d3d08282ea