### PR TITLE
feat: add image caching for HF image quality example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "numpy",
   "tqdm",
   "kuzu",
+  "Pillow",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- cache images in `run_hf_image_quality` to avoid redundant downloads
- expose cache size via `cache_size` argument and add Pillow dependency

## Testing
- `python -m py_compile examples/run_hf_image_quality.py`
- `pip install Pillow`
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest -v tests.test_epochs.TestEpochs.test_epochs_over_pairs` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b52ee9e7c08327988628e74a82ead2