### PR TITLE
Ensure neurons connect on creation and respect small-tensor GPU threshold

### DIFF
--- a/marble/plugins/buildingblock_create_neuron.py
+++ b/marble/plugins/buildingblock_create_neuron.py
@@ -24,6 +24,8 @@ class CreateNeuronPlugin(BuildingBlock):
     ):
         idx = self._to_index(brain, index)
         conn = self._to_index(brain, connect_to_index) if connect_to_index is not None else None
+        if conn is None and brain.neurons:
+            conn = next(iter(brain.neurons))
         try:
             return brain.add_neuron(
                 idx,

--- a/marble/plugins/wanderer_resource_allocator.py
+++ b/marble/plugins/wanderer_resource_allocator.py
@@ -500,6 +500,9 @@ class ResourceAllocatorPlugin:
                 target_device = "disk"
             else:
                 target_device = "cpu"
+            size_mb = t.element_size() * t.nelement() / (1024 * 1024)
+            if target_device == "cuda" and size_mb < self.min_gpu_tensor_mb:
+                target_device = "cpu"
             self._safe_transfer(obj, attr, t, target_device)
 
     def start_auto_rebalance(self, wanderer, interval: float = 5.0) -> None:

--- a/tests/test_building_blocks.py
+++ b/tests/test_building_blocks.py
@@ -11,7 +11,7 @@ class TestBuildingBlocks(unittest.TestCase):
         brain = Brain(1, size=2)
         create = get_buildingblock_type("create_neuron")
         n0 = create.apply(brain, (0,), [0.0])
-        brain.add_neuron((1,), tensor=[0.0])
+        brain.add_neuron((1,), tensor=[0.0], connect_to=(0,))
         weight = get_buildingblock_type("change_neuron_weight")
         weight.apply(brain, (0,), 2.0)
         bias = get_buildingblock_type("change_neuron_bias")
@@ -94,9 +94,11 @@ class TestBuildingBlocks(unittest.TestCase):
     def test_synapse_blocks(self):
         brain = Brain(1, size=2)
         brain.add_neuron((0,), tensor=[0.0])
-        brain.add_neuron((1,), tensor=[0.0])
+        brain.add_neuron((1,), tensor=[0.0], connect_to=(0,))
         n0 = brain.get_neuron((0,))
         n1 = brain.get_neuron((1,))
+        for s in list(n1.incoming) + list(n1.outgoing):
+            brain.remove_synapse(s)
         cs = get_buildingblock_type("create_synapse")
         syn = cs.apply(brain, (0,), (1,), weight=1.0, bias=0.5)
         w = get_buildingblock_type("change_synapse_weight")

--- a/tests/test_conv2d_conv3d_improvement.py
+++ b/tests/test_conv2d_conv3d_improvement.py
@@ -21,19 +21,35 @@ class TestConv2D3DImprovement(unittest.TestCase):
 
         register_wanderer_type("det_conv_nd", DeterministicPlugin())
 
-    def _add_free(self, b, tensor):
+    def _add_free(self, b, tensor, connect_to=None, direction="bi", keep_connection=True):
         for idx in b.available_indices():
             if b.get_neuron(idx) is None:
-                return b.add_neuron(idx, tensor=tensor)
-        return b.add_neuron(b.available_indices()[0], tensor=tensor)
+                if connect_to is None:
+                    connect = next(iter(b.neurons.keys())) if b.neurons else None
+                else:
+                    connect = getattr(connect_to, "position", connect_to)
+                n = b.add_neuron(idx, tensor=tensor, connect_to=connect, direction=direction)
+                if not keep_connection:
+                    for s in list(n.incoming) + list(n.outgoing):
+                        b.remove_synapse(s)
+                return n
+        if connect_to is None:
+            connect = next(iter(b.neurons.keys())) if b.neurons else None
+        else:
+            connect = getattr(connect_to, "position", connect_to)
+        n = b.add_neuron(b.available_indices()[0], tensor=tensor, connect_to=connect, direction=direction)
+        if not keep_connection:
+            for s in list(n.incoming) + list(n.outgoing):
+                b.remove_synapse(s)
+        return n
 
     def _build_params(self, b, kernel_vals, stride=1, padding=0, dilation=1, bias=0.0):
         p = []
-        p.append(self._add_free(b, list(kernel_vals)))
-        p.append(self._add_free(b, [float(stride)]))
-        p.append(self._add_free(b, [float(padding)]))
-        p.append(self._add_free(b, [float(dilation)]))
-        p.append(self._add_free(b, [float(bias)]))
+        p.append(self._add_free(b, list(kernel_vals), keep_connection=False))
+        p.append(self._add_free(b, [float(stride)], keep_connection=False))
+        p.append(self._add_free(b, [float(padding)], keep_connection=False))
+        p.append(self._add_free(b, [float(dilation)], keep_connection=False))
+        p.append(self._add_free(b, [float(bias)], keep_connection=False))
         return p
 
     def _loss_after_walk(self, w, steps, start):
@@ -44,20 +60,19 @@ class TestConv2D3DImprovement(unittest.TestCase):
         b = self.Brain(2, size=(10, 10))
         avail = b.available_indices()
         # Build 2 data rows to form 2x3 input
-        row1 = self._add_free(b, [1.0, 2.0, 3.0])
-        row2 = self._add_free(b, [2.0, 3.0, 4.0])
-        dst = self._add_free(b, [0.0])
-        base = self._add_free(b, [0.0])
+        row1 = self._add_free(b, [1.0, 2.0, 3.0], keep_connection=False)
+        row2 = self._add_free(b, [2.0, 3.0, 4.0], keep_connection=False)
+        dst = self._add_free(b, [0.0], keep_connection=False)
+        base = self._add_free(b, [0.0], keep_connection=False)
         # Baseline path
         b.connect(getattr(row1, "position"), getattr(base, "position"), direction="uni")
         b.connect(getattr(base, "position"), getattr(dst, "position"), direction="uni")
 
         # Conv2d with zero kernel (2x2 zeros) and zero bias, stride=1, pad=0, dil=1
         params = self._build_params(b, [0.0, 0.0, 0.0, 0.0], 1, 0, 1, 0.0)
-        conv = self._add_free(b, [0.0])
+        conv = self._add_free(b, [0.0], connect_to=getattr(dst, "position"), direction="uni")
         self.wire_params(b, conv, params)
         self.wire_data(b, conv, [row1, row2])
-        b.connect(getattr(conv, "position"), getattr(dst, "position"), direction="uni")
         # Promote to conv2d
         conv.type_name = "conv2d"
         from marble.marblemain import _NEURON_TYPES  # noqa: E402
@@ -97,20 +112,19 @@ class TestConv2D3DImprovement(unittest.TestCase):
         b = self.Brain(2, size=(12, 12))
         avail = b.available_indices()
         # Build 2 slices, each 2x2 (flattened): total volume 2x2x2 when stacked
-        slice1 = self._add_free(b, [1.0, 2.0, 3.0, 4.0])
-        slice2 = self._add_free(b, [2.0, 3.0, 4.0, 5.0])
-        dst = self._add_free(b, [0.0])
-        base = self._add_free(b, [0.0])
+        slice1 = self._add_free(b, [1.0, 2.0, 3.0, 4.0], keep_connection=False)
+        slice2 = self._add_free(b, [2.0, 3.0, 4.0, 5.0], keep_connection=False)
+        dst = self._add_free(b, [0.0], keep_connection=False)
+        base = self._add_free(b, [0.0], keep_connection=False)
         # Baseline
         b.connect(getattr(slice1, "position"), getattr(base, "position"), direction="uni")
         b.connect(getattr(base, "position"), getattr(dst, "position"), direction="uni")
 
         # Conv3d with zero kernel cube (2x2x2 zeros) and zero bias
         params = self._build_params(b, [0.0] * 8, 1, 0, 1, 0.0)
-        conv = self._add_free(b, [0.0])
+        conv = self._add_free(b, [0.0], connect_to=getattr(dst, "position"), direction="uni")
         self.wire_params(b, conv, params)
         self.wire_data(b, conv, [slice1, slice2])
-        b.connect(getattr(conv, "position"), getattr(dst, "position"), direction="uni")
         conv.type_name = "conv3d"
         from marble.marblemain import _NEURON_TYPES  # noqa: E402
         plug = _NEURON_TYPES.get("conv3d")


### PR DESCRIPTION
## Summary
- Automatically link newly created neurons to an existing one when no connection is provided
- Avoid shuttling tiny tensors to GPU by honoring `min_gpu_tensor_mb`
- Update tests to connect neurons at creation and clean up temporary synapses

## Testing
- `pytest tests/test_building_blocks.py tests/test_conv2d_conv3d_improvement.py tests/test_conv_transpose_improvement.py -q`
- `pytest -q $(ls tests | grep -v 3d_printer_sim | sed 's/^/tests\//')`

------
https://chatgpt.com/codex/tasks/task_e_68b8a6169b888327b78309188759d52d