### PR TITLE
feat: extend selfattention metrics

### DIFF
--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -100,3 +100,17 @@ The following test modules still need to be run and outputs analyzed:
 - tests/test_wanderer_bestpath_weights.py [complete]
 - tests/test_wanderer_walk_summary.py [complete]
 - tests/test_wanderer_wayfinder_plugin.py [complete]
+
+# SelfAttention metrics integration
+
+## Goal
+Ensure all SelfAttention routines consume the full set of reported state metrics
+(`sa_loss`, `sa_loss_speed`, `sa_loss_accel`, `sa_model_complexity`) when making
+decisions.
+
+## Steps
+1. Audit existing selfattention plugins and list those not using `ctx` metrics.
+2. Update each plugin to adjust behaviour based on the metrics and log their
+   usage to `REPORTER`.
+3. Expand tests to cover metric-driven behaviour for every plugin.
+4. Document the available metrics and integration guidelines in `ARCHITECTURE.md`.

--- a/marble/plugins/selfattention_signal_booster.py
+++ b/marble/plugins/selfattention_signal_booster.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+import torch
+
 from ..wanderer import expose_learnable_params
 from ..reporter import report
 
@@ -19,15 +21,36 @@ class SignalBoosterRoutine:
     def after_step(self, selfattention: "SelfAttention", reporter_ro: Any, wanderer: "Wanderer", step_index: int, ctx: Dict[str, Any]):
         bg_t = _boost_param(wanderer)
         try:
-            gain = float(bg_t.detach().to("cpu").item())
+            gain_t = torch.tensor(bg_t.detach().to("cpu").item(), dtype=torch.float32)
         except Exception:
-            gain = 1.0
+            gain_t = torch.tensor(1.0)
+        loss = float(ctx.get("sa_loss", 0.0) or 0.0)
+        speed = float(ctx.get("sa_loss_speed", 0.0) or 0.0)
+        accel = float(ctx.get("sa_loss_accel", 0.0) or 0.0)
+        complexity = float(ctx.get("sa_model_complexity", 0.0) or 0.0)
+        gain_t = gain_t / (1.0 + torch.abs(torch.tensor(loss)))
+        gain_t = gain_t / (1.0 + torch.abs(torch.tensor(speed)))
+        gain_t = gain_t / (1.0 + torch.abs(torch.tensor(accel)))
+        gain_t = gain_t / (1.0 + torch.tensor(complexity))
+        gain = float(gain_t.detach().to("cpu").item())
         try:
             base = float(selfattention.get_param("temperature", 1.0))
             selfattention.set_param("temperature", base * gain)
         except Exception:
             pass
-        report("selfattention", "signal_booster", {"step": step_index, "gain": gain}, "events")
+        report(
+            "selfattention",
+            "signal_booster",
+            {
+                "step": step_index,
+                "gain": gain,
+                "loss": loss,
+                "speed": speed,
+                "accel": accel,
+                "complexity": complexity,
+            },
+            "events",
+        )
         return None
 
 


### PR DESCRIPTION
## Summary
- expand SelfAttention with loss acceleration and extra metric scaling
- make SignalBoosterRoutine react to loss, speed, acceleration, and model complexity
- document pending audit of all SelfAttention plugins

## Testing
- `python -m unittest -v tests.test_selfattention_conv1d`
- `python -m unittest -v tests.test_more_selfattention_plugins`
- `python -m unittest -v tests.test_advanced_selfattention_plugins`
- `python -m unittest -v tests.test_ultra_selfattention_plugins`
- `python -m unittest -v tests.test_learnable_params`
- `python -m unittest -v tests.test_findbestneurontype_fallback`
- `python -m unittest -v tests.test_learning_paradigm_helpers`


------
https://chatgpt.com/codex/tasks/task_e_68b4294231908327bf29b41999039924