### PR TITLE
Silence evaluation progress bars in neuron type search

### DIFF
--- a/marble/plugins/selfattention_findbestneurontype.py
+++ b/marble/plugins/selfattention_findbestneurontype.py
@@ -104,14 +104,23 @@ class FindBestNeuronTypeRoutine:
                         # Failed to create due to unmet wiring requirements
                         continue
                     neuro_bak = getattr(w, "_neuro_plugins", [])
+                    leave_bak = getattr(w, "pbar_leave", True)
+                    verb_bak = getattr(w, "pbar_verbose", True)
                     try:
                         setattr(w, "_neuro_plugins", [])
+                        setattr(w, "pbar_leave", False)
+                        setattr(w, "pbar_verbose", False)
                         res = w.walk(max_steps=1, start=n, lr=0.0)
                         cand_loss = float(res.get("loss", baseline))
                     except Exception:
                         cand_loss = baseline
                     finally:
                         setattr(w, "_neuro_plugins", neuro_bak)
+                        try:
+                            setattr(w, "pbar_leave", leave_bak)
+                            setattr(w, "pbar_verbose", verb_bak)
+                        except Exception:
+                            pass
                         try:
                             brain.remove_neuron(n)
                         except Exception:


### PR DESCRIPTION
## Summary
- silence evaluation walks in `FindBestNeuronTypeRoutine` by toggling progress bar flags

## Testing
- `python -m unittest -v tests.test_findbestneurontype_fallback`
- `python -m unittest -v tests.test_ultra_selfattention_plugins`

------
https://chatgpt.com/codex/tasks/task_e_68b8024499a083279e57d6eee8b4e1a8