### PR TITLE
Implement manual HuggingFace dataset streaming

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -186,8 +186,8 @@ Hugging Face Integration
 
 - Login: `hf_login(token=None, add_to_git_credential=False, endpoint=None)` logs in via `huggingface_hub`. When `token` is `None`, reads `HF_TOKEN` or `HUGGINGFACE_TOKEN`. Logs events under `huggingface/auth`.
 - Logout: `hf_logout()` best-effort logout via `huggingface_hub.logout`.
-- Streaming datasets: `load_hf_streaming_dataset(path, name=None, split="train", codec=None, streaming="memory", trust_remote_code=False, download_config=None, cache_images=True, cache_size=20, **kwargs)` wraps `datasets.load_dataset` and supports multiple materialization modes. The `streaming` argument accepts
-  - `"memory"` (default): stream data directly into memory,
+- Streaming datasets: `load_hf_streaming_dataset(path, name=None, split="train", codec=None, streaming="memory", trust_remote_code=False, download_config=None, cache_images=True, cache_size=20, **kwargs)` wraps `datasets.load_dataset` and supports multiple materialization modes. Unlike the native `datasets` streaming, the `"memory"` and `"memory_lazy_images"` modes manually download one parquet shard at a time, yield its samples, and delete the shard before proceeding to the next. The `streaming` argument accepts
+  - `"memory"` (default): incremental in-memory streaming via sequential parquet downloads,
   - `"memory_lazy_images"`: like `"memory"` but store only image URLs until accessed,
   - `"disk"`: store data on disk and stream from there,
   - `"disk_lazy_images"`: disk-backed with image URLs only,

--- a/tests/test_hf_manual_streaming.py
+++ b/tests/test_hf_manual_streaming.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import tempfile
+import types
+import unittest
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from unittest import mock
+
+import marble.hf_utils as hf_utils
+import datasets as ds
+
+
+class HFManualStreamingTest(unittest.TestCase):
+    def test_parquet_streaming_and_cleanup(self):
+        tmpdir = tempfile.mkdtemp()
+        repo_dir = os.path.join(tmpdir, "repo")
+        train_dir = os.path.join(repo_dir, "train")
+        os.makedirs(train_dir, exist_ok=True)
+        pq.write_table(pa.table({"txt": ["a"]}), os.path.join(train_dir, "0000.parquet"))
+        pq.write_table(pa.table({"txt": ["b"]}), os.path.join(train_dir, "0001.parquet"))
+        downloaded = []
+
+        class HfApi:
+            def list_repo_files(self, repo_id, repo_type="dataset"):
+                return ["train/0000.parquet", "train/0001.parquet"]
+
+        def hf_hub_download(repo_id, filename, repo_type="dataset", local_dir=None, local_dir_use_symlinks=False):
+            src = os.path.join(repo_dir, filename)
+            if local_dir is None:
+                local_dir = tempfile.mkdtemp(dir=tmpdir)
+            os.makedirs(local_dir, exist_ok=True)
+            dst = os.path.join(local_dir, os.path.basename(filename))
+            shutil.copy(src, dst)
+            downloaded.append(dst)
+            return dst
+
+        hub = types.SimpleNamespace(HfApi=HfApi, hf_hub_download=hf_hub_download)
+
+        with mock.patch.object(hf_utils, "_ensure_hf_imports", return_value=(hub, ds)):
+            wrapper = hf_utils.load_hf_streaming_dataset("dummyrepo", split="train")
+            texts = [ex.get_raw("txt") for ex in wrapper]
+
+        self.assertEqual(texts, ["a", "b"])
+        for path in downloaded:
+            self.assertFalse(os.path.exists(path))
+        shutil.rmtree(tmpdir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Stream Hugging Face datasets by downloading one parquet shard at a time and deleting after use
- Document new manual streaming strategy in architecture overview
- Add test covering manual shard streaming and cleanup

## Testing
- `PYTHONPATH=. pytest tests/test_hf_utils_download_config.py -q`
- `PYTHONPATH=. pytest tests/test_hf_lazy_image_loading.py -q`
- `PYTHONPATH=. pytest tests/test_hf_manual_streaming.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6ab6c3eb48327ac1777ce0855e751