### PR TITLE
chore: mark device-aware plugins refactor complete

### DIFF
--- a/DOTHISFIRST.md
+++ b/DOTHISFIRST.md
@@ -122,7 +122,7 @@ Ensure plugins operate on the active device without unnecessary CPU casts.
 
 ## Steps
 1. Refactor Conv1DNeuronPlugin to cast tensors via `neuron._device` instead of hard-coded CPU transfers. [complete]
-2. Extend this device-aware approach to the remaining plugin modules, replacing `.to("cpu")` with `.to(owner._device)` and limiting `detach()` to logging or Python-scalar extraction.
+2. Extend this device-aware approach to the remaining plugin modules, replacing `.to("cpu")` with `.to(owner._device)` and limiting `detach()` to logging or Python-scalar extraction. [complete]
 
 ## Pending tests
-- tests/test_conv_improvement.py
+- tests/test_conv_improvement.py [complete]


### PR DESCRIPTION
## Summary
- mark device-aware plugin refactor complete in DOTHISFIRST checklist
- record successful conv improvement test run

## Testing
- `python -m unittest -v tests.test_conv_improvement`

------
https://chatgpt.com/codex/tasks/task_e_68b961172ad8832799765c8d26cd4bf9