### PR TITLE
Avoid locking delays between Wanderer walks

### DIFF
--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -418,7 +418,7 @@ class Wanderer(_DeviceHelper):
                 lock_ctx = None
                 try:
                     if hasattr(self.brain, "lock_neuron"):
-                        lock_ctx = self.brain.lock_neuron(n, timeout=0.5)
+                        lock_ctx = self.brain.lock_neuron(n, timeout=0.0)
                 except Exception:
                     lock_ctx = None
                 if lock_ctx is not None:

--- a/tests/test_wanderer_lock_timeout.py
+++ b/tests/test_wanderer_lock_timeout.py
@@ -1,0 +1,31 @@
+import unittest
+import types
+from marble.marblemain import Brain, run_wanderer_training
+from marble.reporter import REPORTER, clear_report_group
+
+class TestWandererLockTimeout(unittest.TestCase):
+    def setUp(self):
+        self.reporter = REPORTER
+        clear_report_group("lock_timeout")
+
+    def test_lock_neuron_nonblocking(self):
+        b = Brain(1, mode="grid")
+        b.add_neuron((0,), tensor=[0.0])
+        timeouts = []
+
+        def lock_neuron(self, neuron, timeout=None):
+            timeouts.append(timeout)
+            class Dummy:
+                def __enter__(self):
+                    return self
+                def __exit__(self, exc_type, exc, tb):
+                    return False
+            return Dummy()
+        b.lock_neuron = types.MethodType(lock_neuron, b)
+        run_wanderer_training(b, num_walks=1, max_steps=1, lr=0.0)
+        self.reporter.item["timeouts", "lock_timeout", "metrics"] = timeouts
+        print("lock timeouts:", timeouts)
+        self.assertTrue(all(t == 0.0 for t in timeouts))
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- make neuron lock acquisition nonblocking to remove idle wait between walks
- add unit test to confirm Wanderer uses zero-timeout locks

## Testing
- `PYTHONPATH=. python tests/test_wanderer.py`
- `PYTHONPATH=. python tests/test_wanderer_lock_timeout.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6ec3ea794832787a1b3b6437e2400