### PR TITLE
feat: enumerate marlin configuration items

### DIFF
--- a/3d_printer_sim/developmentplan.md
+++ b/3d_printer_sim/developmentplan.md
@@ -130,7 +130,7 @@ Step 9: Advanced Physics and Failure Modes
         Subsubstep 9.11.7: Account for belt tension, frame rigidity, and stepper calibration on final print fidelity
 
 Step 10: Comprehensive Marlin Configuration Coverage
-    Substep 10.1: Parse Marlin Configuration.h and Configuration_adv.h to enumerate all configuration items
+    Substep 10.1: Parse Marlin Configuration.h and Configuration_adv.h to enumerate all configuration items [complete]
     Substep 10.2: Implement each configuration item in the simulator respecting physical behavior
         Subsubstep 10.2.1: CONFIGURATION_H_VERSION
         Subsubstep 10.2.2: STRING_CONFIG_H_AUTHOR

--- a/3d_printer_sim/marlin_analysis.md
+++ b/3d_printer_sim/marlin_analysis.md
@@ -15,3 +15,10 @@ Marlin organizes hardware support under `src/HAL/`, providing separate directori
 - Maximum print area derived from bed sizes and axis limits.
 - Extruder count set by `EXTRUDERS` and related advanced options.
 These settings must be mirrored in the simulator's configuration system.
+
+## Configuration Enumeration Tool
+
+To ensure comprehensive coverage, ``marlin_config_parser.py`` downloads
+Marlin's ``Configuration.h`` and ``Configuration_adv.h`` and extracts all
+``#define`` identifiers. This script keeps the simulator's development
+plan aligned with upstream firmware options.

--- a/3d_printer_sim/marlin_config_parser.py
+++ b/3d_printer_sim/marlin_config_parser.py
@@ -1,0 +1,49 @@
+"""Utility to enumerate configuration items from Marlin's default
+Configuration.h and Configuration_adv.h files.
+
+The parser downloads the two configuration headers from the Marlin
+repository and extracts all ``#define`` identifiers. This helps keep the
+simulator's configuration coverage in sync with upstream firmware.
+
+Only the Python standard library is used so the module remains
+self-contained within ``3d_printer_sim``.
+"""
+from __future__ import annotations
+
+import re
+import urllib.request
+from typing import Iterable, List
+
+MARLIN_BASE = (
+    "https://raw.githubusercontent.com/MarlinFirmware/Marlin/2.1.x/Marlin"
+)
+FILES = ("Configuration.h", "Configuration_adv.h")
+
+
+def fetch_marlin_files(filenames: Iterable[str]) -> List[str]:
+    """Download Marlin configuration files and return their contents."""
+    contents: List[str] = []
+    for name in filenames:
+        url = f"{MARLIN_BASE}/{name}"
+        with urllib.request.urlopen(url) as resp:  # nosec: B310 - controlled URL
+            contents.append(resp.read().decode("utf-8", errors="ignore"))
+    return contents
+
+
+def parse_config_items(text: str) -> List[str]:
+    """Return all ``#define`` identifiers found in *text*."""
+    pattern = re.compile(r"^\s*#define\s+(\w+)", re.MULTILINE)
+    return [m.group(1) for m in pattern.finditer(text)]
+
+
+def enumerate_config_items() -> List[str]:
+    """Enumerate all configuration items from Marlin's default headers."""
+    items: set[str] = set()
+    for text in fetch_marlin_files(FILES):
+        items.update(parse_config_items(text))
+    return sorted(items)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    for name in enumerate_config_items():
+        print(name)

--- a/tests/test_marlin_config_parser.py
+++ b/tests/test_marlin_config_parser.py
@@ -1,0 +1,36 @@
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+spec = importlib.util.spec_from_file_location(
+    "marlin_config_parser", pathlib.Path("3d_printer_sim/marlin_config_parser.py")
+)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+parse_config_items = module.parse_config_items
+enumerate_config_items = module.enumerate_config_items
+
+
+class TestMarlinConfigParser(unittest.TestCase):
+    def test_parse_config_items(self) -> None:
+        sample = """
+#define FOO 1
+#define BAR
+    #define BAZ 3
+"""
+        self.assertEqual(parse_config_items(sample), ["FOO", "BAR", "BAZ"])
+        print("parsed items:", parse_config_items(sample))
+
+    def test_enumerate_config_items_with_mock(self) -> None:
+        module.fetch_marlin_files = lambda files: ["#define ALPHA 1\n", "#define BETA 2\n"]
+        items = enumerate_config_items()
+        self.assertEqual(items, ["ALPHA", "BETA"])
+        print("enumerated items:", items)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `marlin_config_parser` to pull Marlin Configuration headers and list all `#define` parameters
- document parser in `marlin_analysis.md` and mark development plan step 10.1 complete
- cover parser behaviour with unit tests

## Testing
- `python -m unittest -v tests.test_marlin_config_parser`


------
https://chatgpt.com/codex/tasks/task_e_68b4782e41408327a0647409410b102a