### PR TITLE
Implement plugin action sampling with Bernoulli and Gumbel top-k

### DIFF
--- a/marble/__init__.py
+++ b/marble/__init__.py
@@ -7,5 +7,12 @@ except Exception:
 
 from .auto_param import enable_auto_param_learning
 from .plugin_encoder import PluginEncoder
+from .action_sampler import compute_logits, sample_actions, select_plugins
 
-__all__ = ["enable_auto_param_learning", "PluginEncoder"]
+__all__ = [
+    "enable_auto_param_learning",
+    "PluginEncoder",
+    "compute_logits",
+    "sample_actions",
+    "select_plugins",
+]

--- a/marble/action_sampler.py
+++ b/marble/action_sampler.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Utility functions for sampling plugin actions based on embeddings.
+
+The module exposes helpers to compute logits from plugin embeddings and
+sample a subset of plugin identifiers via either Bernoulli sampling or
+Gumbel top-k selection."""
+
+from typing import List
+
+import torch
+
+
+def compute_logits(e_t: torch.Tensor, e_a_t: torch.Tensor) -> torch.Tensor:
+    """Return logits ``z_i`` from plugin and action embeddings.
+
+    Parameters
+    ----------
+    e_t:
+        Tensor of shape ``(num_plugins, d)`` containing embeddings for each
+        plugin.
+    e_a_t:
+        Tensor of shape ``(d,)`` representing the aggregated action
+        embedding.
+    """
+    return e_t @ e_a_t
+
+
+def sample_actions(
+    logits: torch.Tensor,
+    *,
+    mode: str = "bernoulli",
+    top_k: int = 1,
+) -> torch.Tensor:
+    """Sample plugin actions from ``logits``.
+
+    Parameters
+    ----------
+    logits:
+        Tensor of shape ``(num_plugins,)`` with unnormalised log probabilities.
+    mode:
+        Either ``"bernoulli"`` for independent Bernoulli trials or
+        ``"gumbel-top-k"`` for Gumbel top-k sampling.
+    top_k:
+        Number of selections when ``mode`` is ``"gumbel-top-k"``.
+    """
+    if mode == "bernoulli":
+        probs = torch.sigmoid(logits)
+        return torch.bernoulli(probs).to(torch.long)
+    if mode == "gumbel-top-k":
+        gumbels = -torch.log(-torch.log(torch.rand_like(logits)))
+        scores = logits + gumbels
+        _, idx = scores.topk(top_k)
+        out = torch.zeros_like(logits, dtype=torch.long)
+        out.scatter_(0, idx, 1)
+        return out
+    raise ValueError(f"unknown sampling mode: {mode}")
+
+
+def select_plugins(
+    plugin_ids: torch.Tensor,
+    e_t: torch.Tensor,
+    e_a_t: torch.Tensor,
+    *,
+    mode: str = "bernoulli",
+    top_k: int = 1,
+) -> List[int]:
+    """Return a subset of ``plugin_ids`` based on sampled actions."""
+    logits = compute_logits(e_t, e_a_t)
+    mask = sample_actions(logits, mode=mode, top_k=top_k)
+    indices = mask.nonzero(as_tuple=False).squeeze(1)
+    return plugin_ids[indices].tolist()
+
+
+__all__ = ["compute_logits", "sample_actions", "select_plugins"]

--- a/tests/test_action_sampler.py
+++ b/tests/test_action_sampler.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import torch
+from marble.action_sampler import select_plugins
+
+
+class TestActionSampler(unittest.TestCase):
+    def test_bernoulli_sampling(self) -> None:
+        plugin_ids = torch.tensor([5, 6, 7])
+        e_t = torch.tensor([[20.0, 0.0], [-20.0, 0.0], [-20.0, 0.0]])
+        e_a = torch.tensor([1.0, 0.0])
+        selected = select_plugins(plugin_ids, e_t, e_a, mode="bernoulli")
+        print("bernoulli selected ids:", selected)
+        self.assertEqual(selected, [5])
+
+    def test_gumbel_topk_sampling(self) -> None:
+        torch.manual_seed(0)
+        plugin_ids = torch.tensor([10, 11, 12, 13])
+        e_t = torch.tensor([
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0, 0.0],
+            [0.0, 0.0, 3.0, 0.0],
+            [0.0, 0.0, 0.0, 4.0],
+        ])
+        e_a = torch.ones(4)
+        selected = select_plugins(plugin_ids, e_t, e_a, mode="gumbel-top-k", top_k=2)
+        print("gumbel selected ids:", selected)
+        self.assertEqual(selected, [11, 13])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add `action_sampler` utility to convert plugin embeddings into logits and sample actions via Bernoulli or Gumbel-top-k
- expose sampling helpers from `marble.__init__`
- cover sampling modes with dedicated unit tests

## Testing
- `python tests/test_action_sampler.py`

------
https://chatgpt.com/codex/tasks/task_e_68b954db35ec83279192c2682672635b