### PR TITLE
Reuse progress bar across walks

### DIFF
--- a/tests/test_single_progress_bar.py
+++ b/tests/test_single_progress_bar.py
@@ -1,0 +1,46 @@
+import types
+
+
+def test_single_progress_bar(monkeypatch):
+    from marble.marblemain import Brain
+    import marble.wanderer as wanderer
+    from marble.wanderer import Wanderer
+
+    class DummyPbar:
+        instances = 0
+
+        def __init__(self, *args, **kwargs):
+            DummyPbar.instances += 1
+            self.total = kwargs.get("total", 0)
+
+        def set_description(self, *args, **kwargs):
+            pass
+
+        def set_postfix(self, *args, **kwargs):
+            pass
+
+        def update(self, *args, **kwargs):
+            pass
+
+        def refresh(self):
+            pass
+
+        def write(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(wanderer, "_tqdm_factory", lambda: DummyPbar)
+
+    b = Brain(1)
+    start = b.add_neuron((0,))
+    w = Wanderer(b, seed=0)
+    b._progress_total_walks = 2  # type: ignore[attr-defined]
+    b._progress_walk = 0  # type: ignore[attr-defined]
+    w.walk(max_steps=1, start=start)
+    b._progress_walk = 1  # type: ignore[attr-defined]
+    w.walk(max_steps=1, start=start)
+
+    assert DummyPbar.instances == 1
+    assert getattr(w, "_pbar", None) is None


### PR DESCRIPTION
## Summary
- reuse a single tqdm progress bar across wanderer walks
- add regression test to ensure only one progress bar instance is created

## Testing
- `python -m pytest tests/test_single_progress_bar.py -q`
- `PYTHONPATH=. python tests/test_training_with_datapairs.py`


------
https://chatgpt.com/codex/tasks/task_e_68b80470f2e4832782bcadb56c7ad7cf