### PR TITLE
refine progress bar neuron metrics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,7 +107,7 @@ Core Components
     - `dynamicdimensions` plugin periodically adds a new dimension to the `Brain`, observes neuron growth, and removes the dimension if it doesn't improve loss.
     - `AutoPlugin` meta-plugin learns to enable or disable other Wanderer/neuroplasticity plugins per step and accepts `disabled_plugins=[...]` to completely remove certain plugins from the stack.
   - Gradient clipping: configurable per `Wanderer` via `gradient_clip` dict (`method`: `norm` or `value`, with `max_norm`/`norm_type` or `clip_value`). Applied after `loss.backward()` and before parameter updates.
-  - Progress reporting: `Wanderer.walk` now emits a `tqdm` progress bar (or `tqdm.notebook` in IPython) updated each step with epoch/walk counts, neuron and synapse totals, brain size, step speed, path count, and loss metrics. `tqdm` is an explicit dependency.
+  - Progress reporting: `Wanderer.walk` now emits a `tqdm` progress bar (or `tqdm.notebook` in IPython) updated each step with epoch/walk counts, neuron and synapse totals, step speed, path count, and loss metrics. `tqdm` is an explicit dependency.
   - Mixed precision: `MixedPrecisionPlugin` now activates only on CUDA-enabled devices. It uses `torch.amp.GradScaler` when GPUs are available and is a no-op on CPU to avoid precision loss.
 
 - Training Helpers: High-level flows to run Wanderer training:

--- a/marble/progressbar.py
+++ b/marble/progressbar.py
@@ -130,18 +130,17 @@ class ProgressBar(ProgressBarBase):
         status: Dict[str, Any] = data.get("status", {})
         try:
             self._bar.set_postfix(
-                brain=f"{data.get('cur_size', 0)}/{data.get('cap', '-')}",
+                neurons=f"{data.get('cur_size', 0)}/{data.get('cap', '-')}",
                 loss=f"{data.get('cur_loss', 0.0):.4f}",
                 mean_loss=f"{data.get('mean_loss', 0.0):.4f}",
                 loss_speed=f"{data.get('loss_speed', 0.0):.4f}",
                 mean_loss_speed=f"{data.get('mean_loss_speed', 0.0):.4f}",
-                neurons=data.get("cur_size", 0),
                 neurons_added=status.get("neurons_added", 0),
                 synapses=data.get("synapses", 0),
                 synapses_added=status.get("synapses_added", 0),
                 neurons_pruned=status.get("neurons_pruned", 0),
                 synapses_pruned=status.get("synapses_pruned", 0),
-                paths=data.get("paths", data.get("synapses", 0)),
+                paths=data.get("paths", 0),
                 speed=f"{data.get('mean_speed', 0.0):.2f}",
             )
         except Exception:  # pragma: no cover - cosmetic only

--- a/tests/test_progressbar_labels.py
+++ b/tests/test_progressbar_labels.py
@@ -1,0 +1,25 @@
+import unittest
+from marble.progressbar import ProgressBar
+
+class TestProgressBarLabels(unittest.TestCase):
+    def test_neuron_label_replaces_brain(self):
+        p = ProgressBar()
+        p.start(1)
+        p.update(
+            cur_size=1,
+            cap=2,
+            cur_loss=0,
+            mean_loss=0,
+            loss_speed=0,
+            mean_loss_speed=0,
+            status={},
+            synapses=0,
+            mean_speed=0,
+        )
+        postfix = getattr(p._bar, "postfix", "")
+        self.assertNotIn("brain=", postfix)
+        self.assertIn("neurons=1/2", postfix)
+        p.end(cur_ep=1, tot_ep=1, cur_walk=1, tot_walks=1, loss=0.0, steps=1)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- streamline progress bar postfix: show neuron totals once and drop confusing brain label
- document updated progress bar metrics
- add regression test ensuring neuron label replaces old brain metric

## Testing
- `python -m unittest -v tests.test_progressbar_labels`


------
https://chatgpt.com/codex/tasks/task_e_68b82ab24d248327b3fa289fc7e7d54e