### PR TITLE
feat: add aggressive neuroplasticity options

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -31,6 +31,7 @@ import marble.plugins  # ensure plugin discovery
 from marble.plugins.selfattention_adaptive_grad_clip import AdaptiveGradClipRoutine
 from marble.plugins.selfattention_findbestneurontype import FindBestNeuronTypeRoutine
 from marble.plugins.selfattention_noise_profiler import ContextAwareNoiseRoutine
+from marble.dashboard import start_dashboard
 
 
 class QualityAwareRoutine:
@@ -208,8 +209,14 @@ def main(epochs: int = 1) -> None:
         "rl_gamma": 0.95,
         "l2_lambda": 1e-4,
         "batch_size": 5,
+        "aggressive_starting_neuroplasticity": True,
+        "add_min_new_neurons_per_step": 5,
+        "aggressive_phase_steps": 100,
     }
     cache = _ImageEncodingLRUCache(max_items=cache_size, enabled=cache_enabled)
+    port = 8501
+    start_dashboard(port)
+    print(f"Dashboard available at https://alpaca-model-easily.ngrok-free.app:{port}")
 
     def _start_neuron(left: Dict[str, Any], br):
         # Compose a compact input using the cached image encoding whenever available
@@ -246,6 +253,7 @@ def main(epochs: int = 1) -> None:
             streaming=True,
             batch_size=5,
             left_to_start=_start_neuron,
+            dashboard=True,
         )
     print("streamed quality training complete")
 

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -1,0 +1,10 @@
+# YAML Manual
+
+## Neuroplasticity Training Parameters
+
+- aggressive_starting_neuroplasticity (bool, default: false)
+  Enables an initial phase where a minimum number of neurons is added at each training step.
+- add_min_new_neurons_per_step (int)
+  Required when aggressive_starting_neuroplasticity is true. Minimum neurons to grow per step during the aggressive phase.
+- aggressive_phase_steps (int)
+  Required when aggressive_starting_neuroplasticity is true. Number of steps to keep aggressive growth before reverting to normal behaviour.


### PR DESCRIPTION
## Summary
- allow an aggressive neuroplasticity phase with min neurons per step
- document new neuroplasticity config in yaml-manual
- enable dashboard and aggressive phase in HF image quality example

## Testing
- `python -m unittest -v tests.test_neuroplasticity`
- `python -m unittest -v tests.test_training_with_datapairs`


------
https://chatgpt.com/codex/tasks/task_e_68b555681c488327a9ceb4c8c56d88d3