### PR TITLE
Log optional plugin toggles

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -237,11 +237,12 @@ def main(
         "DistillationPlugin",
         "WanderAlongSynapseWeightsPlugin",
         "DynamicDimensionsPlugin",
-        "MixedPrecisionPlugin",  # auto loss scaling via mixed precision
-        "QualityAwareRoutine",
-        "AdaptiveGradClipRoutine",
-        #"FindBestNeuronTypeRoutine",
-        "ContextAwareNoiseRoutine",
+        # The following plugins are intentionally left optional so that
+        # ``autoplugin`` can learn when to enable or disable them.
+        # "MixedPrecisionPlugin",  # auto loss scaling via mixed precision
+        # "QualityAwareRoutine",
+        # "AdaptiveGradClipRoutine",
+        # "ContextAwareNoiseRoutine",
     ]
     # Instantiate AutoPlugin with mandatory plugin support when available.
     try:

--- a/marble/plugins/wanderer_autoplugin.py
+++ b/marble/plugins/wanderer_autoplugin.py
@@ -141,7 +141,7 @@ class AutoPlugin:
         name: str,
         active: bool,
     ) -> None:
-        if not self._log_path:
+        if not self._log_path or name in self._mandatory:
             return
         key = (plugintype, name)
         state = self._log_state.setdefault(


### PR DESCRIPTION
## Summary
- avoid logging mandatory plugin events in `AutoPlugin`
- let `run_hf_image_quality` treat several plugins as optional so AutoPlugin can explore and log them

## Testing
- `python -m unittest -v tests.test_autoplugin_logging`
- `python -m unittest -v tests.test_autoplugin_mandatory`
- `python -m unittest -v tests.test_autoplugin_exclude`
- `python -m unittest -v tests.test_autoplugin_buildingblocks`
- `python -m unittest -v tests.test_autoplugin_bias`
- `python -m unittest -v tests.test_autoplugin_autodiscovery`
- `python examples/run_hf_image_quality.py` (aborted after metrics)


------
https://chatgpt.com/codex/tasks/task_e_68b931de9ac08327a862fc6248f94907