### PR TITLE
feat: lazy HF dataset image fetching

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -193,7 +193,7 @@ Hugging Face Integration
   - `"memory_full"`: materialize the entire dataset in memory,
   - `"memory_full_lazy_images"`: full materialization with image URLs,
   - `"disk_full_lazy_image"`: full materialization on disk with image URLs.
-  It returns an `HFStreamingDatasetWrapper` that yields `HFEncodedExample` objects and exposes an image-cache for on-demand downloads.
+  Image fields are detected via dataset features and stored as download URLs; when a field is accessed, the image is fetched, encoded with `UniversalTensorCodec`, cached, and inserted into the sample. The function returns an `HFStreamingDatasetWrapper` that yields `HFEncodedExample` objects and exposes an image-cache for on-demand downloads.
   - Auto-encoding policy: Accessing any field from an `HFEncodedExample` automatically encodes the value using `UniversalTensorCodec` and returns a tensor/list matching the codec’s device policy (CUDA when available, else CPU).
   - Raw access: `HFEncodedExample.get_raw(key)` retrieves the underlying unencoded value; `HFStreamingDatasetWrapper.raw()` returns the original datasets object.
   - Reporting: Dataset loads are logged under `huggingface/dataset`, including `{path, name, split, streaming}`. Each encoded field access reports `{field, tokens}`.

--- a/tests/test_hf_lazy_image_loading.py
+++ b/tests/test_hf_lazy_image_loading.py
@@ -1,0 +1,63 @@
+import base64
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+import marble.hf_utils as hf_utils
+
+
+class Image:
+    pass
+
+
+class DummyDataset:
+    def __init__(self, path):
+        self.features = {"image": Image()}
+        self._path = path
+
+    def __iter__(self):
+        yield {"image": {"url": self._path}}
+
+
+class DummyDSModule:
+    def __init__(self, path):
+        self._path = path
+
+    def load_dataset(self, **kwargs):
+        return DummyDataset(self._path)
+
+
+class HFLazyImageLoadingTest(unittest.TestCase):
+    def test_lazy_image_download_and_encode(self):
+        png_bytes = base64.b64decode(
+            b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/wIAAgMBgE9TkwAAAABJRU5ErkJggg=="
+        )
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".png") as tmp:
+            tmp.write(png_bytes)
+            path = tmp.name
+        dummy_mod = DummyDSModule(path)
+        with mock.patch.object(
+            hf_utils.HFStreamingDatasetWrapper,
+            "_download_image",
+            autospec=True,
+            wraps=hf_utils.HFStreamingDatasetWrapper._download_image,
+        ) as dl_mock:
+            with mock.patch.object(hf_utils, "_ensure_hf_imports", return_value=(None, dummy_mod)):
+                wrapper = hf_utils.load_hf_streaming_dataset("dummy", streaming="memory_lazy_images")
+            sample = next(iter(wrapper))
+            self.assertEqual(dl_mock.call_count, 0)
+            self.assertEqual(sample.get_raw("image"), path)
+            encoded = sample["image"]
+            self.assertEqual(dl_mock.call_count, 1)
+            self.assertNotIsInstance(encoded, str)
+            decoded = wrapper._codec.decode(encoded)
+            with open(path, "rb") as f:
+                self.assertEqual(decoded, f.read())
+            self.assertNotIsInstance(sample.get_raw("image"), str)
+        os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- detect image fields in Hugging Face datasets and store image URLs instead of image objects
- lazily download and encode images on field access, caching the encoded tensors
- document lazy image behavior and add tests

## Testing
- `python -m unittest -v tests.test_hf_lazy_image_loading`
- `python -m unittest -v tests.test_hf_utils_download_config`


------
https://chatgpt.com/codex/tasks/task_e_68b5a2a6c8e083279771ae4a4fed3e02