### PR TITLE
Implement loss-based neuron pruning

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -816,6 +816,8 @@ class Brain:
     - kuzu_path: optional filename for a Kuzu graph database mirroring the brain
     - learn_all_numeric_parameters: when True, numeric defaults in subsequently
       imported modules are auto-exposed as learnable parameters
+    - prune_hit_count: number of times a neuron must exceed walk mean loss difference
+      before it is pruned
 
     The brain maintains a discrete occupancy grid; neurons/synapses must be placed
     at indices that are inside this shape.
@@ -839,6 +841,7 @@ class Brain:
         snapshot_keep: Optional[int] = None,
         kuzu_path: Optional[str] = None,
         learn_all_numeric_parameters: bool = False,
+        prune_hit_count: int = 2,
     ) -> None:
         if n < 1:
             raise ValueError("n must be >= 1")
@@ -863,6 +866,8 @@ class Brain:
         self.neurons_pruned = 0
         self.synapses_added = 0
         self.synapses_pruned = 0
+        self.prune_hit_count = int(prune_hit_count)
+        self._prune_marks: Dict[Neuron, int] = {}
 
         if self.mode == "grid":
             self.dynamic = size is None

--- a/tests/test_neuron_pruning_mechanism.py
+++ b/tests/test_neuron_pruning_mechanism.py
@@ -1,0 +1,31 @@
+import unittest
+import types
+import torch
+
+from marble.marblemain import Brain, Wanderer
+
+
+class TestNeuronPruningMechanism(unittest.TestCase):
+    def test_prune_after_two_hits(self) -> None:
+        b = Brain(1, mode="sparse", sparse_bounds=((0.0, None),))
+        n1 = b.add_neuron((0.0,), tensor=[0.0])
+        n2 = b.add_neuron((1.0,), tensor=[0.0])
+        b.connect((0.0,), (1.0,), direction="uni")
+        b.connect((1.0,), (0.0,), direction="uni")
+
+        def no_record(self, diff: float) -> None:
+            pass
+
+        n1.record_loss_diff = types.MethodType(no_record, n1)
+        n1.mean_loss_diff = 10.0
+
+        w = Wanderer(b, seed=123)
+        w._compute_loss = lambda outputs, override_loss=None: torch.tensor(0.0)
+        stats = w.walk(max_steps=4, lr=1e-2, start=n1)
+        print("pruning walk stats:", stats)
+        self.assertEqual(b.neurons_pruned, 1)
+        self.assertNotIn(n1, b.neurons.values())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- track pruning marks and configurable hit threshold in `Brain`
- prune neurons when their mean loss difference repeatedly exceeds walk average
- add regression test for new pruning behavior

## Testing
- `pytest tests/test_neuron_pruning_mechanism.py -q`
- `pytest tests/test_neuron_loss_diff_tracking.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5798475a48327a755aedcc1e06849