### PR TITLE
feat: tighten resource allocator limits

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,7 @@
 resource_allocator:
-  max_disk_mb: 20480  # maximum MB for disk offload (20 GB)
+  max_disk_mb: 30720  # maximum MB for disk offload (30 GB)
   compress_offload: true  # store offloaded tensors in float16
   min_gpu_tensor_mb: 1.0  # tensors smaller than this stay on CPU
   ram_offload_threshold: 0.9  # offload tensors to disk when RAM usage exceeds this ratio
+  vram_offload_threshold: 0.9  # move tensors off GPU when VRAM usage exceeds this ratio
   disk_usage_threshold: 0.95  # stop offloading when disk usage exceeds this ratio

--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -35,6 +35,7 @@ from marble.plugins.selfattention_findbestneurontype import FindBestNeuronTypeRo
 from marble.plugins.selfattention_noise_profiler import ContextAwareNoiseRoutine
 from marble.dashboard import start_dashboard
 from marble.plugins.wanderer_autoplugin import AutoPlugin
+from marble.plugins.wanderer_resource_allocator import clear as clear_resources
 
 
 class QualityAwareRoutine:
@@ -241,7 +242,9 @@ def main(epochs: int = 1) -> None:
         print(f"processed datapairs: {cnt}")
         if cnt == 0:
             raise RuntimeError("run_training_with_datapairs returned count=0")
+        clear_resources()
     print("streamed quality training complete")
+    clear_resources()
 
 
 if __name__ == "__main__":

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -11,7 +11,7 @@
 
 ## Resource Allocator Settings
 
-- resource_allocator.max_disk_mb (int, default: 20480)
+ - resource_allocator.max_disk_mb (int, default: 30720)
   Limits total size in MB of tensors offloaded to disk by the resource allocator.
   Must be positive. When exceeded, tensors are cleared instead of offloaded.
 - resource_allocator.compress_offload (bool, default: true)
@@ -23,6 +23,9 @@
 - resource_allocator.ram_offload_threshold (float, default: 0.9)
   RAM usage ratio beyond which rarely accessed tensors are proactively
   offloaded to disk. Value must be between 0 and 1.
+- resource_allocator.vram_offload_threshold (float, default: 0.9)
+  VRAM usage ratio beyond which tensors are moved off the GPU to CPU or disk.
+  Value must be between 0 and 1.
 - resource_allocator.disk_usage_threshold (float, default: 0.95)
   Maximum allowed disk usage ratio before tensors are offloaded. Prevents disk
   exhaustion; value must be between 0 and 1.


### PR DESCRIPTION
## Summary
- cap resource allocator to 90% RAM/VRAM and 30GB disk usage
- expose vram_offload_threshold in config and docs
- add clear() helper and use it in HF image quality example

## Testing
- `python -m unittest -v tests.test_resource_allocator_disk_limit`
- `python -m unittest -v tests.test_resource_allocator_disk_usage`
- `python -m unittest -v tests.test_resource_allocator_ram_pressure`
- `python -m unittest -v tests.test_training_with_datapairs`


------
https://chatgpt.com/codex/tasks/task_e_68b6874230608327acbce1bc22ebd188