### PR TITLE
Add L1 contribution regressor for decision controller

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,7 @@ autoplugin:
   decision_interval: 1  # steps between plugin selector decisions
 decision_controller:
   budget: 10.0  # maximum total cost for selected actions
+  contribution_l1: 0.01  # L1 penalty for contribution regressor
 max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection
 auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs

--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import os
 from typing import Dict, Iterable, List, Any, Set
 
+import torch
+
 from .constraints import check_budget, check_incompatibility, check_throughput
 
 # Incompatibility sets I_t: mapping plugin name to set of incompatible plugins
@@ -62,7 +64,104 @@ def _load_budget() -> float:
 BUDGET_LIMIT = _load_budget()
 
 
-def decide_actions(h_t: Dict[str, Dict[str, float]], x_t: Dict[str, Any], history: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+def _load_l1_penalty() -> float:
+    """Load L1 penalty for contribution regressor from ``config.yaml``."""
+    base = os.path.dirname(os.path.dirname(__file__))
+    cfg: Dict[str, Dict[str, Any]] = {}
+    try:
+        with open(os.path.join(base, "config.yaml"), "r", encoding="utf-8") as fh:
+            section: str | None = None
+            for raw in fh:
+                line = raw.split("#", 1)[0].rstrip()
+                if not line:
+                    continue
+                if not line.startswith(" ") and line.endswith(":"):
+                    section = line[:-1].strip()
+                    cfg[section] = {}
+                    continue
+                if section and ":" in line:
+                    k, v = line.split(":", 1)
+                    try:
+                        cfg[section][k.strip()] = float(v.strip())
+                    except Exception:
+                        cfg[section][k.strip()] = v.strip()
+    except Exception:
+        return 0.0
+    dc = cfg.get("decision_controller", {})
+    try:
+        return float(dc.get("contribution_l1", 0.0))
+    except Exception:
+        return 0.0
+
+
+L1_PENALTY = _load_l1_penalty()
+
+
+def train_contribution_regressor(
+    activation: torch.Tensor,
+    outcomes: torch.Tensor,
+    l1_penalty: float | None = None,
+    lr: float = 0.01,
+    epochs: int = 1000,
+) -> torch.Tensor:
+    """Train linear regressor ``q_a(z)`` with ℓ1 penalty.
+
+    Parameters
+    ----------
+    activation:
+        Matrix of plugin activations with shape ``(samples, plugins)``.
+    outcomes:
+        Target outcomes corresponding to each row in ``activation``.
+    l1_penalty:
+        Strength of the ℓ1 penalty. When ``None``, uses value from config.
+    lr:
+        Learning rate for simple gradient descent.
+    epochs:
+        Number of optimization steps.
+
+    Returns
+    -------
+    torch.Tensor
+        Learned weight vector of shape ``(plugins,)``.
+    """
+
+    if l1_penalty is None:
+        l1_penalty = L1_PENALTY
+    weights = torch.zeros(activation.shape[1], device=activation.device, requires_grad=True)
+    for _ in range(epochs):
+        pred = activation @ weights
+        loss = ((pred - outcomes) ** 2).mean() + l1_penalty * weights.abs().sum()
+        loss.backward()
+        with torch.no_grad():
+            weights -= lr * weights.grad
+            weights.grad.zero_()
+    return weights.detach()
+
+
+def estimate_plugin_contributions(
+    activation: torch.Tensor,
+    outcomes: torch.Tensor,
+    plugin_names: List[str],
+    l1_penalty: float | None = None,
+) -> Dict[str, float]:
+    """Estimate per-plugin contribution scores.
+
+    The contribution score for each plugin corresponds to the learned weight
+    of the ℓ1-regularized regressor.
+    """
+
+    weights = train_contribution_regressor(activation, outcomes, l1_penalty)
+    return {
+        name: float(w.detach().to("cpu").item()) for name, w in zip(plugin_names, weights)
+    }
+
+
+def decide_actions(
+    h_t: Dict[str, Dict[str, float]],
+    x_t: Dict[str, Any],
+    history: Iterable[Dict[str, Any]],
+    contrib_scores: Dict[str, float] | None = None,
+) -> Dict[str, Any]:
     """Select actions while enforcing incompatibilities, capacity and budget.
 
     Parameters
@@ -74,6 +173,9 @@ def decide_actions(h_t: Dict[str, Dict[str, float]], x_t: Dict[str, Any], histor
     history:
         Iterable of previous action dictionaries. Used to enforce capacity
         limits across time.
+    contrib_scores:
+        Optional mapping of plugin names to contribution scores. Higher scores
+        effectively reduce the plugin's cost during selection.
 
     Returns
     -------
@@ -90,7 +192,11 @@ def decide_actions(h_t: Dict[str, Dict[str, float]], x_t: Dict[str, Any], histor
             running_costs[name] = running_costs.get(name, 0.0) + cost
 
     # Sort candidates by cost so cheaper actions are preferred under budget
-    ordered = sorted(x_t.items(), key=lambda kv: h_t.get(kv[0], {}).get("cost", 0.0))
+    ordered = sorted(
+        x_t.items(),
+        key=lambda kv: h_t.get(kv[0], {}).get("cost", 0.0)
+        - (contrib_scores.get(kv[0], 0.0) if contrib_scores else 0.0),
+    )
 
     selected: Dict[str, Any] = {}
     active: Set[str] = set()
@@ -98,6 +204,8 @@ def decide_actions(h_t: Dict[str, Dict[str, float]], x_t: Dict[str, Any], histor
 
     for name, action in ordered:
         cost = float(h_t.get(name, {}).get("cost", 0.0))
+        if contrib_scores:
+            cost -= float(contrib_scores.get(name, 0.0))
         if not check_throughput(name, usage, CAPACITY_LIMITS):
             continue
         if not check_budget(name, cost, remaining, running_costs, BUDGET_LIMIT):
@@ -114,4 +222,12 @@ def decide_actions(h_t: Dict[str, Dict[str, float]], x_t: Dict[str, Any], histor
     return selected
 
 
-__all__ = ["decide_actions", "INCOMPATIBILITY_SETS", "CAPACITY_LIMITS", "BUDGET_LIMIT"]
+__all__ = [
+    "decide_actions",
+    "INCOMPATIBILITY_SETS",
+    "CAPACITY_LIMITS",
+    "BUDGET_LIMIT",
+    "train_contribution_regressor",
+    "estimate_plugin_contributions",
+    "L1_PENALTY",
+]

--- a/tests/test_contribution_regressor.py
+++ b/tests/test_contribution_regressor.py
@@ -1,0 +1,22 @@
+import unittest
+import torch
+import marble.decision_controller as dc
+
+
+class TestContributionRegressor(unittest.TestCase):
+    def test_contribution_influences_selection(self):
+        torch.manual_seed(0)
+        activation = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+        outcomes = torch.tensor([2.0, -1.0, 1.0])
+        contribs = dc.estimate_plugin_contributions(activation, outcomes, ["A", "B"], l1_penalty=0.01)
+        h_t = {"A": {"cost": 5.0}, "B": {"cost": 4.0}}
+        x_t = {"A": "on", "B": "on"}
+        dc.BUDGET_LIMIT = 5.0
+        selected = dc.decide_actions(h_t, x_t, [], contrib_scores=contribs)
+        print("contribs:", contribs)
+        print("selected with contribs:", selected)
+        self.assertEqual(selected, {"A": "on"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -59,6 +59,9 @@
   Maximum cumulative cost allowed for plugin actions during a single decision
   step. Actions exceeding the remaining budget are discarded starting with the
   highest cost.
+- decision_controller.contribution_l1 (float, default: 0.01)
+  L1 penalty strength applied when training the plugin contribution regressor.
+  Higher values yield sparser contribution weights.
 
 ## Reward Shaper Settings
 


### PR DESCRIPTION
## Summary
- extend config and manual with `contribution_l1` to tune L1 penalty
- add training and estimation helpers for plugin contributions using an ℓ1-regularized linear model
- allow decision controller to prioritize plugins based on learned contributions and test the integration

## Testing
- `python -m unittest -v tests.test_contribution_regressor`
- `python -m unittest -v tests.test_decision_controller`


------
https://chatgpt.com/codex/tasks/task_e_68b9589ad1b083279acb140af4d1001e