### PR TITLE
Ensure run_training_with_datapairs applies optimizer and custom losses

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -2829,6 +2829,9 @@ def run_training_with_datapairs(
             lr_i /= batch_sz
         _current_target["val"] = enc_right
         stats = w.walk(max_steps=ms, start=start, lr=lr_i, lobe=lobe)
+        finish_loss, delta = w.walkfinish()
+        stats["loss"] = finish_loss
+        stats["delta"] = delta
         stats["plugins"] = [p.__class__.__name__ for p in getattr(w, "_wplugins", []) or []]
         history.append(stats)
         for p in train_plugins:

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -1110,7 +1110,17 @@ class Wanderer(_DeviceHelper):
                 terms.append(loss_mod(yt, tgt))
             base_loss = sum(terms) if terms else torch.tensor(0.0, device=self._device)
         elif callable(self._loss_spec):
-            base_loss = self._loss_spec(outputs)
+            if self._target_provider is not None:
+                terms = []
+                for y in outputs:
+                    try:
+                        tgt = self._target_provider(y)
+                        terms.append(self._loss_spec(y, tgt))
+                    except Exception:
+                        pass
+                base_loss = sum(terms) if terms else torch.tensor(0.0, device=self._device)
+            else:
+                base_loss = self._loss_spec(outputs)
         else:
             terms = []
             for y in outputs:


### PR DESCRIPTION
## Summary
- ensure `run_training_with_datapairs` executes `walkfinish` so Adam updates learnable parameters
- allow `Wanderer` to compute losses for callables that need targets via `_target_provider`

## Testing
- `pytest tests/test_training_with_datapairs.py -q`
- `pytest tests/test_learning_paradigm.py -q`
- `pytest tests/test_brain_status.py -q`
- `pytest tests/test_auto_max_steps.py -q`
- `pytest tests/test_neuroplasticity.py -q`
- `python examples/run_hf_image_quality.py` *(interrupted with Ctrl+C after metrics)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a0c68008327b4e1377d9083c64e