### PR TITLE
Handle missing mandatory_plugins support in AutoPlugin

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -166,10 +166,20 @@ def main(epochs: int = 1) -> None:
         "FindBestNeuronTypeRoutine",
         "ContextAwareNoiseRoutine",
     ]
-    register_wanderer_type(
-        "autoplugin_logger",
-        AutoPlugin(log_path="autoplugin.log", mandatory_plugins=mandatory_plugins),
-    )
+    # Instantiate AutoPlugin with mandatory plugin support when available.
+    try:
+        ap = AutoPlugin(
+            log_path="autoplugin.log", mandatory_plugins=mandatory_plugins
+        )
+    except TypeError:
+        # Older AutoPlugin versions do not accept ``mandatory_plugins``.
+        ap = AutoPlugin(log_path="autoplugin.log")
+        # Preserve mandatory behaviour if the attribute exists.
+        if hasattr(ap, "_mandatory"):
+            ap._mandatory.update(mandatory_plugins)
+        else:
+            ap._mandatory = set(mandatory_plugins)
+    register_wanderer_type("autoplugin_logger", ap)
     wplugins = [
         "batchtrainer",
         "qualityweightedloss",


### PR DESCRIPTION
## Summary
- ensure `run_hf_image_quality.py` gracefully instantiates `AutoPlugin` when older versions lack `mandatory_plugins`

## Testing
- `python -m pytest tests/test_autoplugin_mandatory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d62c5cbc8327871a0b83777d9dc2