### PR TITLE
Use memory streaming in HF image quality example

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -1,7 +1,7 @@
 """Example: Streamed quality training on a Hugging Face dataset.
 
 This script demonstrates how to:
-- Load the Rapidata Imagen preference dataset in streaming mode
+- Load the Rapidata Imagen preference dataset via memory streaming (one shard at a time)
 - Derive quality quotients from human preference and alignment scores
 - Train a small Brain with stacked Wanderer plugins and neuroplasticity
 - Employ a custom SelfAttention routine combined with adaptive grad clipping
@@ -108,7 +108,7 @@ def main(epochs: int = 1) -> None:
     ds = load_hf_streaming_dataset(
         "Rapidata/Imagen-4-ultra-24-7-25_t2i_human_preference",
         split="train",
-        streaming="disk_lazy_images",  # disk-backed dataset; images downloaded lazily per sample
+        streaming="memory",  # stream shards into memory and encode images immediately
         codec=codec,
         download_config=DownloadConfig(max_retries=hf_retries),
         cache_images=cache_enabled,


### PR DESCRIPTION
## Summary
- switch image quality example to `streaming="memory"`
- clarify docstring about memory streaming

## Testing
- `python -m tests.test_hf_manual_streaming`
- `python -m tests.test_hf_utils_download_config`


------
https://chatgpt.com/codex/tasks/task_e_68b6adcdddbc8327a7cd4a03705608e4