### PR TITLE
propagate device to reporter logs

### DIFF
--- a/tests/test_device_reporting.py
+++ b/tests/test_device_reporting.py
@@ -1,0 +1,21 @@
+import unittest
+
+from marble.graph import Neuron
+from marble.reporter import REPORTER, clear_report_group
+
+
+class TestDeviceReporting(unittest.TestCase):
+    def setUp(self):
+        clear_report_group("neuron")
+
+    def test_forward_reports_device(self):
+        n = Neuron([1.0])
+        n._device = "cuda"
+        n.forward(n.tensor)
+        item = REPORTER.item("forward", "neuron", "metrics")
+        print("device in neuron forward report:", item.get("device"))
+        self.assertEqual(item.get("device"), "cuda")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- prefer CUDA when available in DeviceHelper
- tag reporter entries with the selected device
- cover device propagation with a new unit test

## Testing
- `python -m unittest -v tests.test_reporter`
- `python -m unittest -v tests.test_reporter_clear`
- `python -m unittest -v tests.test_reporter_subgroups`
- `python -m unittest -v tests.test_device_reporting`
- `python -m unittest -v tests.test_quantumtype_plugin`


------
https://chatgpt.com/codex/tasks/task_e_68b7f1ea26a48327ae27024ec04e3b1b