### PR TITLE
Clamp loss inputs for stable HF image quality demo

### DIFF
--- a/marble/plugins/wanderer_qualityweightedloss.py
+++ b/marble/plugins/wanderer_qualityweightedloss.py
@@ -19,8 +19,15 @@ class QualityWeightedLossPlugin:
         if not hasattr(tgt, "float"):
             tgt = torch.tensor(tgt, dtype=torch.float32, device=torch_device)
         tgt = tgt.view_as(y)
-        weight = tgt.clamp(min=0.0)
-        return (weight * (y - tgt) ** 2).mean()
+        # Replace NaNs/Infs and clamp to a reasonable range to avoid numeric
+        # explosions that previously produced ``inf`` losses during early
+        # training. This keeps the example script stable without altering the
+        # overall training configuration.
+        y = torch.nan_to_num(y, nan=0.0, posinf=1e6, neginf=-1e6).clamp(-1e6, 1e6)
+        tgt = torch.nan_to_num(tgt, nan=0.0, posinf=1e6, neginf=-1e6).clamp(-1e6, 1e6)
+        diff = (y - tgt).clamp(-1e3, 1e3)
+        weight = tgt.clamp(min=0.0, max=1e3)
+        return (weight * diff.pow(2)).mean()
 
 __all__ = ["QualityWeightedLossPlugin"]
 


### PR DESCRIPTION
## Summary
- clamp target scaling ratios in `AutoTargetScalerPlugin` to avoid runaway loss
- sanitize outputs and targets in quality-weighted and base MSE losses

## Testing
- `pytest tests/test_auto_target_scaler.py`
- `pytest tests/test_training_with_datapairs.py`
- `python examples/run_hf_image_quality.py` (manually interrupted after verifying finite losses)


------
https://chatgpt.com/codex/tasks/task_e_68b82fde16c88327a201a1b1bf5a2a3b