### PR TITLE
feat: optional pre-forward path for Wanderer

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2025-09-19
+- Added optional CPU pre-forward pass for `Wanderer` via `pre_forward=True`,
+  recording CPU compute and GPU transfer times to help tune VRAM usage.
 2025-09-01
 - Compress repeating byte sequences in `UniversalTensorCodec` via on-the-fly
   dictionary to reduce token counts and VRAM usage.

--- a/tests/test_wanderer_pre_forward.py
+++ b/tests/test_wanderer_pre_forward.py
@@ -1,0 +1,22 @@
+import unittest
+
+
+class TestWandererPreForward(unittest.TestCase):
+    def test_pre_forward_option_measures_transfer(self):
+        from marble.marblemain import Brain, Wanderer
+        b = Brain(2, size=(4, 4))
+        it = iter(b.available_indices())
+        i1 = next(it)
+        i2 = next(it)
+        n1 = b.add_neuron(i1, tensor=0.0)
+        b.add_neuron(i2, tensor=0.0)
+        b.connect(i1, i2, direction="uni")
+        w = Wanderer(b, pre_forward=True)
+        w.walk(max_steps=1, start=n1, lr=1e-2)
+        print("pre_forward times:", w._last_pre_forward_time, w._last_transfer_time)
+        self.assertTrue(w.pre_forward)
+        self.assertGreaterEqual(w._last_transfer_time, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add `pre_forward` flag to Wanderer to optionally run a CPU pre-pass and measure CPU/GPU transfer overhead
- log CPU compute and transfer times for tuning
- cover pre-forward option with a new test and document in changelog

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `PYTHONPATH=. python tests/test_wanderer_pre_forward.py`
- `PYTHONPATH=. python tests/test_wanderer_walk_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5d12d1204832795e86b771bdc7ba9