### PR TITLE
Optimize UniversalTensorCodec with sequence compression

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,7 +58,7 @@ Helper and Analysis Tools
 
 Core Components
 
-- `UniversalTensorCodec`: Serializes any Python object via pickle to bytes, builds a byte-level vocabulary, and encodes/decodes to integer token sequences. If PyTorch is available, returns tensors on CUDA when available, else CPU; otherwise returns Python lists. Supports `export_vocab`/`import_vocab` for reproducible vocabularies.
+- `UniversalTensorCodec`: Serializes any Python object via pickle to bytes and compresses repeating byte sequences with an on-the-fly dictionary (LZW-style) so that each repeated sequence maps to a single token. If PyTorch is available, returns tensors on CUDA when available, else CPU; otherwise returns Python lists. Supports `export_vocab`/`import_vocab` for reproducible vocabularies.
 
 - `DataPair` + helpers: Lightweight container for two arbitrary Python objects with dependency-injected codec. Helpers: `make_datapair`, `encode_datapair`, `decode_datapair`. All encode/decode events are logged under reporter group `datapair/events`.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 2025-09-01
+- Compress repeating byte sequences in `UniversalTensorCodec` via on-the-fly
+  dictionary to reduce token counts and VRAM usage.
 - Track per-neuron loss differences with rolling history and mean value.
 - Add support for `train_type` kwarg to `marble.training.run_training_with_datapairs` to match `marble.marblemain` API.
 - Wire Brain-train plugin lifecycle (`on_init`/`on_end`) and merge returned summaries.

--- a/marblemain_snapshot.txt
+++ b/marblemain_snapshot.txt
@@ -7,7 +7,8 @@ Rules respected:
 
 Design:
 - Uses pickle to serialize arbitrary Python objects to bytes.
-- Builds a byte-level vocabulary on the fly (observed bytes -> token ids).
+- Compresses repeating byte sequences with an on-the-fly dictionary
+  (LZW-style) so each sequence maps to a single token id.
 - Encodes to a 1D tensor of integer token ids. If torch is available, returns
   a CPU LongTensor; otherwise returns a plain Python list of ints.
 - Vocabulary can be exported/imported to/from a JSON file.
@@ -28,9 +29,9 @@ TensorLike = Union[List[int], "_TorchTensor"]
 
 class UniversalTensorCodec:
     def __init__(self) -> None:
-        # Vocab maps bytes<0..255> to token ids and back.
-        self._byte_to_token: Dict[int, int] = {}
-        self._token_to_byte: List[int] = []
+        # Vocab maps byte sequences to token ids and back.
+        self._seq_to_token: Dict[bytes, int] = {}
+        self._token_to_seq: List[bytes] = []
 
         # Lazy torch detection
         self._torch = self._try_import_torch()
@@ -38,11 +39,12 @@ class UniversalTensorCodec:
 
     # --- Public API ---
     def reset_vocab(self) -> None:
-        self._byte_to_token.clear()
-        self._token_to_byte.clear()
+        self._seq_to_token.clear()
+        self._token_to_seq.clear()
+        self._ensure_base_vocab()
 
     def vocab_size(self) -> int:
-        return len(self._token_to_byte)
+        return len(self._token_to_seq)
 
     def encode(self, obj: Any) -> TensorLike:
         data = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
@@ -69,7 +71,7 @@ class UniversalTensorCodec:
         return obj
 
     def export_vocab(self, path: str) -> None:
-        payload = {"token_to_byte": self._token_to_byte}
+        payload = {"token_to_seq": [list(seq) for seq in self._token_to_seq]}
         with open(path, "w", encoding="utf-8") as f:
             json.dump(payload, f)
         try:
@@ -80,30 +82,50 @@ class UniversalTensorCodec:
     def import_vocab(self, path: str) -> None:
         with open(path, "r", encoding="utf-8") as f:
             payload = json.load(f)
-        token_to_byte = payload.get("token_to_byte")
-        if not isinstance(token_to_byte, list) or not all(
-            isinstance(x, int) and 0 <= x <= 255 for x in token_to_byte
+        token_to_seq = payload.get("token_to_seq")
+        if not isinstance(token_to_seq, list) or not all(
+            isinstance(seq, list) and all(isinstance(x, int) and 0 <= x <= 255 for x in seq)
+            for seq in token_to_seq
         ):
             raise ValueError("Invalid vocabulary file format")
-        self._token_to_byte = list(token_to_byte)
-        self._byte_to_token = {b: i for i, b in enumerate(self._token_to_byte)}
+        self._token_to_seq = [bytes(seq) for seq in token_to_seq]
+        self._seq_to_token = {seq: i for i, seq in enumerate(self._token_to_seq)}
         try:
             report("codec", "import_vocab", {"path": path, "size": self.vocab_size()}, "io")
         except Exception:
             pass
 
     # --- Internal helpers ---
+    def _ensure_base_vocab(self) -> None:
+        if not self._token_to_seq:
+            for i in range(256):
+                seq = bytes([i])
+                self._seq_to_token[seq] = i
+                self._token_to_seq.append(seq)
+
     def _bytes_to_tokens(self, data: bytes) -> List[int]:
-        # Extend vocab on the fly for new bytes
-        for b in data:
-            if b not in self._byte_to_token:
-                self._byte_to_token[b] = len(self._token_to_byte)
-                self._token_to_byte.append(b)
-        return [self._byte_to_token[b] for b in data]
+        self._ensure_base_vocab()
+        dict_ = self._seq_to_token
+        tokens: List[int] = []
+        if not data:
+            return tokens
+        w = bytes([data[0]])
+        for b in data[1:]:
+            c = bytes([b])
+            wc = w + c
+            if wc in dict_:
+                w = wc
+            else:
+                tokens.append(dict_[w])
+                dict_[wc] = len(self._token_to_seq)
+                self._token_to_seq.append(wc)
+                w = c
+        tokens.append(dict_[w])
+        return tokens
 
     def _tokens_to_bytes(self, tokens: Iterable[int]) -> bytes:
         try:
-            return bytes(self._token_to_byte[t] for t in tokens)
+            return b"".join(self._token_to_seq[t] for t in tokens)
         except (IndexError, TypeError) as e:
             raise ValueError("Token id out of range for current vocabulary") from e
 

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-
+import pickle
 
 class CustomThing:
     def __init__(self, x):
@@ -66,6 +66,18 @@ class TestUniversalTensorCodec(unittest.TestCase):
         finally:
             if out_path.exists():
                 os.remove(out_path)
+
+    def test_repeating_sequence_compression(self):
+        codec = self.Codec()
+        data = b"A" * 100
+        raw_len = len(pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL))
+        tokens = codec.encode(data)
+        try:
+            tok_len = int(tokens.numel()) if hasattr(tokens, "numel") else len(tokens)
+        except Exception:
+            tok_len = -1
+        print("compression lens:", tok_len, raw_len)
+        self.assertLess(tok_len, raw_len)
 
     def test_package_import(self):
         # Ensure the package is importable and only marblemain has imports


### PR DESCRIPTION
## Summary
- Compress repeating byte sequences with an on-the-fly dictionary (LZW-style) in UniversalTensorCodec
- Document new codec behaviour and log entry in CHANGELOG
- Add test covering repeated-sequence compression and fix missing imports

## Testing
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_datapair`


------
https://chatgpt.com/codex/tasks/task_e_68b5b7c5ba508327985dbcf7bb541dec