### PR TITLE
Add tensor tracking context manager for custom allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # _marble
+
+## Tracking custom tensors
+
+The resource allocator plugin can juggle not only graph tensors but also any
+custom buffers you allocate in your scripts. Wrap assignments in
+`track_tensor` so the allocator can offload them when VRAM gets tight.
+
+```python
+from marble.plugins import wanderer_resource_allocator as resource_allocator
+import torch
+
+class Holder:
+    buf: torch.Tensor | None = None
+
+holder = Holder()
+with resource_allocator.track_tensor(holder, "buf"):
+    holder.buf = torch.zeros(
+        1024, device="cuda" if torch.cuda.is_available() else "cpu"
+    )
+```
+
+After the context exits the buffer is registered and may be moved between GPU,
+CPU or even disk automatically.

--- a/examples/run_wine_hello.py
+++ b/examples/run_wine_hello.py
@@ -1,7 +1,20 @@
 from marble.marblemain import run_wine_hello_world
+from marble.plugins import wanderer_resource_allocator as resource_allocator
+import torch
 
 
 def main():
+    # Demonstrate tracking a custom tensor so the resource allocator can move
+    # it between devices when needed.
+    class _Buf:
+        buf = None
+
+    holder = _Buf()
+    with resource_allocator.track_tensor(holder, "buf"):
+        holder.buf = torch.zeros(
+            128, device="cuda" if torch.cuda.is_available() else "cpu"
+        )
+
     res = run_wine_hello_world(
         log_path="wanderer_steps.jsonl",
         num_pairs=50,

--- a/marble/hf_utils.py
+++ b/marble/hf_utils.py
@@ -75,11 +75,13 @@ class _ImageEncodingLRUCache:
     def put(self, key: str, value: Any) -> None:
         if not self.enabled:
             return
-        if key in self._od:
-            self._od.pop(key)
-        self._od[key] = value
-        while len(self._od) > max(0, self.max_items):
-            self._od.popitem(last=False)
+        from .plugins import wanderer_resource_allocator as resource_allocator
+        with resource_allocator.track_tensor(self._od, key):
+            if key in self._od:
+                self._od.pop(key)
+            self._od[key] = value
+            while len(self._od) > max(0, self.max_items):
+                self._od.popitem(last=False)
 
     def get_or_encode(self, obj: Any, codec) -> Tuple[str, Any]:
         key = self._make_key(obj)


### PR DESCRIPTION
## Summary
- add `track_tensor` context manager to resource allocator plugin to register new tensors and handle mapping keys
- use `track_tensor` when caching encoded images via `_ImageEncodingLRUCache`
- document usage and show example of wrapping custom GPU allocations

## Testing
- `pytest tests/test_wanderer_resource_allocator.py -q`
- `pytest tests/test_resource_allocator_vram_overflow.py -q`
- `pytest tests/test_resource_allocator_disk_limit.py -q`
- `pytest tests/test_hf_utils_download_config.py -q`
- `pytest tests/test_hf_lazy_image_loading.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b0076ca0832784730b858fe0b308