### PR TITLE
Implement plugin state-change penalty

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,7 @@ autoplugin:
 decision_controller:
   budget: 10.0  # maximum total cost for selected actions
   contribution_l1: 0.01  # L1 penalty for contribution regressor
+  tau_threshold: 1.0  # minimum seconds between state changes before penalty
 max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection
 auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs

--- a/tests/test_decision_controller.py
+++ b/tests/test_decision_controller.py
@@ -1,4 +1,5 @@
 import unittest
+import time
 import marble.decision_controller as dc
 
 
@@ -28,6 +29,19 @@ class TestDecisionController(unittest.TestCase):
         history = [{"A": "on"}]
         selected = dc.decide_actions(h_t, x_t, history)
         print("selected with per-plugin budget:", selected)
+        self.assertEqual(selected, {"B": "on"})
+
+    def test_tau_penalty(self):
+        dc.BUDGET_LIMIT = 5.0
+        dc.TAU_THRESHOLD = 5.0
+        dc.LAST_STATE_CHANGE.clear()
+        now = time.time()
+        dc.record_plugin_state_change("A", now)
+        h_t = {"A": {"cost": 1}, "B": {"cost": 1}}
+        x_t = {"A": "on", "B": "on"}
+        history = []
+        selected = dc.decide_actions(h_t, x_t, history)
+        print("selected with tau penalty:", selected)
         self.assertEqual(selected, {"B": "on"})
 
 

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -62,6 +62,10 @@
 - decision_controller.contribution_l1 (float, default: 0.01)
   L1 penalty strength applied when training the plugin contribution regressor.
   Higher values yield sparser contribution weights.
+- decision_controller.tau_threshold (float, default: 1.0)
+  Minimum seconds a plugin should wait between state changes. When the actual
+  interval \(\tau_t\) falls below this value, a penalty of ``tau_threshold - \tau_t``
+  is added to the plugin's cost during action selection.
 
 ## Reward Shaper Settings
 


### PR DESCRIPTION
## Summary
- track last state-change time per plugin and apply cost penalty when executed too soon
- configure minimum interval via new `decision_controller.tau_threshold` setting with docs
- test decision controller penalty behavior

## Testing
- `python -m unittest -v tests.test_decision_controller`
- `python -m unittest -v tests.test_reward_shaper`


------
https://chatgpt.com/codex/tasks/task_e_68b95ef264608327ac5e95fe8393f95b