### PR TITLE
fix tensor clone warning for learnable params

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -1445,7 +1445,17 @@ class Brain:
         device = "cuda" if torch is not None and torch.cuda.is_available() else "cpu"
         if torch is not None:
             try:
-                t = torch.tensor(init_value, dtype=torch.float32, device=device, requires_grad=requires_grad)
+                if torch.is_tensor(init_value):
+                    t = init_value.clone().detach().to(device=device, dtype=torch.float32)
+                    if requires_grad:
+                        t.requires_grad_()
+                else:
+                    t = torch.tensor(
+                        init_value,
+                        dtype=torch.float32,
+                        device=device,
+                        requires_grad=requires_grad,
+                    )
             except Exception:
                 t = torch.tensor([float(init_value)], dtype=torch.float32, device=device, requires_grad=requires_grad)
         else:


### PR DESCRIPTION
## Summary
- avoid UserWarning when wrapping existing tensors by cloning/detaching before moving to device

## Testing
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD pytest tests/test_learnable_params.py`
- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=$PWD pytest tests/test_brain.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6d926f05083279a1a98af7a16844f