### PR TITLE
Warn when HF training processes no datapairs

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -251,7 +251,7 @@ def main(epochs: int = 1) -> None:
 
     for _ in range(int(epochs)):
         pairs = _sample_pairs(ds, codec, cache)
-        run_training_with_datapairs(
+        res = run_training_with_datapairs(
             brain,
             pairs,
             codec,
@@ -266,6 +266,10 @@ def main(epochs: int = 1) -> None:
             left_to_start=_start_neuron,
             dashboard=True,
         )
+        cnt = res.get("count", 0)
+        print(f"processed datapairs: {cnt}")
+        if cnt == 0:
+            raise RuntimeError("run_training_with_datapairs returned count=0")
     print("streamed quality training complete")
 
 


### PR DESCRIPTION
## Summary
- log the number of datapairs processed in `run_hf_image_quality.py`
- raise an error if `run_training_with_datapairs` returns a zero count

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `pytest tests/test_training_with_datapairs.py -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68b585b157848327b8e6999b45ff23cb