### PR TITLE
Prune or reconnect neurons stuck at zero delta

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,3 +5,4 @@ resource_allocator:
   ram_offload_threshold: 0.9  # offload tensors to disk when RAM usage exceeds this ratio
   vram_offload_threshold: 0.9  # move tensors off GPU when VRAM usage exceeds this ratio
   disk_usage_threshold: 0.95  # stop offloading when disk usage exceeds this ratio
+max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection

--- a/tests/test_wanderer_flat_delta.py
+++ b/tests/test_wanderer_flat_delta.py
@@ -1,0 +1,22 @@
+import unittest
+import torch
+
+from marble.marblemain import Brain, Wanderer
+
+
+class TestWandererFlatDelta(unittest.TestCase):
+    def test_flat_delta_marks_neuron(self) -> None:
+        b = Brain(1, mode="sparse", sparse_bounds=((0.0, None),))
+        n1 = b.add_neuron((0.0,), tensor=[0.0])
+        n2 = b.add_neuron((1.0,), tensor=[0.0])
+        b.connect((0.0,), (0.0,), direction="uni")
+        w = Wanderer(b, seed=123, neuro_config={"max_flat_steps": 1})
+        w._compute_loss = lambda outputs, override_loss=None: torch.tensor(0.0)
+        w.walk(max_steps=3, lr=1e-2, start=n1)
+        marks = getattr(b, "_prune_marks", {})
+        print("flat_delta_marks", marks.get(n1, 0))
+        self.assertIn(n1, marks)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -9,6 +9,11 @@
 - aggressive_phase_steps (int)
   Required when aggressive_starting_neuroplasticity is true. Number of steps to keep aggressive growth before reverting to normal behaviour.
 
+- max_flat_steps (int, default: 5)
+  Maximum number of consecutive walk steps a neuron can report a ``delta`` of
+  ``0.0`` before it is marked for pruning or a new synaptic connection is
+  forced via plugin. Must be non-negative.
+
 ## Resource Allocator Settings
 
  - resource_allocator.max_disk_mb (int, default: 30720)


### PR DESCRIPTION
## Summary
- track consecutive zero-delta steps per neuron during Wanderer walks
- prune-mark or create a new synapse when a neuron stays flat too long
- expose `max_flat_steps` config knob with docs and tests

## Testing
- `pytest tests/test_wanderer.py -q`
- `pytest tests/test_neuron_pruning_mechanism.py -q`
- `pytest tests/test_wanderer_flat_delta.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f587eb64832798b92daf75a27d48