### PR TITLE
Enable Adam optimization for wanderer learnables

### DIFF
--- a/marble/plugins/wanderer_resource_allocator.py
+++ b/marble/plugins/wanderer_resource_allocator.py
@@ -108,6 +108,11 @@ class ResourceAllocatorPlugin:
         st.setdefault("resource_hits", {})
         st.setdefault("last_loss", None)
         st.setdefault("last_time", time.perf_counter())
+        before = set(getattr(wanderer, "_learnables", {}))
+        self._params(wanderer)
+        after = set(getattr(wanderer, "_learnables", {}))
+        for name in after - before:
+            wanderer.set_param_optimization(name, enabled=True)
 
     # Helper metrics -----------------------------------------------------
     def _system_metrics(self) -> dict:

--- a/tests/test_wanderer_resource_allocator.py
+++ b/tests/test_wanderer_resource_allocator.py
@@ -21,6 +21,22 @@ class TestResourceAllocatorPlugin(unittest.TestCase):
         print("param_count", len(params))
         self.assertGreaterEqual(len(params), 30)
 
+    def test_params_optimized_by_default(self):
+        b = self.Brain(1, size=(1,))
+        w = self.Wanderer(b)
+        plug = next(p for p in w._wplugins if p.__class__.__name__ == "ResourceAllocatorPlugin")
+        # Fetch one learnable param tensor
+        pname = next(iter(w._learnables))
+        t = w.get_learnable_param_tensor(pname)
+        torch = w._torch  # type: ignore[attr-defined]
+        before = t.clone()
+        loss = t.sum()
+        loss.backward()
+        w._update_learnables()
+        after = w.get_learnable_param_tensor(pname)
+        print("param_before_after", before.tolist(), after.tolist())
+        self.assertFalse(torch.equal(before, after))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- switch wanderer learnable parameter updates from SGD to Adam with per-parameter state
- auto-enable optimization for ResourceAllocatorPlugin parameters on init
- add regression test confirming allocator params update on backward pass

## Testing
- `python -m unittest -v tests.test_learnable_params`
- `python -m unittest -v tests.test_wanderer_resource_allocator`


------
https://chatgpt.com/codex/tasks/task_e_68b43e83880c8327b1cdf5fea029833e