### PR TITLE
Add plugin encoder and global plugin IDs

### DIFF
--- a/marble/__init__.py
+++ b/marble/__init__.py
@@ -6,5 +6,6 @@ except Exception:
     pass
 
 from .auto_param import enable_auto_param_learning
+from .plugin_encoder import PluginEncoder
 
-__all__ = ["enable_auto_param_learning"]
+__all__ = ["enable_auto_param_learning", "PluginEncoder"]

--- a/marble/plugin_encoder.py
+++ b/marble/plugin_encoder.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""Encoding utilities for plugin-driven decision networks.
+
+This module provides the :class:`PluginEncoder` which maps plugin IDs to
+learnable embeddings and combines them with encoded walker context and past
+actions.  It is designed so that every plugin automatically receives a stable
+``plugin_id`` during registration.  Future plugins registered through the
+automatic discovery mechanism in :mod:`marble.plugins` will therefore be
+compatible without additional boilerplate.
+"""
+
+from typing import Iterable
+
+import torch
+from torch import nn
+
+
+class PluginEncoder(nn.Module):
+    """Encode plugin identifiers alongside context and action history.
+
+    Parameters
+    ----------
+    num_plugins:
+        Total number of registered plugins.  This determines the vocabulary
+        size for the embedding table.  The value can be obtained from
+        ``len(marble.plugins.PLUGIN_ID_REGISTRY)``.
+    embed_dim:
+        Dimensionality of the embedding vectors for plugin IDs.
+    action_dim:
+        Dimensionality used for summarising past actions.
+    ctx_dim:
+        Size of each context vector fed into the recurrent unit.
+    rnn_type:
+        Either ``"gru"`` or ``"lstm"`` specifying which recurrent unit is
+        used to aggregate the walker context.
+    """
+
+    def __init__(
+        self,
+        num_plugins: int,
+        embed_dim: int = 16,
+        action_dim: int = 16,
+        ctx_dim: int = 16,
+        *,
+        rnn_type: str = "gru",
+    ) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding(num_plugins, embed_dim)
+        rnn_cls = nn.GRU if rnn_type.lower() == "gru" else nn.LSTM
+        self.ctx_rnn = rnn_cls(ctx_dim, ctx_dim, batch_first=True)
+        # Reuse the plugin embedding matrix for past actions so that action
+        # identifiers correspond to plugin IDs.
+        self.action_embed = self.embedding
+
+    def forward(
+        self,
+        plugin_ids: torch.Tensor,
+        ctx_seq: torch.Tensor,
+        past_action_ids: torch.Tensor | Iterable[int],
+    ) -> torch.Tensor:
+        """Return concatenated feature representation.
+
+        Parameters
+        ----------
+        plugin_ids:
+            Tensor of shape ``(batch,)`` containing the IDs of plugins for
+            which features are being generated.
+        ctx_seq:
+            Context tensor of shape ``(batch, steps, ctx_dim)`` describing the
+            walker state across ``steps`` time steps.
+        past_action_ids:
+            Tensor of shape ``(batch, history)`` listing previously executed
+            plugin IDs.  The embedding of these IDs is averaged to produce a
+            fixed-size vector representing the action history.
+        """
+
+        if not isinstance(past_action_ids, torch.Tensor):
+            past_action_ids = torch.tensor(list(past_action_ids), dtype=torch.long, device=plugin_ids.device)
+            past_action_ids = past_action_ids.unsqueeze(0).expand(plugin_ids.size(0), -1)
+
+        plug_emb = self.embedding(plugin_ids)
+        _, h_ctx = self.ctx_rnn(ctx_seq)
+        if isinstance(h_ctx, tuple):  # LSTM returns (h, c)
+            h_ctx = h_ctx[0]
+        h_ctx = h_ctx.squeeze(0)
+        past_emb = self.action_embed(past_action_ids)
+        past_emb = past_emb.mean(dim=1)
+        return torch.cat([plug_emb, h_ctx, past_emb], dim=-1)
+
+
+__all__ = ["PluginEncoder"]

--- a/marble/plugins/__init__.py
+++ b/marble/plugins/__init__.py
@@ -20,6 +20,26 @@ from ..selfattention import register_selfattention_type
 from ..marblemain import register_brain_train_type
 from ..buildingblock import register_buildingblock_type
 
+# Global registry assigning a unique numeric ID to every plugin.  The IDs are
+# stable across runs as long as the set of available plugins does not change.
+# This enables neural modules to embed plugins via ``nn.Embedding`` without any
+# manual bookkeeping in individual plugin implementations.
+PLUGIN_ID_REGISTRY: dict[str, int] = {}
+
+
+def _assign_plugin_id(name: str, cls: type) -> int:
+    """Return a stable integer ID for ``name`` and attach it to ``cls``.
+
+    The assigned ID is stored both in :data:`PLUGIN_ID_REGISTRY` and as
+    ``plugin_id``/``PLUGIN_ID`` attributes on the plugin class so that
+    instantiated plugins can access it directly.
+    """
+
+    pid = PLUGIN_ID_REGISTRY.setdefault(name, len(PLUGIN_ID_REGISTRY))
+    setattr(cls, "PLUGIN_ID", pid)
+    setattr(cls, "plugin_id", pid)
+    return pid
+
 
 def _find_plugin_class(module: Any) -> Optional[Type[Any]]:
     for obj in module.__dict__.values():
@@ -43,23 +63,47 @@ for mod in pkgutil.iter_modules(__path__):
     plugin_name = getattr(module, "PLUGIN_NAME", None)
     if name.startswith("wanderer_"):
         base = name[len("wanderer_") :]
-        register_wanderer_type(plugin_name or base, cls())
+        pid = _assign_plugin_id(plugin_name or base, cls)
+        inst = cls()
+        inst.plugin_id = pid
+        register_wanderer_type(plugin_name or base, inst)
     elif name.startswith("neuroplasticity_"):
         base = name[len("neuroplasticity_") :]
-        register_neuroplasticity_type(plugin_name or base, cls())
+        pid = _assign_plugin_id(plugin_name or base, cls)
+        inst = cls()
+        inst.plugin_id = pid
+        register_neuroplasticity_type(plugin_name or base, inst)
     elif name.startswith("selfattention_"):
         base = name[len("selfattention_") :]
-        register_selfattention_type(plugin_name or base, cls())
+        pid = _assign_plugin_id(plugin_name or base, cls)
+        inst = cls()
+        inst.plugin_id = pid
+        register_selfattention_type(plugin_name or base, inst)
     elif name.startswith("synapse_"):
         base = name[len("synapse_") :]
-        register_synapse_type(plugin_name or base, cls())
+        pid = _assign_plugin_id(plugin_name or base, cls)
+        inst = cls()
+        inst.plugin_id = pid
+        register_synapse_type(plugin_name or base, inst)
     elif name.startswith("brain_train_"):
         base = name[len("brain_train_") :]
-        register_brain_train_type(plugin_name or base, cls())
+        pid = _assign_plugin_id(plugin_name or base, cls)
+        inst = cls()
+        inst.plugin_id = pid
+        register_brain_train_type(plugin_name or base, inst)
     elif name.startswith("buildingblock_"):
         base = name[len("buildingblock_") :]
-        register_buildingblock_type(plugin_name or base, cls())
+        pid = _assign_plugin_id(plugin_name or base, cls)
+        inst = cls()
+        inst.plugin_id = pid
+        register_buildingblock_type(plugin_name or base, inst)
     else:
         # Default to neuron plugin registration
-        register_neuron_type(plugin_name or name, cls())
+        pid = _assign_plugin_id(plugin_name or name, cls)
+        inst = cls()
+        inst.plugin_id = pid
+        register_neuron_type(plugin_name or name, inst)
+
+
+__all__ += ["PLUGIN_ID_REGISTRY"]
 

--- a/tests/test_plugin_encoder.py
+++ b/tests/test_plugin_encoder.py
@@ -1,0 +1,26 @@
+import unittest
+
+import torch
+
+from marble.plugin_encoder import PluginEncoder
+import marble.plugins as plugins
+
+
+class PluginEncoderTest(unittest.TestCase):
+    def test_encode_shapes(self) -> None:
+        num_plugins = len(plugins.PLUGIN_ID_REGISTRY)
+        self.assertGreater(num_plugins, 0)
+        encoder = PluginEncoder(num_plugins, embed_dim=4, action_dim=4, ctx_dim=3)
+        # Pick first plugin id
+        pid = next(iter(plugins.PLUGIN_ID_REGISTRY.values()))
+        plugin_ids = torch.tensor([pid], dtype=torch.long)
+        ctx_seq = torch.zeros(1, 2, 3)
+        past_ids = torch.tensor([[pid, pid]])
+        out = encoder(plugin_ids, ctx_seq, past_ids)
+        print("encoded_shape", tuple(out.shape))
+        expected_dim = 4 + 3 + 4
+        self.assertEqual(out.shape, (1, expected_dim))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Assign a stable numeric `plugin_id` to every plugin during auto-registration so models can embed plugin choices.
- Introduce `PluginEncoder` using an `nn.Embedding` table plus GRU/LSTM context encoder to combine plugin IDs, walker context and past actions.
- Add regression test ensuring `PluginEncoder` outputs concatenated features with expected dimensions.

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest -v tests.test_conv_improvement`
- `python -m unittest -v tests.test_plugin_encoder`


------
https://chatgpt.com/codex/tasks/task_e_68b948fe052c83279dff486c080f7208