### PR TITLE
Add reward shaper with OLS trends

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,3 +12,5 @@ decision_controller:
 max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection
 auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs
+reward_shaper:
+  window_size: 10  # number of recent steps for OLS

--- a/marble/reward_shaper.py
+++ b/marble/reward_shaper.py
@@ -1,0 +1,115 @@
+"""Reward shaping based on performance trends.
+
+Maintains a sliding window of latency, throughput and cost statistics. For each
+window, Ordinary Least Squares (OLS) is used to estimate the linear trend of
+these metrics over time. The resulting slopes are combined into a shaped reward
+suited for actor–critic updates: decreasing latency and cost yield positive
+rewards while increasing throughput is rewarded.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Dict, Tuple
+import os
+import torch
+
+
+def _config_window_size() -> int:
+    """Load ``reward_shaper.window_size`` from ``config.yaml``.
+
+    Returns a value of at least ``2``. Falls back to ``10`` if the file or entry
+    is missing or invalid.
+    """
+
+    try:
+        base = os.path.dirname(os.path.dirname(__file__))
+        with open(os.path.join(base, "config.yaml"), "r", encoding="utf-8") as fh:
+            in_section = False
+            for raw in fh:
+                line = raw.split("#", 1)[0].strip().lower()
+                if not line:
+                    continue
+                if line.startswith("reward_shaper:"):
+                    in_section = True
+                    continue
+                if in_section:
+                    if line.startswith("window_size:"):
+                        try:
+                            val = int(line.split(":", 1)[1])
+                            return max(2, val)
+                        except Exception:
+                            return 10
+                    if line[0] not in (" ", "\t"):
+                        break
+    except Exception:
+        pass
+    return 10
+
+
+class RewardShaper:
+    """Track performance metrics and compute shaped rewards.
+
+    Parameters
+    ----------
+    window_size:
+        Number of recent samples kept for trend estimation. Defaults to the
+        ``reward_shaper.window_size`` value from :mod:`config.yaml`.
+    """
+
+    def __init__(self, window_size: int | None = None) -> None:
+        size = window_size if window_size is not None else _config_window_size()
+        self.window_size = max(2, int(size))
+        self._lat: Deque[float] = deque(maxlen=self.window_size)
+        self._thr: Deque[float] = deque(maxlen=self.window_size)
+        self._cost: Deque[float] = deque(maxlen=self.window_size)
+
+    @staticmethod
+    def _ols_beta(values: Deque[float]) -> float:
+        """Return the slope of ``values`` over their indices using OLS.
+
+        The computation is performed using ``torch`` tensors to comply with the
+        repository policy that torch is imported when numerical work occurs.
+        """
+
+        n = len(values)
+        if n < 2:
+            return 0.0
+        x = torch.arange(float(n))
+        y = torch.tensor(list(values), dtype=torch.float32)
+        x_mean = x.mean()
+        y_mean = y.mean()
+        cov = ((x - x_mean) * (y - y_mean)).sum()
+        var = ((x - x_mean) ** 2).sum()
+        beta = cov / var if var != 0 else torch.tensor(0.0)
+        return float(beta)
+
+    def update(self, latency: float, throughput: float, cost: float) -> Tuple[float, Dict[str, float]]:
+        """Add a new observation and return shaped reward and betas.
+
+        Parameters
+        ----------
+        latency, throughput, cost:
+            Latest performance statistics.
+
+        Returns
+        -------
+        reward, betas:
+            A tuple containing the shaped reward and a dictionary mapping metric
+            names to their corresponding OLS slopes.
+        """
+
+        self._lat.append(float(latency))
+        self._thr.append(float(throughput))
+        self._cost.append(float(cost))
+
+        beta_lat = self._ols_beta(self._lat)
+        beta_thr = self._ols_beta(self._thr)
+        beta_cost = self._ols_beta(self._cost)
+
+        reward = -beta_lat + beta_thr - beta_cost
+        betas = {"latency": beta_lat, "throughput": beta_thr, "cost": beta_cost}
+        return reward, betas
+
+
+__all__ = ["RewardShaper"]

--- a/tests/test_reward_shaper.py
+++ b/tests/test_reward_shaper.py
@@ -1,0 +1,32 @@
+import unittest
+import torch
+
+from marble.reward_shaper import RewardShaper
+
+
+class TestRewardShaper(unittest.TestCase):
+    def test_reward_and_window(self):
+        rs = RewardShaper(window_size=3)
+        data = [
+            (3.0, 1.0, 3.0),
+            (2.0, 2.0, 2.0),
+            (1.0, 3.0, 1.0),
+            (0.0, 4.0, 0.0),
+        ]
+        rewards = []
+        for lat, thr, cost in data:
+            r, betas = rs.update(lat, thr, cost)
+            print("step", len(rewards), "reward", r, "betas", betas)
+            rewards.append(r)
+        # After initial fill, latency and cost decreasing -> negative betas
+        self.assertLess(betas["latency"], 0.0)
+        self.assertLess(betas["cost"], 0.0)
+        self.assertGreater(betas["throughput"], 0.0)
+        self.assertGreater(rewards[-1], 0.0)
+        # Sliding window size should not exceed 3
+        self.assertEqual(rs._lat.maxlen, 3)
+        self.assertEqual(len(rs._lat), 3)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -59,3 +59,9 @@
   Maximum cumulative cost allowed for plugin actions during a single decision
   step. Actions exceeding the remaining budget are discarded starting with the
   highest cost.
+
+## Reward Shaper Settings
+
+- reward_shaper.window_size (int, default: 10)
+  Number of recent performance samples kept for computing OLS trends used to
+  shape actor-critic rewards. Must be at least 2.


### PR DESCRIPTION
## Summary
- add `RewardShaper` utility that tracks latency, throughput, and cost, estimating OLS trends
- expose `reward_shaper.window_size` configuration and document it
- test reward shaping and window behaviour

## Testing
- `python -m unittest -v tests.test_reward_shaper`
- `python -m unittest -v tests.test_conv_improvement`


------
https://chatgpt.com/codex/tasks/task_e_68b94c32568883278e2f4d5d67df0dbc