### PR TITLE
Enable per-event AutoPlugin logging and dynamic brain config

### DIFF
--- a/tests/test_autoplugin_logging.py
+++ b/tests/test_autoplugin_logging.py
@@ -17,8 +17,10 @@ class TestAutoPluginLogging(unittest.TestCase):
         n = b.add_neuron(idx, tensor=[1.0], type_name="autoneuron")
         w = Wanderer(b, type_name="autoplugin_logger", neuroplasticity_type="base", seed=0)
         auto = next(p for p in w._wplugins if isinstance(p, AutoPlugin))
-        for _ in range(4):
-            w.walk(max_steps=20, start=n, lr=0.01)
+        w.walk(max_steps=20, start=n, lr=0.01)
+        with open(tmp.name, "r", encoding="utf-8") as fh:
+            pre_data = fh.read()
+        self.assertTrue(pre_data.strip())
         auto.finalize_logs(w)
         with open(tmp.name, "r", encoding="utf-8") as fh:
             data = fh.read()


### PR DESCRIPTION
## Summary
- Open AutoPlugin log files for each event so training logs are viewable live
- Allow Brain formulas when grid size is dynamic and gate neuron insertion accordingly
- Update HF image quality example to infer brain dimensions from its formula, use dynamic size, and enable AutoPlugin logging

## Testing
- `python count_numeric_parameters.py`
- `pytest tests/test_autoplugin_logging.py`
- `pytest tests/test_autoplugin_buildingblocks.py`
- `pytest tests/test_autoplugin_exclude.py`
- `pytest tests/test_autoplugin_bias.py`
- `pytest tests/test_brain_status.py`
- `pytest tests/test_training_with_datapairs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b55f2f40c08327a09fa771921a8111