### PR TITLE
fix reporter dict merge for status updates

### DIFF
--- a/marble/reporter.py
+++ b/marble/reporter.py
@@ -50,7 +50,13 @@ class Reporter:
     def _set_item(self, group_path: Tuple[str, ...], itemname: str, value: Any) -> None:
         with self._lock:
             node = self._ensure_group_path(group_path)
-            node["_items"][str(itemname)] = value
+            key = str(itemname)
+            existing = node["_items"].get(key)
+            if isinstance(existing, dict) and isinstance(value, dict):
+                # merge dictionaries in place instead of replacing
+                existing.update(value)
+            else:
+                node["_items"][key] = value
 
     def get_item(self, group_path: Tuple[str, ...], itemname: str) -> Any:
         with self._lock:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -29,6 +29,16 @@ class TestReporter(unittest.TestCase):
         print("reporter debug msg:", val)
         self.assertEqual(val, {"a": 1})
 
+    def test_dict_merge(self):
+        r = self.reporter
+        r.registergroup("stats")
+        r.item["status", "stats"] = {"a": 1}
+        # second set should merge rather than replace
+        r.item["status", "stats"] = {"b": 2}
+        merged = r.group("stats")["status"]
+        print("reporter merged status:", merged)
+        self.assertEqual(merged, {"a": 1, "b": 2})
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- merge dict values in reporter instead of replacing to ensure status updates accumulate
- test reporter dict merge behavior

## Testing
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_brain_status`


------
https://chatgpt.com/codex/tasks/task_e_68b54acfe644832788ed356d00d41b60