### PR TITLE
feat: limit disk usage for resource allocator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,2 @@
+resource_allocator:
+  max_disk_mb: 20480  # maximum MB for disk offload (20 GB)

--- a/tests/test_resource_allocator_disk_limit.py
+++ b/tests/test_resource_allocator_disk_limit.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+import torch
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from marble.plugins.wanderer_resource_allocator import ResourceAllocatorPlugin
+
+
+class ResourceAllocatorDiskLimitTests(unittest.TestCase):
+    def test_disk_limit_blocks_offload(self) -> None:
+        plug = ResourceAllocatorPlugin()
+        plug.max_disk_mb = 0.0
+        obj = types.SimpleNamespace()
+        obj.weight = torch.ones(4)
+
+        module = __import__("marble.plugins.wanderer_resource_allocator", fromlist=['psutil'])
+        module.psutil = types.SimpleNamespace(virtual_memory=lambda: types.SimpleNamespace(available=0))
+
+        orig_to = torch.Tensor.to
+
+        def fake_to(self, *args, **kwargs):
+            device = args[0] if args else kwargs.get("device")
+            if device == "cuda":
+                raise torch.cuda.OutOfMemoryError("CUDA OOM")
+            return orig_to(self, *args, **kwargs)
+
+        with patch.object(torch.Tensor, "to", fake_to):
+            plug._safe_transfer(obj, "weight", obj.weight, "cuda")
+
+        self.assertFalse(isinstance(getattr(obj, "_weight_offload", None), str))
+        self.assertEqual(obj.weight.numel(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -8,3 +8,9 @@
   Required when aggressive_starting_neuroplasticity is true. Minimum neurons to grow per step during the aggressive phase.
 - aggressive_phase_steps (int)
   Required when aggressive_starting_neuroplasticity is true. Number of steps to keep aggressive growth before reverting to normal behaviour.
+
+## Resource Allocator Settings
+
+- resource_allocator.max_disk_mb (int, default: 20480)
+  Limits total size in MB of tensors offloaded to disk by the resource allocator.
+  Must be positive. When exceeded, tensors are cleared instead of offloaded.


### PR DESCRIPTION
## Summary
- add `resource_allocator.max_disk_mb` setting (default 20GB)
- enforce disk budget in `ResourceAllocatorPlugin`
- document and test disk offload limit

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest -v tests.test_resource_allocator_vram_overflow`
- `python -m unittest -v tests.test_resource_allocator_disk_limit`


------
https://chatgpt.com/codex/tasks/task_e_68b5807124748327924201d75398ec83