### PR TITLE
Add disk usage guard to resource allocator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,3 +3,4 @@ resource_allocator:
   compress_offload: true  # store offloaded tensors in float16
   min_gpu_tensor_mb: 1.0  # tensors smaller than this stay on CPU
   ram_offload_threshold: 0.9  # offload tensors to disk when RAM usage exceeds this ratio
+  disk_usage_threshold: 0.95  # stop offloading when disk usage exceeds this ratio

--- a/marble/plugins/wanderer_resource_allocator.py
+++ b/marble/plugins/wanderer_resource_allocator.py
@@ -156,6 +156,7 @@ class ResourceAllocatorPlugin:
         self.compress_offload = bool(cfg.get("compress_offload", True))
         self.min_gpu_tensor_mb = float(cfg.get("min_gpu_tensor_mb", 1.0))
         self.ram_offload_threshold = float(cfg.get("ram_offload_threshold", 0.9))
+        self.disk_usage_threshold = float(cfg.get("disk_usage_threshold", 0.95))
         self._disk_used_mb = 0.0
         self._rebalance_thread: threading.Thread | None = None
         self._rebalance_stop = threading.Event()
@@ -498,6 +499,7 @@ class ResourceAllocatorPlugin:
             elif (
                 sysm["ram"] > self.ram_offload_threshold
                 and self._disk_used_mb < self.max_disk_mb
+                and sysm["disk"] < self.disk_usage_threshold
                 and score < -move_thr
             ):
                 target_device = "disk"

--- a/tests/test_resource_allocator_disk_usage.py
+++ b/tests/test_resource_allocator_disk_usage.py
@@ -1,0 +1,53 @@
+import os
+import types
+import importlib
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from marble.plugins.wanderer_resource_allocator import (
+    ResourceAllocatorPlugin,
+    TENSOR_REGISTRY,
+)
+
+
+class ResourceAllocatorDiskUsageTests(unittest.TestCase):
+    def test_disk_usage_blocks_offload(self) -> None:
+        plug = ResourceAllocatorPlugin()
+        plug.ram_offload_threshold = 0.0
+        plug.disk_usage_threshold = 0.5
+        class Holder:
+            pass
+        obj = Holder()
+        obj.weight = torch.ones(10_000_000)
+        TENSOR_REGISTRY.register(obj, "weight")
+        module = importlib.import_module("marble.plugins.wanderer_resource_allocator")
+        module.psutil = types.SimpleNamespace(
+            virtual_memory=lambda: types.SimpleNamespace(percent=99, available=10**9),
+            disk_usage=lambda _path: types.SimpleNamespace(percent=99),
+            cpu_percent=lambda: 0,
+        )
+        class DummyW:
+            def __init__(self):
+                self._plugin_state = {"resource_hits": {}}
+                self._learnables = {}
+            def ensure_learnable_param(self, name, init):
+                self._learnables[name] = torch.tensor(init)
+            def get_learnable_param_tensor(self, name):
+                return self._learnables[name]
+            def _compute_loss(self, outputs):
+                return torch.tensor(0.0)
+            _walk_ctx = types.SimpleNamespace(outputs=[])
+        w = DummyW()
+        with patch("torch.cuda.is_available", return_value=False):
+            plug.rebalance_all(w)
+        off_attr = getattr(obj, "_weight_offload", None)
+        print("offload attr", off_attr)
+        self.assertIsNone(off_attr)
+        print("tensor size", obj.weight.numel())
+        self.assertGreater(obj.weight.numel(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -23,3 +23,6 @@
 - resource_allocator.ram_offload_threshold (float, default: 0.9)
   RAM usage ratio beyond which rarely accessed tensors are proactively
   offloaded to disk. Value must be between 0 and 1.
+- resource_allocator.disk_usage_threshold (float, default: 0.95)
+  Maximum allowed disk usage ratio before tensors are offloaded. Prevents disk
+  exhaustion; value must be between 0 and 1.


### PR DESCRIPTION
## Summary
- avoid disk offloading when overall disk usage is high
- expose `disk_usage_threshold` in config and docs for the resource allocator
- test that disk pressure prevents offload

## Testing
- `python -m unittest -v tests.test_resource_allocator_disk_limit`
- `python -m unittest -v tests.test_resource_allocator_ram_pressure`
- `python -m unittest -v tests.test_resource_allocator_disk_usage`


------
https://chatgpt.com/codex/tasks/task_e_68b683b57a98832792a4b40ca8f35de0