### PR TITLE
Add numeric parameter auditing script

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,6 +11,25 @@ This project provides a single-file core library in `marble/marblemain.py` that 
 
 All imports are centralized in `marble/marblemain.py`; other files must not import.
 
+Helper and Analysis Tools
+
+- `count_numeric_parameters.py`: Static analysis helper that scans the
+  `marble/` package for function parameters with numeric defaults. It reports
+  how many of those parameters are automatically exposed via the
+  `@expose_learnable_params` decorator and how many remain fixed constants. Run
+  it from the repository root:
+
+  ```bash
+  $ python count_numeric_parameters.py
+  Total numeric parameters: 97
+  Learnable numeric parameters: 84
+  Non-learnable numeric parameters: 13
+  ```
+
+  This allows quick audits of the codebase as plugins evolve. The accompanying
+  test `tests/test_numeric_parameter_counter.py` ensures the script stays
+  in sync with the library.
+
 Core Components
 
 - `UniversalTensorCodec`: Serializes any Python object via pickle to bytes, builds a byte-level vocabulary, and encodes/decodes to integer token sequences. If PyTorch is available, returns tensors on CUDA when available, else CPU; otherwise returns Python lists. Supports `export_vocab`/`import_vocab` for reproducible vocabularies.

--- a/count_numeric_parameters.py
+++ b/count_numeric_parameters.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Count numeric parameters in function signatures across the repo.
+
+This script parses all Python files in the repository and reports how many
+function parameters with default numeric values exist. It also distinguishes
+between parameters that are exposed as learnable via the
+``@expose_learnable_params`` decorator and those that are not.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Tuple
+
+# Only analyse the core ``marble`` package. Tests and other helper scripts are
+# ignored so that counts reflect the library itself.
+REPO_ROOT = Path(__file__).parent
+TARGET_ROOT = REPO_ROOT / "marble"
+
+
+def is_numeric_constant(node: ast.expr) -> bool:
+    """Return True if *node* is an int or float constant."""
+    return isinstance(node, ast.Constant) and isinstance(node.value, (int, float))
+
+
+def has_expose_decorator(node: ast.FunctionDef) -> bool:
+    """Check if the function has an ``expose_learnable_params`` decorator."""
+    for dec in node.decorator_list:
+        if isinstance(dec, ast.Name) and dec.id == "expose_learnable_params":
+            return True
+        if isinstance(dec, ast.Attribute) and dec.attr == "expose_learnable_params":
+            return True
+    return False
+
+
+def count_file(path: Path) -> Tuple[int, int]:
+    """Count numeric parameters in *path*.
+
+    Returns a tuple ``(learnable, non_learnable)`` for this file.
+    """
+    with path.open("r", encoding="utf8") as f:
+        tree = ast.parse(f.read(), filename=str(path))
+
+    learnable = 0
+    non_learnable = 0
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            numeric_defaults = [
+                default
+                for default in node.args.defaults
+                if is_numeric_constant(default)
+            ]
+            if not numeric_defaults:
+                continue
+
+            if has_expose_decorator(node):
+                learnable += len(numeric_defaults)
+            else:
+                non_learnable += len(numeric_defaults)
+    return learnable, non_learnable
+
+
+def main() -> None:
+    learnable_total = 0
+    non_learnable_total = 0
+
+    for pyfile in TARGET_ROOT.rglob("*.py"):
+        lrn, non = count_file(pyfile)
+        learnable_total += lrn
+        non_learnable_total += non
+
+    total = learnable_total + non_learnable_total
+    print(f"Total numeric parameters: {total}")
+    print(f"Learnable numeric parameters: {learnable_total}")
+    print(f"Non-learnable numeric parameters: {non_learnable_total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_numeric_parameter_counter.py
+++ b/tests/test_numeric_parameter_counter.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+
+
+def test_numeric_parameter_counts():
+    proc = subprocess.run(
+        [sys.executable, 'count_numeric_parameters.py'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = proc.stdout
+    assert 'Total numeric parameters: 97' in out
+    assert 'Learnable numeric parameters: 84' in out
+    assert 'Non-learnable numeric parameters: 13' in out


### PR DESCRIPTION
## Summary
- add `count_numeric_parameters.py` to audit numeric parameters and learnable defaults in the `marble` package
- document the tool and provide usage example in `ARCHITECTURE.md`
- add regression test for the parameter counting script

## Testing
- `python -m pytest tests/test_numeric_parameter_counter.py::test_numeric_parameter_counts -q`
- `python -m pytest tests/test_learnable_params.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b442c8bacc8327b159733825e1ff4c