### PR TITLE
Use tqdm.auto for adaptive progress bars

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,4 +6,5 @@
 - Keep tqdm progress lines visible when training via `run_training_with_datapairs`:
   - Added `Wanderer.pbar_leave` public attribute (default False).
   - The datapair and wanderer-training helpers set `w.pbar_leave = True` so the status line isn’t suppressed.
-  - Added `Wanderer.pbar_verbose` to emit explicit per-walk start/end messages; enabled by both helpers.
+ - Added `Wanderer.pbar_verbose` to emit explicit per-walk start/end messages; enabled by both helpers.
+- Switch progress reporting to use `tqdm.auto` for robust notebook and terminal updates.

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -104,11 +104,7 @@ _NEURO_TYPES = NEURO_TYPES_REGISTRY
 
 def _tqdm_factory():
     try:
-        from IPython import get_ipython  # type: ignore
-        if get_ipython() is not None:  # pragma: no cover - runtime check
-            from tqdm.notebook import tqdm  # type: ignore
-        else:  # pragma: no cover
-            from tqdm import tqdm  # type: ignore
+        from tqdm.auto import tqdm  # type: ignore
     except Exception:  # pragma: no cover
         from tqdm import tqdm  # type: ignore
     return tqdm


### PR DESCRIPTION
## Summary
- fix Wanderer progress bar selection to rely on `tqdm.auto`
- note change in changelog

## Testing
- `python -m pytest tests/test_wanderer.py -q`
- `python -m pytest tests/test_training_with_datapairs.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b543e2a89c8327ad638208e812a135