### PR TITLE
Fix HF image quality example DownloadConfig

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -105,16 +105,12 @@ def main(epochs: int = 1) -> None:
         hf_retries = int(os.environ.get("MARBLE_IMG_RETRY", "5"))
     except Exception:
         hf_retries = 5
-    try:
-        hf_timeout = float(os.environ.get("MARBLE_IMG_TIMEOUT", "60"))
-    except Exception:
-        hf_timeout = 60.0
     ds = load_hf_streaming_dataset(
         "Rapidata/Imagen-4-ultra-24-7-25_t2i_human_preference",
         split="train",
         streaming="disk_lazy_images",  # disk-backed dataset; images downloaded lazily per sample
         codec=codec,
-        download_config=DownloadConfig(max_retries=hf_retries, timeout=hf_timeout),
+        download_config=DownloadConfig(max_retries=hf_retries),
         cache_images=cache_enabled,
         cache_size=cache_size,
     )


### PR DESCRIPTION
## Summary
- remove unsupported `timeout` arg when creating `DownloadConfig`
- rely solely on retry count for dataset downloads

## Testing
- `pytest tests/test_hf_utils_download_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6979771188327a6570293b88b1684