### PR TITLE
Ensure codec and allocator favor CUDA devices

### DIFF
--- a/marble/codec.py
+++ b/marble/codec.py
@@ -150,17 +150,15 @@ class UniversalTensorCodec:
             return False
 
     def _select_device(self) -> str:
+        """Prefer CUDA when available, otherwise fall back to CPU."""
         if self._torch is None:
             return "cpu"
         try:
-            return str(self._torch.tensor(0).device)
+            if self._torch.cuda.is_available():
+                return "cuda"
         except Exception:
-            try:
-                if self._torch.cuda.is_available():
-                    return "cuda"
-            except Exception:
-                pass
-            return "cpu"
+            pass
+        return "cpu"
 
 
 __all__ = ["UniversalTensorCodec", "TensorLike"]


### PR DESCRIPTION
## Summary
- make `UniversalTensorCodec` prefer CUDA when available
- push all tracked tensors to GPU when VRAM has headroom

## Testing
- `python -m unittest -v tests.test_codec`
- `python -m unittest -v tests.test_wanderer`


------
https://chatgpt.com/codex/tasks/task_e_68b83a81a02083279c8ac7cc7585308b