### PR TITLE
avoid prefetching streaming shards

### DIFF
--- a/marble/training.py
+++ b/marble/training.py
@@ -185,18 +185,19 @@ def run_training_with_datapairs(
                 h.update(chunk(enc_l)); h.update(chunk(enc_r))
             return h.hexdigest()
 
-        if getattr(brain, "_dataset_signature", None) is None:
-            try:
-                brain._dataset_signature = _dataset_sig(datapairs)
-            except Exception:
-                brain._dataset_signature = None
-        else:
-            if not getattr(brain, "allow_dissimilar_datasets_in_wanderers", False):
+        if not streaming:
+            if getattr(brain, "_dataset_signature", None) is None:
                 try:
-                    if brain._dataset_signature != _dataset_sig(datapairs):
-                        raise ValueError("Dataset signature differs from the first-run signature for this Brain")
+                    brain._dataset_signature = _dataset_sig(datapairs)
                 except Exception:
-                    pass
+                    brain._dataset_signature = None
+            else:
+                if not getattr(brain, "allow_dissimilar_datasets_in_wanderers", False):
+                    try:
+                        if brain._dataset_signature != _dataset_sig(datapairs):
+                            raise ValueError("Dataset signature differs from the first-run signature for this Brain")
+                    except Exception:
+                        pass
 
         cfg = neuro_config
         wtype = wanderer_type


### PR DESCRIPTION
## Summary
- skip dataset signature computation when using streaming datapairs to prevent unnecessary shard downloads

## Testing
- `python -m unittest tests.test_hf_manual_streaming -v`
- `python -m unittest tests.test_training_with_datapairs -v`
- `python -m unittest tests.test_batch_training_plugin -v`
- `python -m unittest tests.test_neuroplasticity -v`
- `python -m unittest tests.test_brain_status -v`
- `python -m unittest tests.test_selfattention_phase_shift -v`
- `python -m unittest tests.test_learning_paradigm -v`


------
https://chatgpt.com/codex/tasks/task_e_68b6b6c094b483278dbbce8ef991694d