### PR TITLE
feat: automate plugin device casts

### DIFF
--- a/marble/plugins/selfattention_weight_decay.py
+++ b/marble/plugins/selfattention_weight_decay.py
@@ -28,7 +28,7 @@ class WeightDecayRoutine:
     ):
         d_t = _decay_param(wanderer)
         try:
-            decay = float(d_t.detach().to("cpu").item())
+            decay = float(d_t.detach().to(wanderer._device).item())
         except Exception:
             decay = 0.01
         decay *= metric_factor(ctx, "weight_decay")
@@ -37,8 +37,8 @@ class WeightDecayRoutine:
             if w is None:
                 continue
             try:
-                wt = torch.tensor([float(w)], dtype=torch.float32)
-                syn.weight = float((wt * (1.0 - decay)).detach().to("cpu").item())
+                wt = torch.tensor([float(w)], dtype=torch.float32, device=wanderer._device)
+                syn.weight = float((wt * (1.0 - decay)).detach().to(wanderer._device).item())
             except Exception:
                 pass
         report("selfattention", "weight_decay", {"step": step_index, "decay": decay}, "events")

--- a/marble/plugins/wanderer_fractalseed.py
+++ b/marble/plugins/wanderer_fractalseed.py
@@ -23,7 +23,7 @@ class FractalSeedPlugin:
         if not choices:
             return None, "forward"
         (d_t,) = self._params(wanderer)
-        d = float(d_t.detach().to("cpu").item()) if hasattr(d_t, "detach") else float(d_t)
+        d = float(d_t.detach().to(wanderer._device).item()) if hasattr(d_t, "detach") else float(d_t)
         base = torch.arange(len(choices), dtype=torch.float32)
         self._counter += 1
         weights = torch.frac(base * d * (self._counter)) + 1e-6

--- a/marble/plugins/wanderer_shadowclone.py
+++ b/marble/plugins/wanderer_shadowclone.py
@@ -25,7 +25,7 @@ class ShadowClonePlugin:
         (bias_t,) = self._params(wanderer)
         torch = getattr(wanderer, "_torch", None)
         if torch is not None:
-            prob = float(torch.sigmoid(bias_t).detach().to("cpu").item())
+            prob = float(torch.sigmoid(bias_t).detach().to(wanderer._device).item())
         else:
             prob = 1.0 / (1.0 + math.exp(-float(bias_t)))
         idx = random.randrange(len(choices))

--- a/scripts/refactor_plugins_device.py
+++ b/scripts/refactor_plugins_device.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Automates device-aware refactor across all plugins and runs tests.
+
+This script scans every plugin under ``marble/plugins`` and replaces
+any explicit ``.to("cpu")`` casts with ``.to(owner._device)`` so tensors
+follow the owning object's active device.  It also ensures that detach
+is only used when converting to Python scalars by keeping ``detach``
+when an ``.item()`` call is present on the same expression.
+
+After modifying plugins, the script executes each test module in
+``tests/`` individually, respecting repository testing policy.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PLUGIN_DIR = ROOT / "marble" / "plugins"
+TEST_DIR = ROOT / "tests"
+
+CPU_CAST_RE = re.compile(r"\.to\(\s*['\"]cpu['\"]\s*\)")
+DETACH_CLEAN_RE = re.compile(r"\.detach\(\)\.to\(owner._device\)(?!\.item\()")
+
+
+def patch_plugin(path: pathlib.Path) -> bool:
+    text = path.read_text()
+    original = text
+    text = CPU_CAST_RE.sub(".to(owner._device)", text)
+    # Remove detach() when not followed by .item(); keep for scalar extraction
+    text = DETACH_CLEAN_RE.sub(".to(owner._device)", text)
+    if text != original:
+        path.write_text(text)
+        return True
+    return False
+
+
+def run_tests() -> None:
+    tests = sorted(
+        p for p in TEST_DIR.glob("test_*.py") if "3d_printer_sim" not in p.name
+    )
+    for t in tests:
+        mod = f"tests.{t.stem}"
+        print(f"Running {mod}")
+        subprocess.run([sys.executable, "-m", "unittest", "-v", mod], check=True)
+
+
+def main() -> None:
+    changed = False
+    for py in PLUGIN_DIR.glob("*.py"):
+        if patch_plugin(py):
+            print(f"Patched {py.relative_to(ROOT)}")
+            changed = True
+    if not changed:
+        print("No plugins required patching.")
+    run_tests()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add refactor_plugins_device script to switch `.to('cpu')` casts across plugins to the active device and run tests
- keep wanderer computations on-device for fractalseed and shadowclone plugins
- ensure self-attention weight decay uses the wanderer's device context

## Testing
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_advanced_wanderer_plugins`


------
https://chatgpt.com/codex/tasks/task_e_68b7fbdaaff08327b710bb963b9afe15