### PR TITLE
avoid torch use in dashboard

### DIFF
--- a/marble/dashboard.py
+++ b/marble/dashboard.py
@@ -44,15 +44,13 @@ def update_metrics(
     mean_loss: float,
     loss_speed: float,
     mean_loss_speed: float,
+    *,
+    cuda_available: bool,
+    available_plugins: int,
+    neuron_types_available: int,
 ) -> None:
     """Write latest training metrics to the shared metrics file."""
     global _plugin_actions
-    try:
-        from .graph import _NEURON_TYPES
-        from .wanderer import WANDERER_TYPES_REGISTRY, NEURO_TYPES_REGISTRY
-        import torch
-    except Exception:
-        return
 
     plugin_names = [p.__class__.__name__ for p in getattr(wanderer, "_wplugins", []) or []]
     plugin_names += [p.__class__.__name__ for p in getattr(wanderer, "_neuro_plugins", []) or []]
@@ -62,7 +60,6 @@ def update_metrics(
     most_active = max(_plugin_actions.items(), key=lambda x: x[1])[0] if _plugin_actions else None
 
     active_plugins = len(plugin_names)
-    available_plugins = len(WANDERER_TYPES_REGISTRY) + len(NEURO_TYPES_REGISTRY)
 
     used_neuron_types = {
         getattr(n, "type_name", None)
@@ -70,7 +67,6 @@ def update_metrics(
         if getattr(n, "type_name", None)
     }
     neuron_types_used = len(used_neuron_types)
-    neuron_types_available = len(_NEURON_TYPES)
 
     paths = len(getattr(brain, "synapses", []))
 
@@ -97,7 +93,7 @@ def update_metrics(
         "neurons_removed": int(getattr(brain, "neurons_pruned", 0)),
         "synapses_added": int(getattr(brain, "synapses_added", 0)),
         "synapses_removed": int(getattr(brain, "synapses_pruned", 0)),
-        "cuda": bool(torch.cuda.is_available()),
+        "cuda": bool(cuda_available),
         "last_snapshot_time": snapshot_time,
         "last_snapshot_size_mb": snapshot_size,
     }

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -10,7 +10,7 @@ import random
 import contextlib
 import inspect
 
-from .graph import _DeviceHelper, Neuron, Synapse
+from .graph import _DeviceHelper, Neuron, Synapse, _NEURON_TYPES
 from .lobe import Lobe
 from .reporter import report
 from .learnable_param import LearnableParam
@@ -545,7 +545,20 @@ class Wanderer(_DeviceHelper):
             try:
                 from .dashboard import update_metrics, dashboard_active
                 if dashboard_active():
-                    update_metrics(self.brain, self, steps, max_steps, cur_loss, mean_loss, loss_speed, mean_loss_speed)
+                    import torch
+                    update_metrics(
+                        self.brain,
+                        self,
+                        steps,
+                        max_steps,
+                        cur_loss,
+                        mean_loss,
+                        loss_speed,
+                        mean_loss_speed,
+                        cuda_available=torch.cuda.is_available(),
+                        available_plugins=len(WANDERER_TYPES_REGISTRY) + len(NEURO_TYPES_REGISTRY),
+                        neuron_types_available=len(_NEURON_TYPES),
+                    )
             except Exception:
                 pass
             cur_size, cap = (0, None)


### PR DESCRIPTION
## Summary
- pass CUDA and plugin info from Wanderer instead of importing torch inside dashboard
- update Wanderer to compute metrics and supply them to the dashboard writer

## Testing
- `pytest tests/test_wanderer.py`
- `pytest tests/test_training_with_datapairs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b57b1d07008327a4236800090c0927