### PR TITLE
feat: enhance resource allocator efficiency

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,3 @@
 resource_allocator:
   max_disk_mb: 20480  # maximum MB for disk offload (20 GB)
+  compress_offload: true  # store offloaded tensors in float16

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -14,3 +14,6 @@
 - resource_allocator.max_disk_mb (int, default: 20480)
   Limits total size in MB of tensors offloaded to disk by the resource allocator.
   Must be positive. When exceeded, tensors are cleared instead of offloaded.
+- resource_allocator.compress_offload (bool, default: true)
+  When true, tensors moved to CPU or disk are converted to ``float16`` to save
+  space. They are restored to their original dtype when reloaded.


### PR DESCRIPTION
## Summary
- track tensor access frequency for smarter GPU/CPU decisions
- add async transfers, compression, and memory-mapped disk offload to resource allocator
- document new `compress_offload` setting

## Testing
- `python -m pytest tests/test_resource_allocator_disk_limit.py -q`
- `python -m pytest tests/test_wanderer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c0586dac8327af1b1caccca403a6