### PR TITLE
Use single-line tqdm progress

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,7 +125,7 @@ Core Components
   Change 2025-09-01: The lock-based datapair helper in `marble.training` now accepts `train_type` and applies brain-train plugin hooks (`on_init`/`on_end`) mirroring the extended helper in `marble.marblemain`. It also applies any enabled learning paradigms to the active `Wanderer` for consistent behavior across both entry points.
   Additionally, visible progress: `Wanderer` exposes public attributes to control progress behavior:
   - `pbar_leave`: controls tqdm's `leave` option. Both `run_training_with_datapairs` and `run_wanderer_training` set this to `True` so progress lines remain after completion.
-  - `pbar_verbose`: when `True`, emits explicit per-walk boundary messages using `tqdm.write` ("... walks: start" / "... walks: end (loss=..., steps=...)"). Helpers enable this to provide per-walk output alongside per-step progress.
+  - `pbar_verbose`: when `True`, emits explicit per-walk boundary messages using `tqdm.write` ("... walks: start" / "... walks: end (loss=..., steps=...)"). Helpers leave this disabled so the progress bar stays on a single updating line; enable manually if the extra messages are desired.
   SelfAttention can manage both via `get_param`/`set_param` on the owner Wanderer.
 
 - Reporter: Global `REPORTER` instance to record structured data. Convenience functions `report`, `report_group`, `report_dir`, and `clear_report_group` provide ergonomic logging, querying, and cleanup. Tests and core flows record key metrics and events for auditability.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,6 @@
 
 - Keep tqdm progress lines visible when training via `run_training_with_datapairs`:
   - Added `Wanderer.pbar_leave` public attribute (default False).
-  - The datapair and wanderer-training helpers set `w.pbar_leave = True` so the status line isn’t suppressed.
- - Added `Wanderer.pbar_verbose` to emit explicit per-walk start/end messages; enabled by both helpers.
-- Switch progress reporting to use `tqdm.auto` for robust notebook and terminal updates.
+- The datapair and wanderer-training helpers set `w.pbar_leave = True` so the status line isn’t suppressed.
+ - Added `Wanderer.pbar_verbose` to emit explicit per-walk start/end messages; helpers now leave it disabled so progress remains on a single line.
+ - Progress reporting uses `tqdm.auto` for robust notebook and terminal updates.

--- a/marble/training.py
+++ b/marble/training.py
@@ -52,7 +52,6 @@ def run_wanderer_training(
         )
         try:
             setattr(w, "pbar_leave", True)
-            setattr(w, "pbar_verbose", True)
         except Exception:
             pass
         history: List[Dict[str, Any]] = []
@@ -210,10 +209,9 @@ def run_training_with_datapairs(
             optimizer=optimizer,
             mixedprecision=mixedprecision,
         )
-        # Ensure progress bars remain visible and emit walk boundary lines under this helper
+        # Ensure progress bars remain visible for the datapair helper
         try:
             setattr(w, "pbar_leave", True)
-            setattr(w, "pbar_verbose", True)
         except Exception:
             pass
         if selfattention is not None:

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -103,17 +103,16 @@ _NEURO_TYPES = NEURO_TYPES_REGISTRY
 
 
 def _tqdm_factory():
-    try:
-        # Prefer notebook widget when running inside IPython to avoid
-        # newline spam from the plain tqdm variant.
-        from IPython import get_ipython  # type: ignore
-        ip = get_ipython()
-        if ip is not None and getattr(ip, "kernel", None) is not None:
-            from tqdm.notebook import tqdm  # type: ignore
-        else:  # pragma: no cover - fallback path
-            from tqdm import tqdm  # type: ignore
-    except Exception:  # pragma: no cover - minimal environments
-        from tqdm import tqdm  # type: ignore
+    """Return a tqdm variant suited for the current environment.
+
+    ``tqdm.auto`` automatically picks ``tqdm.notebook`` when running inside
+    IPython notebooks and falls back to the standard tqdm otherwise. This
+    keeps progress reporting to a single updating line regardless of the
+    front end.
+    """
+
+    from tqdm.auto import tqdm  # type: ignore
+
     return tqdm
 
 
@@ -539,11 +538,11 @@ class Wanderer(_DeviceHelper):
                     loss_speed=f"{loss_speed:.4f}",
                     mean_loss_speed=f"{mean_loss_speed:.4f}",
                     neurons=cur_size,
-                    neurons_added=status.get("neurons_added"),
+                    neurons_added=status.get("neurons_added", 0),
                     synapses=len(getattr(self.brain, "synapses", [])),
-                    synapses_added=status.get("synapses_added"),
-                    neurons_pruned=status.get("neurons_pruned"),
-                    synapses_pruned=status.get("synapses_pruned"),
+                    synapses_added=status.get("synapses_added", 0),
+                    neurons_pruned=status.get("neurons_pruned", 0),
+                    synapses_pruned=status.get("synapses_pruned", 0),
                     paths=len(getattr(self.brain, "synapses", [])),
                     speed=f"{mean_speed:.2f}",
                 )


### PR DESCRIPTION
## Summary
- use `tqdm.auto` in Wanderer so progress uses notebook-aware single-line bars
- keep datapair and wanderer helpers quiet by default and always show neurons/synapses added/pruned in postfix
- document that helpers leave `pbar_verbose` disabled

## Testing
- `python count_numeric_parameters.py`
- `pytest tests/test_wanderer_helper_and_synapse.py -q`
- `pytest tests/test_lobe_training.py -q`
- `pytest tests/test_batch_training_plugin.py -q`
- `pytest tests/test_selfattention_phase_shift.py -q`
- `pytest tests/test_brain_status.py -q`
- `pytest tests/test_neuroplasticity.py -q`
- `pytest tests/test_learning_paradigm.py -q`
- `pytest tests/test_training_with_datapairs.py -q`
- `pytest tests/test_selfattention_conv1d.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b54d53b72083279cd9797eeb5e76f4