### PR TITLE
Fix status display updating and show new counters

### DIFF
--- a/tests/test_brain_status.py
+++ b/tests/test_brain_status.py
@@ -31,6 +31,9 @@ class TestBrainStatus(unittest.TestCase):
         print("training status:", res.get("status"))
         self.assertIn("status", res)
         self.assertIn("plugins_active", res["status"])
+        # ensure new counters are exposed through training status
+        self.assertIn("neurons_added", res["status"])
+        self.assertGreaterEqual(res["status"]["neurons_added"], 1)
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- use `tqdm.notebook` inside IPython to avoid newline spam in progress bars
- expose brain status counters like neurons/synapses added and pruned directly in the progress bar
- verify training helper surfaces new status counters

## Testing
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python tests/test_brain_status.py -q`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python tests/test_wanderer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54862fad08327b20197e8e322a4c0