### PR TITLE
track learnable param tensors

### DIFF
--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -1072,8 +1072,11 @@ class Wanderer(_DeviceHelper):
             min_value=min_value,
             max_value=max_value,
         )
-        self._learnables[name] = lp
-        self._plugin_state.setdefault("learnable_params", {})[name] = t
+        from .plugins.wanderer_resource_allocator import track_tensor as _tt
+        state = self._plugin_state.setdefault("learnable_params", {})
+        with _tt(lp, "tensor"):
+            self._learnables[name] = lp
+        state[name] = t
         try:
             report("wanderer", "ensure_learnable", {"name": name}, "builder")
         except Exception:


### PR DESCRIPTION
## Summary
- ensure Wanderer's learnable parameters get registered with `track_tensor` so resource allocator can offload them when needed

## Testing
- `pytest tests/test_resource_allocator_disk_limit.py::ResourceAllocatorDiskLimitTests::test_disk_limit_blocks_offload -q`
- `pytest tests/test_resource_allocator_vram_overflow.py::ResourceAllocatorOOMTests::test_cuda_oom_triggers_disk_offload -q`
- `PYTHONPATH=. pytest tests/test_learnable_params.py::LearnableParamTests::test_global_learnables_and_decorator -q`
- `PYTHONPATH=. pytest tests/test_learnable_params.py::AutoParamLearningTests::test_auto_learn_all_numeric_parameters -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b45d9b7c8327864190381a32b5f7