### PR TITLE
Add wildcard helper to load all Wanderer plugins

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -33,6 +33,7 @@ from marble.marblemain import (
     load_hf_streaming_dataset,
     SelfAttention,
     register_wanderer_type,
+    expand_wplugins,
 )
 import marble.plugins  # ensure plugin discovery
 from marble.plugins.selfattention_adaptive_grad_clip import AdaptiveGradClipRoutine
@@ -225,7 +226,9 @@ def main(
         "dynamicdimensions",
         "autoplugin_logger",
         "auto_target_scaler",
+        "*",  # shorthand for all other plugins
     ]
+    wplugins = expand_wplugins(wplugins)
     neuro_cfg = {
         "grow_on_step_when_stuck": True,
         "max_new_per_walk": 1,

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -2211,7 +2211,7 @@ __all__ += ["register_brain_train_type"]
 from . import plugins as _plugins  # noqa: F401
 
 # Plugin registry for Wanderer (moved). Import registry and registrar.
-from .wanderer import register_wanderer_type  # re-exported below
+from .wanderer import register_wanderer_type, expand_wplugins  # re-exported below
 from .wanderer import WANDERER_TYPES_REGISTRY as _WANDERER_TYPES
 try:
     # Ensure built-in Wanderer plugins that self-register are loaded on import
@@ -2239,6 +2239,7 @@ __all__ += [
     "Wanderer",
     "register_wanderer_type",
     "register_neuroplasticity_type",
+    "expand_wplugins",
     "expose_learnable_params",
 ]
 

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -40,6 +40,33 @@ def register_neuroplasticity_type(name: str, plugin: Any) -> None:
     NEURO_TYPES_REGISTRY[str(name)] = plugin
 
 
+def expand_wplugins(names: Sequence[str], sentinel: str = "*") -> List[str]:
+    """Expand a shorthand entry to include all registered Wanderer plugins.
+
+    Parameters
+    ----------
+    names:
+        Sequence of plugin short names. If ``sentinel`` is present, it
+        represents "all remaining" plugins that are registered but not
+        explicitly listed.
+    sentinel:
+        Marker string denoting the shorthand. Defaults to ``"*"``.
+
+    Returns
+    -------
+    list[str]
+        The plugin names with the sentinel expanded, preserving the order of
+        explicitly provided names and appending the remaining plugins in
+        alphabetical order.
+    """
+
+    explicit = [n for n in names if n != sentinel]
+    if sentinel not in names:
+        return list(explicit)
+    remaining = [n for n in sorted(WANDERER_TYPES_REGISTRY) if n not in explicit]
+    return explicit + remaining
+
+
 def expose_learnable_params(fn: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator: expose function parameters as Wanderer learnables.
 
@@ -1316,6 +1343,7 @@ __all__ = [
     "register_neuroplasticity_type",
     "WANDERER_TYPES_REGISTRY",
     "NEURO_TYPES_REGISTRY",
+    "expand_wplugins",
     "Wanderer",
     "push_temporary_plugins",
     "pop_temporary_plugins",

--- a/tests/test_expand_wplugins.py
+++ b/tests/test_expand_wplugins.py
@@ -1,0 +1,18 @@
+import unittest
+
+from marble.marblemain import Brain, Wanderer, expand_wplugins
+import marble.plugins  # ensure plugin discovery
+
+
+class ExpandWPluginsTest(unittest.TestCase):
+    def test_expand_shorthand(self) -> None:
+        b = Brain(1)
+        names = expand_wplugins(["batchtrainer", "*"])
+        self.assertIn("batchtrainer", names)
+        self.assertGreater(len(names), 1)
+        w = Wanderer(b, type_name=",".join(names))
+        self.assertGreater(len(getattr(w, "_wplugins", []) or []), 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `expand_wplugins` helper to turn `*` into the full set of registered Wanderer plugins
- expose helper through `marble.marblemain` and use it in the HF image quality example
- cover wildcard expansion with a new unit test

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest -v tests.test_expand_wplugins`
- `python -m unittest -v tests.test_autoplugin_autodiscovery`


------
https://chatgpt.com/codex/tasks/task_e_68b7d1448cc08327ad90930a88bb6280