### PR TITLE
enforce neuron connectivity after first node

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -1108,7 +1108,15 @@ class Brain:
                 raise ValueError("coordinate length must equal n")
             return coords
 
-    def add_neuron(self, index: Sequence[int], *, tensor: Union[TensorLike, Sequence[float], float, int] = 0.0, **kwargs: Any) -> Neuron:
+    def add_neuron(
+        self,
+        index: Sequence[int],
+        *,
+        tensor: Union[TensorLike, Sequence[float], float, int] = 0.0,
+        connect_to: Optional[Sequence[int]] = None,
+        direction: str = "bi",
+        **kwargs: Any,
+    ) -> Neuron:
         if self.mode == "grid":
             idx = tuple(int(i) for i in index)
             if getattr(self, "dynamic", False):
@@ -1142,6 +1150,12 @@ class Brain:
             except Exception:
                 pass
             self.neurons_added += 1
+            if len(self.neurons) > 1:
+                if connect_to is None:
+                    raise RuntimeError(
+                        "tried to create a neuron not connected to at least one another neuron via at least one other synapse"
+                    )
+                self.connect(idx, connect_to, direction=direction)
             return neuron
         else:
             coords = tuple(float(v) for v in index)
@@ -1161,6 +1175,12 @@ class Brain:
             except Exception:
                 pass
             self.neurons_added += 1
+            if len(self.neurons) > 1:
+                if connect_to is None:
+                    raise RuntimeError(
+                        "tried to create a neuron not connected to at least one another neuron via at least one other synapse"
+                    )
+                self.connect(coords, connect_to, direction=direction)
             return neuron
 
     def get_neuron(self, index: Sequence[int]) -> Optional[Neuron]:

--- a/marble/plugins/buildingblock_create_neuron.py
+++ b/marble/plugins/buildingblock_create_neuron.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """BuildingBlock: create a neuron."""
 
-from typing import Any, Sequence
+from typing import Any, Optional, Sequence
 
 from ..buildingblock import BuildingBlock
 from ..wanderer import expose_learnable_params
@@ -19,12 +19,17 @@ class CreateNeuronPlugin(BuildingBlock):
         weight: float = 1.0,
         bias: float = 0.0,
         type_name: str | None = None,
+        connect_to_index: Optional[Sequence[int]] = None,
+        direction: str = "bi",
     ):
         idx = self._to_index(brain, index)
+        conn = self._to_index(brain, connect_to_index) if connect_to_index is not None else None
         try:
             return brain.add_neuron(
                 idx,
                 tensor=tensor,
+                connect_to=conn,
+                direction=direction,
                 weight=self._to_float(weight),
                 bias=self._to_float(bias),
                 type_name=type_name,

--- a/tests/test_neuron_connectivity.py
+++ b/tests/test_neuron_connectivity.py
@@ -1,0 +1,18 @@
+import unittest
+
+from marble.marblemain import Brain
+
+
+class TestNeuronConnectivity(unittest.TestCase):
+    def test_second_neuron_requires_connection(self):
+        b = Brain(1, size=2)
+        b.add_neuron((0,), tensor=0.0)
+        with self.assertRaises(RuntimeError):
+            b.add_neuron((1,), tensor=0.0)
+
+    def test_second_neuron_with_connection(self):
+        b = Brain(1, size=2)
+        b.add_neuron((0,), tensor=0.0)
+        b.add_neuron((1,), tensor=0.0, connect_to=(0,))
+        self.assertEqual(len(b.synapses), 1)
+


### PR DESCRIPTION
## Summary
- require a connection when adding neurons after the first
- extend `CreateNeuronPlugin` to pass optional connection info
- cover connectivity rules with dedicated tests

## Testing
- `python -m pytest tests/test_neuron_connectivity.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b83e116350832799a740badd95f4a9