### PR TITLE
Fix Streamlit dashboard loading loop

### DIFF
--- a/marble/dashboard.py
+++ b/marble/dashboard.py
@@ -149,13 +149,15 @@ def main() -> None:
 
     st.title("Marble Training Dashboard")
     placeholder = st.empty()
-    while True:
-        try:
-            data = json.loads(_METRICS_FILE.read_text())
-        except Exception:
-            data = {}
-        placeholder.json(data)
-        time.sleep(1.0)
+
+    try:
+        data = json.loads(_METRICS_FILE.read_text())
+    except Exception:
+        data = {}
+
+    placeholder.json(data)
+    time.sleep(1.0)
+    st.experimental_rerun()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Avoid infinite loop in dashboard Streamlit app; run once then rerun to keep UI responsive.

## Testing
- `python - <<'PY' ...` (config scan) 
- `pytest tests/test_reporter.py`

------
https://chatgpt.com/codex/tasks/task_e_68b559c827c0832782bbe284580614bb