### PR TITLE
Set GPU tensor threshold to zero and fix neuron connectivity in tests

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 resource_allocator:
   max_disk_mb: 30720  # maximum MB for disk offload (30 GB)
   compress_offload: true  # store offloaded tensors in float16
-  min_gpu_tensor_mb: 1.0  # tensors smaller than this stay on CPU
+  min_gpu_tensor_mb: 0.0  # send all tensors to GPU regardless of size
   ram_offload_threshold: 0.9  # offload tensors to disk when RAM usage exceeds this ratio
   vram_offload_threshold: 0.9  # move tensors off GPU when VRAM usage exceeds this ratio
   disk_usage_threshold: 0.95  # stop offloading when disk usage exceeds this ratio

--- a/marble/plugins/wanderer_resource_allocator.py
+++ b/marble/plugins/wanderer_resource_allocator.py
@@ -155,7 +155,7 @@ class ResourceAllocatorPlugin:
         cfg = _load_resource_cfg()
         self.max_disk_mb = float(cfg.get("max_disk_mb", 30720))
         self.compress_offload = bool(cfg.get("compress_offload", True))
-        self.min_gpu_tensor_mb = float(cfg.get("min_gpu_tensor_mb", 1.0))
+        self.min_gpu_tensor_mb = float(cfg.get("min_gpu_tensor_mb", 0.0))
         self.ram_offload_threshold = float(cfg.get("ram_offload_threshold", 0.9))
         self.vram_offload_threshold = float(cfg.get("vram_offload_threshold", 0.9))
         self.disk_usage_threshold = float(cfg.get("disk_usage_threshold", 0.95))

--- a/tests/test_building_blocks.py
+++ b/tests/test_building_blocks.py
@@ -11,7 +11,7 @@ class TestBuildingBlocks(unittest.TestCase):
         brain = Brain(1, size=2)
         create = get_buildingblock_type("create_neuron")
         n0 = create.apply(brain, (0,), [0.0])
-        brain.add_neuron((1,), tensor=[0.0])
+        brain.add_neuron((1,), tensor=[0.0], connect_to=(0,))
         weight = get_buildingblock_type("change_neuron_weight")
         weight.apply(brain, (0,), 2.0)
         bias = get_buildingblock_type("change_neuron_bias")
@@ -94,7 +94,9 @@ class TestBuildingBlocks(unittest.TestCase):
     def test_synapse_blocks(self):
         brain = Brain(1, size=2)
         brain.add_neuron((0,), tensor=[0.0])
-        brain.add_neuron((1,), tensor=[0.0])
+        brain.add_neuron((1,), tensor=[0.0], connect_to=(0,))
+        for s in list(brain.synapses):
+            brain.remove_synapse(s)
         n0 = brain.get_neuron((0,))
         n1 = brain.get_neuron((1,))
         cs = get_buildingblock_type("create_synapse")

--- a/tests/test_conv2d_conv3d_improvement.py
+++ b/tests/test_conv2d_conv3d_improvement.py
@@ -24,7 +24,19 @@ class TestConv2D3DImprovement(unittest.TestCase):
     def _add_free(self, b, tensor):
         for idx in b.available_indices():
             if b.get_neuron(idx) is None:
+                if b.neurons:
+                    first = next(iter(b.neurons))
+                    neu = b.add_neuron(idx, tensor=tensor, connect_to=first)
+                    for s in list(neu.incoming) + list(neu.outgoing):
+                        b.remove_synapse(s)
+                    return neu
                 return b.add_neuron(idx, tensor=tensor)
+        if b.neurons:
+            first = next(iter(b.neurons))
+            neu = b.add_neuron(b.available_indices()[0], tensor=tensor, connect_to=first)
+            for s in list(neu.incoming) + list(neu.outgoing):
+                b.remove_synapse(s)
+            return neu
         return b.add_neuron(b.available_indices()[0], tensor=tensor)
 
     def _build_params(self, b, kernel_vals, stride=1, padding=0, dilation=1, bias=0.0):

--- a/tests/test_conv_transpose_improvement.py
+++ b/tests/test_conv_transpose_improvement.py
@@ -24,7 +24,19 @@ class TestConvTransposeImprovement(unittest.TestCase):
     def _add_free(self, b, tensor):
         for idx in b.available_indices():
             if b.get_neuron(idx) is None:
+                if b.neurons:
+                    first = next(iter(b.neurons))
+                    neu = b.add_neuron(idx, tensor=tensor, connect_to=first)
+                    for s in list(neu.incoming) + list(neu.outgoing):
+                        b.remove_synapse(s)
+                    return neu
                 return b.add_neuron(idx, tensor=tensor)
+        if b.neurons:
+            first = next(iter(b.neurons))
+            neu = b.add_neuron(b.available_indices()[0], tensor=tensor, connect_to=first)
+            for s in list(neu.incoming) + list(neu.outgoing):
+                b.remove_synapse(s)
+            return neu
         return b.add_neuron(b.available_indices()[0], tensor=tensor)
 
     def _build_params(self, b, kernel_vals, stride=1, padding=0, dilation=1, bias=0.0):

--- a/tests/test_resource_allocator_small_tensor_cpu.py
+++ b/tests/test_resource_allocator_small_tensor_cpu.py
@@ -12,7 +12,11 @@ from marble.plugins.wanderer_resource_allocator import (
 
 class ResourceAllocatorSmallTensorTests(unittest.TestCase):
     def test_small_tensor_stays_on_cpu(self) -> None:
-        plug = ResourceAllocatorPlugin()
+        with patch(
+            "marble.plugins.wanderer_resource_allocator._load_resource_cfg",
+            return_value={"min_gpu_tensor_mb": 1.0},
+        ):
+            plug = ResourceAllocatorPlugin()
         class Holder:
             pass
 

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -33,9 +33,10 @@
 - resource_allocator.compress_offload (bool, default: true)
   When true, tensors moved to CPU or disk are converted to ``float16`` to save
   space. They are restored to their original dtype when reloaded.
-- resource_allocator.min_gpu_tensor_mb (float, default: 1.0)
+- resource_allocator.min_gpu_tensor_mb (float, default: 0.0)
   Minimum tensor size in megabytes required before the allocator considers
-  moving it to GPU. Smaller tensors stay on CPU to avoid transfer overhead.
+  moving it to GPU. A value of ``0.0`` sends every tensor to GPU regardless of
+  size.
 - resource_allocator.ram_offload_threshold (float, default: 0.9)
   RAM usage ratio beyond which rarely accessed tensors are proactively
   offloaded to disk. Value must be between 0 and 1.


### PR DESCRIPTION
## Summary
- default all tensors to go to GPU by setting `min_gpu_tensor_mb` to 0
- document new resource allocator default
- ensure neurons are connected on creation in several tests and adjust tests accordingly

## Testing
- `python -m pytest tests/test_resource_allocator_small_tensor_cpu.py -q`
- `python -m pytest tests/test_building_blocks.py -q`
- `python -m pytest tests/test_conv2d_conv3d_improvement.py -q`
- `python -m pytest tests/test_conv_transpose_improvement.py -q`
- `python -m pytest tests/test_resource_allocator_disk_limit.py -q`
- `python -m pytest tests/test_resource_allocator_disk_usage.py -q`
- `python -m pytest tests/test_resource_allocator_hit_decay.py -q`
- `python -m pytest tests/test_resource_allocator_ram_pressure.py -q`
- `python -m pytest tests/test_resource_allocator_vram_overflow.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b914f45370832794b1bae9d2387946