### PR TITLE
Enforce mandatory plugins and unify autoneuron device handling

### DIFF
--- a/marble/plugins/wanderer_autoplugin.py
+++ b/marble/plugins/wanderer_autoplugin.py
@@ -192,7 +192,7 @@ class AutoPlugin:
 
         self._current_neuron_id = 0 if neuron is None else id(neuron)
         if name in self._mandatory:
-            self._update_log(wanderer, plugintype, name, True)
+            # Mandatory plugins are always active and excluded from logs
             return True
         if name in self._disabled:
             self._update_log(wanderer, plugintype, name, False)


### PR DESCRIPTION
## Summary
- keep all example-configured plugins active by default and exclude them from autoplugin logs
- auto-convert all newly created neurons in HF quality training example into `autoneuron`
- align autoneuron attention score tensors to the correct device

## Testing
- `pytest tests/test_autoneuron.py -q`
- `pytest tests/test_autoneuron_logging.py -q` *(fails: RuntimeError: Trying to backward through the graph a second time)*
- `pytest tests/test_autoplugin_logging.py -q`
- `pytest tests/test_autoplugin_mandatory.py -q`
- `pytest tests/test_autoplugin_exclude.py -q`
- `pytest tests/test_autoplugin_bias.py -q`
- `pytest tests/test_autoplugin_autodiscovery.py -q`
- `pytest tests/test_dynamic_neuron_builder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d088df648327833b2a88e520ab8e