### PR TITLE
Add policy gradient agent module

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,6 +8,7 @@ This project provides a single-file core library in `marble/marblemain.py` that 
 - Autograd-driven Wanderer with plugin points and neuroplasticity hooks
 - High-level training helpers (including DataPair flows and epochs)
 - Global Reporter for structured logs and auditability
+- Policy gradient utilities with entropy regularization and constraint support
 
 All imports are centralized in `marble/marblemain.py`; other files must not import.
 

--- a/marble/__init__.py
+++ b/marble/__init__.py
@@ -9,6 +9,7 @@ from .auto_param import enable_auto_param_learning
 from .plugin_encoder import PluginEncoder
 from .action_sampler import compute_logits, sample_actions, select_plugins
 from .offpolicy import Trajectory, importance_weights, doubly_robust
+from .policy_gradient import PolicyGradientAgent
 
 __all__ = [
     "enable_auto_param_learning",
@@ -19,4 +20,5 @@ __all__ = [
     "Trajectory",
     "importance_weights",
     "doubly_robust",
+    "PolicyGradientAgent",
 ]

--- a/marble/policy_gradient.py
+++ b/marble/policy_gradient.py
@@ -1,0 +1,111 @@
+"""Policy gradient training helpers.
+
+This module implements a lightweight policy gradient agent with
+entropy regularization, a critic baseline, and action constraints.
+It avoids ``torch.optim`` and ``torch.nn`` layers by operating directly
+on tensors.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence, List
+
+import torch
+
+ConstraintFn = Callable[[torch.Tensor], torch.Tensor]
+
+
+class PolicyGradientAgent:
+    """Simple policy gradient agent with entropy bonus and constraints.
+
+    Parameters
+    ----------
+    state_dim:
+        Dimension of the input state vector.
+    action_dim:
+        Number of discrete actions.
+    lr:
+        Learning rate for the manual gradient step.
+    beta:
+        Weight for the entropy bonus.
+    lambdas:
+        Coefficients for constraint penalties.  ``lambdas[i]`` is paired with
+        ``constraints[i]``.
+    constraints:
+        Sequence of callables ``g_j`` taking an action tensor and returning a
+        penalty tensor of the same shape.
+    """
+
+    def __init__(
+        self,
+        state_dim: int,
+        action_dim: int,
+        lr: float = 1e-2,
+        beta: float = 0.01,
+        lambdas: Sequence[float] | None = None,
+        constraints: Sequence[ConstraintFn] | None = None,
+    ) -> None:
+        self.state_dim = int(state_dim)
+        self.action_dim = int(action_dim)
+        self.lr = float(lr)
+        self.beta = float(beta)
+        self.lambdas: List[float] = list(lambdas) if lambdas is not None else []
+        self.constraints: List[ConstraintFn] = list(constraints) if constraints is not None else []
+
+        # Policy parameters: linear logits ``s @ Wp + bp``
+        self.Wp = torch.zeros(self.state_dim, self.action_dim, requires_grad=True)
+        self.bp = torch.zeros(self.action_dim, requires_grad=True)
+        # Critic parameters: value estimate ``s @ Wv + bv``
+        self.Wv = torch.zeros(self.state_dim, 1, requires_grad=True)
+        self.bv = torch.zeros(1, requires_grad=True)
+
+    # ------------------------------------------------------------------
+    # Helper functions
+    # ------------------------------------------------------------------
+    def _policy_logits(self, states: torch.Tensor) -> torch.Tensor:
+        return states @ self.Wp + self.bp
+
+    def _values(self, states: torch.Tensor) -> torch.Tensor:
+        return (states @ self.Wv + self.bv).squeeze(-1)
+
+    def action_probs(self, states: torch.Tensor) -> torch.Tensor:
+        """Return action probabilities for each state."""
+        return torch.softmax(self._policy_logits(states), dim=-1)
+
+    # ------------------------------------------------------------------
+    # Training step
+    # ------------------------------------------------------------------
+    def step(
+        self,
+        states: torch.Tensor,
+        actions: torch.Tensor,
+        returns: torch.Tensor,
+    ) -> float:
+        """Perform a single policy/critic update and return the loss."""
+        probs = self.action_probs(states)
+        dist = torch.distributions.Categorical(probs=probs)
+        log_probs = dist.log_prob(actions)
+        entropy = dist.entropy()
+
+        values = self._values(states)
+        advantages = returns - values.detach()
+
+        penalty = torch.zeros_like(log_probs)
+        for lam, g in zip(self.lambdas, self.constraints):
+            penalty = penalty + lam * g(actions)
+
+        loss_pg = -(log_probs * (advantages - penalty) + self.beta * entropy)
+        loss_critic = 0.5 * (returns - values) ** 2
+        loss = (loss_pg + loss_critic).mean()
+
+        for p in [self.Wp, self.bp, self.Wv, self.bv]:
+            if p.grad is not None:
+                p.grad.zero_()
+        loss.backward()
+        with torch.no_grad():
+            for p in [self.Wp, self.bp, self.Wv, self.bv]:
+                p -= self.lr * p.grad
+        return loss.detach().to("cpu").item()
+
+
+__all__ = ["PolicyGradientAgent"]

--- a/tests/test_policy_gradient.py
+++ b/tests/test_policy_gradient.py
@@ -1,0 +1,44 @@
+import os
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import torch
+from marble.policy_gradient import PolicyGradientAgent
+
+
+class TestPolicyGradient(unittest.TestCase):
+    def test_policy_update_increases_rewarded_action(self) -> None:
+        torch.manual_seed(0)
+        agent = PolicyGradientAgent(state_dim=1, action_dim=2, lr=0.1, beta=0.0)
+        states = torch.zeros(2, 1)
+        actions = torch.tensor([0, 1])
+        returns = torch.tensor([1.0, 0.0])
+
+        init_probs = agent.action_probs(states)[0].detach().clone()
+        loss = agent.step(states, actions, returns)
+        new_probs = agent.action_probs(states)[0].detach()
+        print("initial probs", init_probs.tolist(), "updated probs", new_probs.tolist(), "loss", loss)
+        self.assertGreater(new_probs[0], init_probs[0])
+
+    def test_constraint_penalty_discourages_action(self) -> None:
+        torch.manual_seed(0)
+        g1 = lambda a: (a == 1).float()
+        agent = PolicyGradientAgent(
+            state_dim=1, action_dim=2, lr=0.1, beta=0.0, lambdas=[5.0], constraints=[g1]
+        )
+        states = torch.zeros(2, 1)
+        actions = torch.tensor([1, 1])
+        returns = torch.tensor([1.0, 1.0])
+
+        init_probs = agent.action_probs(states)[0].detach().clone()
+        agent.step(states, actions, returns)
+        new_probs = agent.action_probs(states)[0].detach()
+        print("constraint initial", init_probs.tolist(), "constraint updated", new_probs.tolist())
+        self.assertLess(new_probs[1], init_probs[1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add PolicyGradientAgent module with entropy bonus, critic baseline and constraint penalties
- expose PolicyGradientAgent via package init and document capability in ARCHITECTURE.md
- cover policy and constraint behavior with dedicated unit tests

## Testing
- `python -m unittest -v tests.test_policy_gradient`


------
https://chatgpt.com/codex/tasks/task_e_68b9623a57d083278c65725f03cd1016