### PR TITLE
Enable mixed precision loss scaling in HF image quality example

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -204,6 +204,7 @@ def main(
         "DistillationPlugin",
         "WanderAlongSynapseWeightsPlugin",
         "DynamicDimensionsPlugin",
+        "MixedPrecisionPlugin",  # auto loss scaling via mixed precision
         "QualityAwareRoutine",
         "AdaptiveGradClipRoutine",
         "FindBestNeuronTypeRoutine",
@@ -236,6 +237,7 @@ def main(
         "distillation",
         "wanderalongsynapseweights",
         "dynamicdimensions",
+        "mixedprecision",  # ensure GradScaler handles loss scaling
         "autoplugin_logger",
         "auto_target_scaler",
         "*",  # shorthand for all other plugins


### PR DESCRIPTION
## Summary
- ensure MixedPrecisionPlugin is always active for HF image quality run
- mark mixedprecision as mandatory so AutoPlugin cannot disable GradScaler loss scaling

## Testing
- `python -m py_compile examples/run_hf_image_quality.py`
- `python -m unittest -v tests.test_expand_wplugins`


------
https://chatgpt.com/codex/tasks/task_e_68b7e028bf9883279733935eec3ad1e0