### PR TITLE
Add brain status tracking and training metrics

### DIFF
--- a/marble/training.py
+++ b/marble/training.py
@@ -294,8 +294,14 @@ def run_training_with_datapairs(
                 out = _merge_dict_safe(out, extra)
             except Exception:
                 pass
+        status = getattr(brain, "status", lambda: {})()
+        out["status"] = status
         try:
             report("training", "datapair_summary", {"count": count, "final_loss": final_loss}, "datapair")
+        except Exception:
+            pass
+        try:
+            report("training", "status", status, "datapair")
         except Exception:
             pass
         return out

--- a/tests/test_brain_status.py
+++ b/tests/test_brain_status.py
@@ -1,0 +1,36 @@
+import unittest
+
+class TestBrainStatus(unittest.TestCase):
+    def setUp(self):
+        from marble.reporter import clear_report_group
+        clear_report_group("brain")
+        clear_report_group("training")
+        from marble.marblemain import Brain, UniversalTensorCodec, make_datapair, run_training_with_datapairs
+        self.Brain = Brain
+        self.Codec = UniversalTensorCodec
+        self.make_dp = make_datapair
+        self.train = run_training_with_datapairs
+
+    def test_brain_status_counts(self):
+        b = self.Brain(2)
+        b.add_neuron((0, 0))
+        b.add_neuron((1, 1))
+        b.connect((0, 0), (1, 1))
+        b.remove_neuron(b.get_neuron((1, 1)))
+        status = b.status()
+        print("brain status:", status)
+        self.assertIn("neurons_added", status)
+        self.assertGreaterEqual(status["neurons_added"], 2)
+        self.assertGreaterEqual(status["synapses_added"], 1)
+
+    def test_training_status(self):
+        b = self.Brain(2)
+        codec = self.Codec()
+        pairs = [self.make_dp(0.0, 0.0)]
+        res = self.train(b, pairs, codec, steps_per_pair=1, lr=1e-3)
+        print("training status:", res.get("status"))
+        self.assertIn("status", res)
+        self.assertIn("plugins_active", res["status"])
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- track neuron and synapse mutations on the Brain and expose a rich status snapshot including CUDA and plugin stats
- propagate Brain status from run_training_with_datapairs to training results and reporter
- add tests for brain and training status reporting

## Testing
- `python -m unittest -v tests.test_brain_status`
- `python -m unittest -v tests.test_training_with_datapairs`
- `python -m unittest -v tests.test_graph`


------
https://chatgpt.com/codex/tasks/task_e_68b545ef4ef48327904dc5a917c291f9