### PR TITLE
Fix neuron connection requirement in tests

### DIFF
--- a/tests/test_curriculum_and_temp_plugins.py
+++ b/tests/test_curriculum_and_temp_plugins.py
@@ -9,7 +9,10 @@ class TestCurriculumAndTempPlugins(unittest.TestCase):
         it = iter(b.available_indices())
         i1 = next(it); i2 = next(it)
         n1 = b.add_neuron(i1, tensor=0.0)
-        n2 = b.add_neuron(i2, tensor=0.0)
+        n2 = b.add_neuron(i2, tensor=0.0, connect_to=i1, direction="uni")
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n1:
+                b.remove_synapse(s)
         b.connect(i1, i2, direction="uni")
         w = Wanderer(b)
         # Use curriculum

--- a/tests/test_learning_paradigm.py
+++ b/tests/test_learning_paradigm.py
@@ -44,7 +44,10 @@ class TestLearningParadigm(unittest.TestCase):
         it = iter(b.available_indices())
         i1 = next(it); i2 = next(it)
         n1 = b.add_neuron(i1, tensor=1.0)
-        n2 = b.add_neuron(i2, tensor=0.0)
+        n2 = b.add_neuron(i2, tensor=0.0, connect_to=i1, direction="uni")
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n1:
+                b.remove_synapse(s)
         b.connect(i1, i2, direction="uni")
         w = Wanderer(b)
         res = w.walk(max_steps=1, start=n1, lr=0.01)

--- a/tests/test_learning_paradigm_stacking.py
+++ b/tests/test_learning_paradigm_stacking.py
@@ -18,8 +18,14 @@ class TestLearningParadigmStacking(unittest.TestCase):
         it = iter(b.available_indices())
         i1 = next(it); i2 = next(it); i3 = next(it)
         n1 = b.add_neuron(i1, tensor=[1.0])
-        n2 = b.add_neuron(i2, tensor=[0.5])
-        n3 = b.add_neuron(i3, tensor=[0.25])
+        n2 = b.add_neuron(i2, tensor=[0.5], connect_to=i1, direction="uni")
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n1:
+                b.remove_synapse(s)
+        n3 = b.add_neuron(i3, tensor=[0.25], connect_to=i2, direction="uni")
+        for s in list(getattr(n3, "outgoing", [])):
+            if s.target is n2:
+                b.remove_synapse(s)
         s12 = b.connect(i1, i2, direction="uni")
         s23 = b.connect(i2, i3, direction="uni")
 

--- a/tests/test_lobe_training.py
+++ b/tests/test_lobe_training.py
@@ -7,9 +7,18 @@ class LobeTrainingTests(unittest.TestCase):
     def test_lobe_independent_training_and_plugins(self):
         b = Brain(1, size=4)
         n0 = b.add_neuron((0,), tensor=1.0)
-        n1 = b.add_neuron((1,), tensor=0.0)
-        n2 = b.add_neuron((2,), tensor=1.0)
-        n3 = b.add_neuron((3,), tensor=0.0)
+        n1 = b.add_neuron((1,), tensor=0.0, connect_to=(0,), direction="uni")
+        for s in list(getattr(n1, "outgoing", [])):
+            if s.target is n0:
+                b.remove_synapse(s)
+        n2 = b.add_neuron((2,), tensor=1.0, connect_to=(0,), direction="uni")
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n0:
+                b.remove_synapse(s)
+        n3 = b.add_neuron((3,), tensor=0.0, connect_to=(0,), direction="uni")
+        for s in list(getattr(n3, "outgoing", [])):
+            if s.target is n0:
+                b.remove_synapse(s)
         s01 = b.connect((0,), (1,))
         s23 = b.connect((2,), (3,))
 

--- a/tests/test_maxpool_improvement.py
+++ b/tests/test_maxpool_improvement.py
@@ -24,8 +24,20 @@ class TestMaxPoolImprovement(unittest.TestCase):
     def _add_free(self, b, tensor):
         for idx in b.available_indices():
             if b.get_neuron(idx) is None:
+                if b.neurons:
+                    first_idx = next(iter(b.neurons.keys()))
+                    n = b.add_neuron(idx, tensor=tensor, connect_to=first_idx)
+                    for s in list(getattr(n, "outgoing", [])):
+                        if s.target is b.get_neuron(first_idx):
+                            b.remove_synapse(s)
+                    return n
                 return b.add_neuron(idx, tensor=tensor)
-        return b.add_neuron(b.available_indices()[0], tensor=tensor)
+        first_idx = next(iter(b.neurons.keys()))
+        n = b.add_neuron(b.available_indices()[0], tensor=tensor, connect_to=first_idx)
+        for s in list(getattr(n, "outgoing", [])):
+            if s.target is b.get_neuron(first_idx):
+                b.remove_synapse(s)
+        return n
 
     def _loss_after_walk(self, w, steps, start):
         stats = w.walk(max_steps=steps, start=start, lr=1e-2)

--- a/tests/test_more_selfattention_plugins.py
+++ b/tests/test_more_selfattention_plugins.py
@@ -6,9 +6,13 @@ class MoreSelfAttentionPluginTests(unittest.TestCase):
         from marble.marblemain import Brain
         b = Brain(1, size=2)
         idxs = list(b.available_indices())
-        b.add_neuron(idxs[0], tensor=[0.0])
+        first = b.add_neuron(idxs[0], tensor=[0.0])
         if len(idxs) > 1:
-            b.add_neuron(idxs[1], tensor=[0.0])
+            second = b.add_neuron(idxs[1], tensor=[0.0], connect_to=idxs[0])
+            # remove auto synapse from second->first and recreate bidirectional link
+            for s in list(getattr(second, "outgoing", [])):
+                if s.target is first:
+                    b.remove_synapse(s)
             b.connect(idxs[0], idxs[1], direction="bi")
         return b
 

--- a/tests/test_neuron_pruning_mechanism.py
+++ b/tests/test_neuron_pruning_mechanism.py
@@ -9,7 +9,11 @@ class TestNeuronPruningMechanism(unittest.TestCase):
     def test_prune_after_two_hits(self) -> None:
         b = Brain(1, mode="sparse", sparse_bounds=((0.0, None),))
         n1 = b.add_neuron((0.0,), tensor=[0.0])
-        n2 = b.add_neuron((1.0,), tensor=[0.0])
+        n2 = b.add_neuron((1.0,), tensor=[0.0], connect_to=(0.0,))
+        # remove auto connection and reconnect both directions
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n1:
+                b.remove_synapse(s)
         b.connect((0.0,), (1.0,), direction="uni")
         b.connect((1.0,), (0.0,), direction="uni")
 

--- a/tests/test_new_wanderer_plugins.py
+++ b/tests/test_new_wanderer_plugins.py
@@ -7,8 +7,12 @@ from marble.marblemain import Brain, Wanderer
 class TestNewWandererPlugins(unittest.TestCase):
     def make_brain(self):
         b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
-        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        first = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        second = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        # remove auto synapse then connect bidirectionally
+        for s in list(getattr(second, "outgoing", [])):
+            if s.target is first:
+                b.remove_synapse(s)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
         return b
 

--- a/tests/test_quantumtype_plugin.py
+++ b/tests/test_quantumtype_plugin.py
@@ -12,8 +12,14 @@ class TestQuantumTypeNeuron(unittest.TestCase):
 
         b = Brain(1, size=(3,))
         src = b.add_neuron((0,), tensor=[2.0])
-        q = b.add_neuron((1,), tensor=[0.0], type_name="quantumtype")
-        dst = b.add_neuron((2,), tensor=[0.0])
+        q = b.add_neuron((1,), tensor=[0.0], type_name="quantumtype", connect_to=(0,), direction="uni")
+        for s in list(getattr(q, "outgoing", [])):
+            if s.target is src:
+                b.remove_synapse(s)
+        dst = b.add_neuron((2,), tensor=[0.0], connect_to=(0,), direction="uni")
+        for s in list(getattr(dst, "outgoing", [])):
+            if s.target is src:
+                b.remove_synapse(s)
         b.connect((0,), (1,), direction="uni")
         b.connect((1,), (2,), direction="uni")
 

--- a/tests/test_synapse_plugins.py
+++ b/tests/test_synapse_plugins.py
@@ -7,7 +7,11 @@ class TestAdvancedSynapsePlugins(unittest.TestCase):
 
         b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
         b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        b.add_neuron((1.0, 0.0), tensor=[0.0], weight=1.0, bias=0.0)
+        n2 = b.add_neuron((1.0, 0.0), tensor=[0.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        # remove auto synapse and reconnect with plugin
+        for s in list(getattr(n2, "outgoing", [])):
+            if getattr(getattr(s, "target", None), "position", None) == (0.0, 0.0):
+                b.remove_synapse(s)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="uni", type_name=plugin_name)
         return b
 

--- a/tests/test_ultra_neuroplasticity_plugins.py
+++ b/tests/test_ultra_neuroplasticity_plugins.py
@@ -7,8 +7,12 @@ class UltraNeuroplasticityPluginSuiteTests(unittest.TestCase):
 
         b = Brain(2, size=(3, 3))
         idxs = list(b.available_indices())
-        b.add_neuron(idxs[0], tensor=[0.0])
-        b.add_neuron(idxs[1], tensor=[0.0])
+        first = b.add_neuron(idxs[0], tensor=[0.0])
+        second = b.add_neuron(idxs[1], tensor=[0.0], connect_to=idxs[0])
+        # remove auto synapse and reconnect as originally
+        for s in list(getattr(second, "outgoing", [])):
+            if s.target is first:
+                b.remove_synapse(s)
         b.connect(idxs[0], idxs[1], direction="uni")
         return b
 

--- a/tests/test_ultra_wanderer_plugins.py
+++ b/tests/test_ultra_wanderer_plugins.py
@@ -6,8 +6,11 @@ from marble.marblemain import Brain, Wanderer
 class UltraWandererPluginSuiteTests(unittest.TestCase):
     def make_brain(self):
         b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
-        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        first = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        second = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        for s in list(getattr(second, "outgoing", [])):
+            if s.target is first:
+                b.remove_synapse(s)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
         return b
 

--- a/tests/test_wanderer.py
+++ b/tests/test_wanderer.py
@@ -11,7 +11,10 @@ class TestWanderer(unittest.TestCase):
         # Build a tiny sparse brain with two neurons connected bidirectionally
         b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
         n1 = b.add_neuron((0.0, 0.0), tensor=[1.0, 2.0], weight=1.0, bias=0.5)
-        n2 = b.add_neuron((1.0, 0.0), tensor=[0.5, 1.5], weight=0.8, bias=-0.2)
+        n2 = b.add_neuron((1.0, 0.0), tensor=[0.5, 1.5], weight=0.8, bias=-0.2, connect_to=(0.0, 0.0))
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n1:
+                b.remove_synapse(s)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
 
         # Snapshot original weights/biases
@@ -51,7 +54,10 @@ class TestWanderer(unittest.TestCase):
 
         b = Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
         b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        n2 = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is b.get_neuron((0.0, 0.0)):
+                b.remove_synapse(s)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
 
         w = Wanderer(b, type_name="det", seed=1)

--- a/tests/test_wanderer_helper_and_synapse.py
+++ b/tests/test_wanderer_helper_and_synapse.py
@@ -13,7 +13,10 @@ class TestWandererHelperAndSynapse(unittest.TestCase):
 
         b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
         n1 = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        n2 = b.add_neuron((1.0, 0.0), tensor=[0.0], weight=1.0, bias=0.0)
+        n2 = b.add_neuron((1.0, 0.0), tensor=[0.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        for s_tmp in list(getattr(n2, "outgoing", [])):
+            if s_tmp.target is n1:
+                b.remove_synapse(s_tmp)
         s = b.connect((0.0, 0.0), (1.0, 0.0), direction="uni")
         # Ensure synapse has weight and scaling applies
         self.assertTrue(hasattr(s, "weight"))
@@ -26,8 +29,11 @@ class TestWandererHelperAndSynapse(unittest.TestCase):
 
     def test_run_wanderer_training_history(self):
         b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
-        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        first = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        second = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        for s_tmp in list(getattr(second, "outgoing", [])):
+            if s_tmp.target is first:
+                b.remove_synapse(s_tmp)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
 
         pre_brain_id = id(b)

--- a/tests/test_wanderer_pre_forward.py
+++ b/tests/test_wanderer_pre_forward.py
@@ -9,7 +9,11 @@ class TestWandererPreForward(unittest.TestCase):
         i1 = next(it)
         i2 = next(it)
         n1 = b.add_neuron(i1, tensor=0.0)
-        b.add_neuron(i2, tensor=0.0)
+        n2 = b.add_neuron(i2, tensor=0.0, connect_to=i1, direction="uni")
+        # remove auto connection from n2->n1 and reconnect i1->i2
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n1:
+                b.remove_synapse(s)
         b.connect(i1, i2, direction="uni")
         w = Wanderer(b, pre_forward=True)
         w.walk(max_steps=1, start=n1, lr=1e-2)

--- a/tests/test_wanderer_resource_allocator.py
+++ b/tests/test_wanderer_resource_allocator.py
@@ -10,7 +10,11 @@ class TestResourceAllocatorPlugin(unittest.TestCase):
     def test_plugin_active_by_default_and_params(self):
         b = self.Brain(1, size=(4,))
         n1 = b.add_neuron((0,), tensor=0.0)
-        n2 = b.add_neuron((1,), tensor=0.0)
+        n2 = b.add_neuron((1,), tensor=0.0, connect_to=(0,), direction="uni")
+        # remove auto-created connection from n2->n1 to match original graph
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n1:
+                b.remove_synapse(s)
         b.connect(getattr(n1, "position"), getattr(n2, "position"), direction="uni")
         w = self.Wanderer(b)
         names = [p.__class__.__name__ for p in getattr(w, "_wplugins", [])]

--- a/tests/test_wanderer_walk_summary.py
+++ b/tests/test_wanderer_walk_summary.py
@@ -21,8 +21,11 @@ class TestWandererWalkSummary(unittest.TestCase):
         self.clear_report_group("training")
 
         b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
-        b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        first = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
+        second = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        for s in list(getattr(second, "outgoing", [])):
+            if s.target is first:
+                b.remove_synapse(s)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
 
         w = self.Wanderer(b, seed=123)

--- a/tests/test_wanderer_wayfinder_plugin.py
+++ b/tests/test_wanderer_wayfinder_plugin.py
@@ -15,8 +15,14 @@ class TestWayfinderPlugin(unittest.TestCase):
     def test_map_and_learnables(self):
         b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
         n0 = b.add_neuron((0.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        n1 = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0)
-        n2 = b.add_neuron((0.0, 1.0), tensor=[1.0], weight=1.0, bias=0.0)
+        n1 = b.add_neuron((1.0, 0.0), tensor=[1.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        for s in list(getattr(n1, "outgoing", [])):
+            if s.target is n0:
+                b.remove_synapse(s)
+        n2 = b.add_neuron((0.0, 1.0), tensor=[1.0], weight=1.0, bias=0.0, connect_to=(0.0, 0.0))
+        for s in list(getattr(n2, "outgoing", [])):
+            if s.target is n0:
+                b.remove_synapse(s)
         b.connect((0.0, 0.0), (1.0, 0.0), direction="uni")
         b.connect((0.0, 0.0), (0.0, 1.0), direction="uni")
 


### PR DESCRIPTION
## Summary
- ensure test brains connect new neurons upon creation to satisfy Brain's connectivity constraints

## Testing
- `python -m unittest tests.test_wanderer_resource_allocator -v`
- `python -m unittest tests.test_more_selfattention_plugins -v`
- `python -m unittest tests.test_ultra_neuroplasticity_plugins -v`
- `python -m unittest tests.test_synapse_plugins -v`
- `python -m unittest tests.test_new_wanderer_plugins -v`
- `python -m unittest tests.test_wanderer_pre_forward -v`
- `python -m unittest tests.test_learning_paradigm_stacking -v`
- `python -m unittest tests.test_ultra_wanderer_plugins -v`
- `python -m unittest tests.test_neuron_pruning_mechanism -v`
- `python -m unittest tests.test_conv_improvement -v`
- `python -m unittest tests.test_maxpool_improvement -v`
- `python -m unittest tests.test_curriculum_and_temp_plugins -v`
- `python -m unittest tests.test_learning_paradigm -v`
- `python -m unittest tests.test_lobe_training -v`
- `python -m unittest tests.test_quantumtype_plugin -v`
- `python -m unittest tests.test_wanderer_helper_and_synapse -v`
- `python -m unittest tests.test_wanderer_walk_summary -v`
- `python -m unittest tests.test_wanderer_wayfinder_plugin -v`
- `python -m unittest tests.test_wanderer -v`


------
https://chatgpt.com/codex/tasks/task_e_68b854a6e96c83279a738c3cd5200033