### PR TITLE
Use temp cache for HF streaming

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -186,7 +186,7 @@ Hugging Face Integration
 
 - Login: `hf_login(token=None, add_to_git_credential=False, endpoint=None)` logs in via `huggingface_hub`. When `token` is `None`, reads `HF_TOKEN` or `HUGGINGFACE_TOKEN`. Logs events under `huggingface/auth`.
 - Logout: `hf_logout()` best-effort logout via `huggingface_hub.logout`.
-- Streaming datasets: `load_hf_streaming_dataset(path, name=None, split="train", codec=None, streaming="memory", trust_remote_code=False, download_config=None, cache_images=True, cache_size=20, **kwargs)` wraps `datasets.load_dataset` and supports multiple materialization modes. Unlike the native `datasets` streaming, the `"memory"` and `"memory_lazy_images"` modes manually download one parquet shard at a time, yield its samples, and delete the shard before proceeding to the next. The `streaming` argument accepts
+- Streaming datasets: `load_hf_streaming_dataset(path, name=None, split="train", codec=None, streaming="memory", trust_remote_code=False, download_config=None, cache_images=True, cache_size=20, **kwargs)` wraps `datasets.load_dataset` and supports multiple materialization modes. Unlike the native `datasets` streaming, the `"memory"` and `"memory_lazy_images"` modes use the Hugging Face index to download exactly one parquet shard at a time into a temporary cache with `force_download=True`, stream its samples, and remove the cache before fetching the next shard. The `streaming` argument accepts
   - `"memory"` (default): incremental in-memory streaming via sequential parquet downloads,
   - `"memory_lazy_images"`: like `"memory"` but store only image URLs until accessed,
   - `"disk"`: store data on disk and stream from there,

--- a/tests/test_hf_manual_streaming.py
+++ b/tests/test_hf_manual_streaming.py
@@ -22,16 +22,26 @@ class HFManualStreamingTest(unittest.TestCase):
         pq.write_table(pa.table({"txt": ["b"]}), os.path.join(train_dir, "0001.parquet"))
         downloaded = []
 
-        class HfApi:
-            def list_repo_files(self, repo_id, repo_type="dataset"):
-                return ["train/0000.parquet", "train/0001.parquet"]
+        class TreeFile:
+            def __init__(self, path):
+                self.path = path
 
-        def hf_hub_download(repo_id, filename, repo_type="dataset", local_dir=None, local_dir_use_symlinks=False):
+        class HfApi:
+            def list_repo_tree(self, repo_id, repo_type="dataset", recursive=True):
+                return [TreeFile("train/0000.parquet"), TreeFile("train/0001.parquet")]
+
+        def hf_hub_download(
+            repo_id,
+            filename,
+            repo_type="dataset",
+            cache_dir=None,
+            force_download=False,
+        ):
             src = os.path.join(repo_dir, filename)
-            if local_dir is None:
-                local_dir = tempfile.mkdtemp(dir=tmpdir)
-            os.makedirs(local_dir, exist_ok=True)
-            dst = os.path.join(local_dir, os.path.basename(filename))
+            if cache_dir is None:
+                cache_dir = tempfile.mkdtemp(dir=tmpdir)
+            os.makedirs(cache_dir, exist_ok=True)
+            dst = os.path.join(cache_dir, os.path.basename(filename))
             shutil.copy(src, dst)
             downloaded.append(dst)
             return dst


### PR DESCRIPTION
## Summary
- Stream Hugging Face parquet datasets by listing repo tree and downloading shards one-by-one with `force_download=True`
- Clean up temporary cache dirs after each shard to keep only a single file on disk
- Document and test the sequential download behaviour

## Testing
- `python -m pytest tests/test_hf_manual_streaming.py`
- `python -m pytest tests/test_hf_utils_download_config.py`
- `python -m pytest tests/test_hf_lazy_image_loading.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6aff4ed0483278d65f1652e4ca95d