### PR TITLE
Add diverse neuron tensor building blocks and integrate with dynamic builder

### DIFF
--- a/marble/plugins/buildingblock_abs_neuron_tensor.py
+++ b/marble/plugins/buildingblock_abs_neuron_tensor.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""BuildingBlock: take absolute value of a neuron's tensor."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class AbsNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int]):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.abs(neuron.tensor)
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [abs(float(v)) for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["AbsNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_dropout_neuron_tensor.py
+++ b/marble/plugins/buildingblock_dropout_neuron_tensor.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+"""BuildingBlock: apply dropout to a neuron's tensor."""
+
+import random
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class DropoutNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int], p: float = 0.5):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        prob = self._to_float(p)
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            mask = (torch.rand_like(neuron.tensor) > prob).to(neuron.tensor.dtype)
+            neuron.tensor = neuron.tensor * mask
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            mask = [1.0 if random.random() > prob else 0.0 for _ in tensor_list]
+            neuron.tensor = [float(v) * m for v, m in zip(tensor_list, mask)]
+        return neuron.tensor
+
+
+__all__ = ["DropoutNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_exp_neuron_tensor.py
+++ b/marble/plugins/buildingblock_exp_neuron_tensor.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""BuildingBlock: exponentiate a neuron's tensor."""
+
+import math
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class ExpNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int]):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.exp(neuron.tensor)
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [math.exp(float(v)) for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["ExpNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_log_neuron_tensor.py
+++ b/marble/plugins/buildingblock_log_neuron_tensor.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""BuildingBlock: apply logarithm to a neuron's tensor."""
+
+import math
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class LogNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int], epsilon: float = 1e-6):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        eps = self._to_float(epsilon)
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.log(torch.abs(neuron.tensor) + eps)
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [math.log(abs(float(v)) + eps) for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["LogNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_relu_neuron_tensor.py
+++ b/marble/plugins/buildingblock_relu_neuron_tensor.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""BuildingBlock: apply ReLU to a neuron's tensor."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class ReluNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int]):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.relu(neuron.tensor)
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [float(v) if float(v) > 0.0 else 0.0 for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["ReluNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_sigmoid_neuron_tensor.py
+++ b/marble/plugins/buildingblock_sigmoid_neuron_tensor.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""BuildingBlock: apply sigmoid to a neuron's tensor."""
+
+import math
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class SigmoidNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int]):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.sigmoid(neuron.tensor)
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [1.0 / (1.0 + math.exp(-float(v))) for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["SigmoidNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_softmax_neuron_tensor.py
+++ b/marble/plugins/buildingblock_softmax_neuron_tensor.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""BuildingBlock: apply softmax to a neuron's tensor."""
+
+import math
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class SoftmaxNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int], dim: int = 0):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        d = int(dim)
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.softmax(neuron.tensor, dim=d)
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            if torch is not None:
+                t = torch.tensor(tensor_list, device=self._device, dtype=torch.float32)
+                neuron.tensor = torch.softmax(t, dim=0).tolist()
+            else:
+                exps = [math.exp(float(v)) for v in tensor_list]
+                s = sum(exps)
+                neuron.tensor = [e / s for e in exps]
+        return neuron.tensor
+
+
+__all__ = ["SoftmaxNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_sqrt_neuron_tensor.py
+++ b/marble/plugins/buildingblock_sqrt_neuron_tensor.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""BuildingBlock: apply square root to a neuron's tensor."""
+
+import math
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class SqrtNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int]):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.sqrt(torch.abs(neuron.tensor))
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [math.sqrt(abs(float(v))) for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["SqrtNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_square_neuron_tensor.py
+++ b/marble/plugins/buildingblock_square_neuron_tensor.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+"""BuildingBlock: square each element of a neuron's tensor."""
+
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class SquareNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int]):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = neuron.tensor * neuron.tensor
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [float(v) * float(v) for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["SquareNeuronTensorPlugin"]

--- a/marble/plugins/buildingblock_tanh_neuron_tensor.py
+++ b/marble/plugins/buildingblock_tanh_neuron_tensor.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""BuildingBlock: apply tanh to a neuron's tensor."""
+
+import math
+from typing import Sequence
+
+from ..buildingblock import BuildingBlock
+from ..wanderer import expose_learnable_params
+
+
+class TanhNeuronTensorPlugin(BuildingBlock):
+    @expose_learnable_params
+    def apply(self, brain, index: Sequence[int]):
+        idx = self._to_index(brain, index)
+        neuron = brain.get_neuron(idx)
+        torch = self._torch
+        if neuron is None:
+            return None
+        if torch is not None and self._is_torch_tensor(neuron.tensor):
+            neuron.tensor = torch.tanh(neuron.tensor)
+        else:
+            tensor_list = neuron.tensor if isinstance(neuron.tensor, list) else list(neuron.tensor)
+            neuron.tensor = [math.tanh(float(v)) for v in tensor_list]
+        return neuron.tensor
+
+
+__all__ = ["TanhNeuronTensorPlugin"]

--- a/marble/plugins/wanderer_neuronbuilder.py
+++ b/marble/plugins/wanderer_neuronbuilder.py
@@ -27,6 +27,16 @@ _EXTRA_SPECS = {
     "clamp_neuron_tensor": {"min_val": -1.0, "max_val": 1.0},
     "reset_neuron_tensor": {},
     "shuffle_neuron_tensor": {},
+    "abs_neuron_tensor": {},
+    "square_neuron_tensor": {},
+    "sqrt_neuron_tensor": {},
+    "log_neuron_tensor": {"epsilon": 1e-6},
+    "exp_neuron_tensor": {},
+    "sigmoid_neuron_tensor": {},
+    "tanh_neuron_tensor": {},
+    "relu_neuron_tensor": {},
+    "softmax_neuron_tensor": {"dim": 0},
+    "dropout_neuron_tensor": {"p": 0.5},
 }
 
 

--- a/tests/test_dynamic_neuron_builder.py
+++ b/tests/test_dynamic_neuron_builder.py
@@ -12,15 +12,28 @@ class TestDynamicNeuronBuilder(unittest.TestCase):
         b.add_neuron((0,), tensor=[0.0])
         # plugin auto-registered under name "neuronbuilder"
         w = Wanderer(b, type_name="neuronbuilder")
-        w.ensure_learnable_param("dyn_use_reset_neuron_age", -10.0)
-        w.ensure_learnable_param("dyn_use_randomize_neuron_weight", -10.0)
-        w.ensure_learnable_param("dyn_use_randomize_neuron_bias", -10.0)
-        w.ensure_learnable_param("dyn_use_scale_neuron_tensor", -10.0)
-        w.ensure_learnable_param("dyn_use_normalize_neuron_tensor", -10.0)
-        w.ensure_learnable_param("dyn_use_noise_neuron_tensor", -10.0)
-        w.ensure_learnable_param("dyn_use_clamp_neuron_tensor", -10.0)
-        w.ensure_learnable_param("dyn_use_reset_neuron_tensor", -10.0)
-        w.ensure_learnable_param("dyn_use_shuffle_neuron_tensor", -10.0)
+        for name in [
+            "reset_neuron_age",
+            "randomize_neuron_weight",
+            "randomize_neuron_bias",
+            "scale_neuron_tensor",
+            "normalize_neuron_tensor",
+            "noise_neuron_tensor",
+            "clamp_neuron_tensor",
+            "reset_neuron_tensor",
+            "shuffle_neuron_tensor",
+            "abs_neuron_tensor",
+            "square_neuron_tensor",
+            "sqrt_neuron_tensor",
+            "log_neuron_tensor",
+            "exp_neuron_tensor",
+            "sigmoid_neuron_tensor",
+            "tanh_neuron_tensor",
+            "relu_neuron_tensor",
+            "softmax_neuron_tensor",
+            "dropout_neuron_tensor",
+        ]:
+            w.ensure_learnable_param(f"dyn_use_{name}", -10.0)
         w.ensure_learnable_param("dyn_shift_neuron_tensor_delta", 2.0)
         w.walk(max_steps=1)
         dyn = [n for n in _NEURON_TYPES.keys() if n.startswith("dyn_")]


### PR DESCRIPTION
## Summary
- add 10 new neuron tensor building blocks such as abs, square, log, sigmoid and more
- integrate the new blocks into DynamicNeuronBuilderPlugin for automatic attention-based usage
- expand tests for building blocks and dynamic builder

## Testing
- `python -m pytest tests/test_building_blocks.py -vv`
- `python -m pytest tests/test_dynamic_neuron_builder.py -vv`
- `python -m pytest tests/test_autoplugin_buildingblocks.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b43353113083278cecfe4dfc31909a