### PR TITLE
Integrate advanced decision controller

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ decision_controller:
   budget: 10.0  # maximum total cost for selected actions
   contribution_l1: 0.01  # L1 penalty for contribution regressor
   tau_threshold: 1.0  # minimum seconds between state changes before penalty
+  cadence: 1  # walk steps between controller decisions
 max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection
 auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -66,6 +66,10 @@
   Minimum seconds a plugin should wait between state changes. When the actual
   interval \(\tau_t\) falls below this value, a penalty of ``tau_threshold - \tau_t``
   is added to the plugin's cost during action selection.
+- decision_controller.cadence (int, default: 1)
+  Number of walk steps between successive decisions of the controller. Actions
+  are only reconsidered on steps that are multiples of this cadence. Must be at
+  least 1.
 
 ## Reward Shaper Settings
 


### PR DESCRIPTION
## Summary
- Orchestrate plugin selection with new `DecisionController` class integrating embeddings, stochastic sampling, reward shaping, actor-critic updates, and off-policy logging
- Add Bayesian contribution estimator and configurable decision cadence
- Document cadence parameter and exercise cadence behavior in tests

## Testing
- `pytest tests/test_decision_controller.py -q`
- `pytest tests/test_plugin_encoder.py -q`
- `pytest tests/test_reward_shaper.py -q`
- `pytest tests/test_offpolicy.py -q`
- `pytest tests/test_action_sampler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b972df28f0832787c2b62c75054064