### PR TITLE
Track per-neuron loss differences

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2025-09-01
+- Track per-neuron loss differences with rolling history and mean value.
 - Add support for `train_type` kwarg to `marble.training.run_training_with_datapairs` to match `marble.marblemain` API.
 - Wire Brain-train plugin lifecycle (`on_init`/`on_end`) and merge returned summaries.
 - Apply learning paradigms to the Wanderer in the lock-based datapair helper for consistent behavior.

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -492,6 +492,10 @@ class Wanderer(_DeviceHelper):
             cur_loss = float(step_loss_t.detach().to("cpu").item())
             prev_loss = step_metrics[-1]["loss"] if step_metrics else None
             delta = cur_loss - prev_loss if prev_loss is not None else 0.0
+            try:
+                current.record_loss_diff(delta)
+            except Exception:
+                pass
 
             now = time.time()
             dt = None

--- a/tests/test_neuron_loss_diff_tracking.py
+++ b/tests/test_neuron_loss_diff_tracking.py
@@ -1,0 +1,38 @@
+import unittest
+import torch
+
+
+class TestNeuronLossDiffTracking(unittest.TestCase):
+    def test_loss_diff_recording(self):
+        torch.manual_seed(0)
+        from marble.marblemain import Brain, Wanderer
+
+        brain = Brain(1)
+        n1 = brain.add_neuron((0,), tensor=1.0)
+        n2 = brain.add_neuron((1,), tensor=0.0, weight=2.0)
+        brain.connect(n1.position, n2.position)
+
+        w = Wanderer(brain, seed=0)
+        w.walk(max_steps=2, start=n1, lr=0.01)
+
+        print("n1 loss diffs:", list(n1.loss_diffs), "mean:", n1.mean_loss_diff)
+        print("n2 loss diffs:", list(n2.loss_diffs), "mean:", n2.mean_loss_diff)
+        self.assertEqual(list(n1.loss_diffs), [0.0])
+        self.assertAlmostEqual(n1.mean_loss_diff, 0.0, places=6)
+        self.assertEqual(list(n2.loss_diffs), [3.0])
+        self.assertAlmostEqual(n2.mean_loss_diff, 3.0, places=6)
+
+    def test_loss_diff_window(self):
+        from marble.marblemain import Neuron
+
+        n = Neuron(0.0, loss_diff_window=2)
+        n.record_loss_diff(1.0)
+        n.record_loss_diff(2.0)
+        n.record_loss_diff(3.0)
+        print("history after diffs:", list(n.loss_diffs), "mean:", n.mean_loss_diff)
+        self.assertEqual(list(n.loss_diffs), [2.0, 3.0])
+        self.assertAlmostEqual(n.mean_loss_diff, 2.5, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- track rolling loss difference history for each neuron and expose mean loss difference
- record per-step loss deltas during wanderer walks
- add tests verifying loss history and windowing

## Testing
- `python -m unittest tests.test_neuron_loss_diff_tracking -v`
- `python -m unittest tests.test_graph -v`


------
https://chatgpt.com/codex/tasks/task_e_68b575bc72948327b0b5037bd0d3dc74