### PR TITLE
fix: unblock hf image quality training

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -12,8 +12,9 @@ Usage:
     py -3 examples/run_hf_image_quality.py
 """
 
-print("Importing packages..")
 from __future__ import annotations
+
+print("Importing packages..")
 
 from typing import Iterator, Any, Dict
 import os
@@ -240,6 +241,8 @@ def main(
         "*",  # shorthand for all other plugins
     ]
     wplugins = expand_wplugins(wplugins)
+    if "synthetictrainer" in wplugins:
+        wplugins.remove("synthetictrainer")
     neuro_cfg = {
         "grow_on_step_when_stuck": True,
         "max_new_per_walk": 1,


### PR DESCRIPTION
## Summary
- ensure `run_hf_image_quality.py` is importable by moving `from __future__` ahead of prints
- skip `synthetictrainer` plugin to avoid deadlock and start training

## Testing
- `pytest tests/test_training_with_datapairs.py -q`
- `python3 - <<'PY'
from examples.run_hf_image_quality import main
main(max_pairs=2, epochs=1)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b7d92edfe48327a64328b015f21605