### PR TITLE
feat: integrate dwell time in decision controller

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,7 @@ decision_controller:
   contribution_l1: 0.01  # L1 penalty for contribution regressor
   tau_threshold: 1.0  # minimum seconds between state changes before penalty
   cadence: 1  # walk steps between controller decisions
+  dwell_bonus: 0.1  # cost reduction per consecutive active step
 max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection
 auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs

--- a/marble/plugins/wanderer_actor_critic.py
+++ b/marble/plugins/wanderer_actor_critic.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-"""Actor-Critic based Wanderer plugin.
+r"""Actor-Critic based Wanderer plugin.
 
 This plugin maintains tiny actor and critic models built directly with
 :mod:`torch` tensor operations.  At each step it computes a discounted

--- a/tests/test_decision_controller.py
+++ b/tests/test_decision_controller.py
@@ -11,7 +11,7 @@ class TestDecisionController(unittest.TestCase):
         h_t = {"A": {"cost": 2}, "B": {"cost": 1}, "C": {"cost": 4}}
         x_t = {"A": "on", "B": "on", "C": "on"}
         history = [{"B": "on"}]
-        selected = dc.decide_actions(h_t, x_t, history)
+        selected = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
         print("selected after constraints:", selected)
         self.assertEqual(selected, {"A": "on"})
 
@@ -20,7 +20,7 @@ class TestDecisionController(unittest.TestCase):
         h_t = {"A": {"cost": 2}, "B": {"cost": 1}, "C": {"cost": 4}}
         x_t = {"A": "on", "B": "on", "C": "on"}
         history = []
-        selected = dc.decide_actions(h_t, x_t, history)
+        selected = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
         print("selected under budget:", selected)
         self.assertEqual(selected, {"B": "on", "A": "on"})
 
@@ -29,7 +29,7 @@ class TestDecisionController(unittest.TestCase):
         h_t = {"A": {"cost": 3}, "B": {"cost": 3}}
         x_t = {"A": "on", "B": "on"}
         history = [{"A": "on"}]
-        selected = dc.decide_actions(h_t, x_t, history)
+        selected = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
         print("selected with per-plugin budget:", selected)
         self.assertEqual(selected, {"B": "on"})
 
@@ -42,7 +42,7 @@ class TestDecisionController(unittest.TestCase):
         h_t = {"A": {"cost": 1}, "B": {"cost": 1}}
         x_t = {"A": "on", "B": "on"}
         history = []
-        selected = dc.decide_actions(h_t, x_t, history)
+        selected = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
         print("selected with tau penalty:", selected)
         self.assertEqual(selected, {"B": "on"})
 
@@ -57,6 +57,20 @@ class TestDecisionController(unittest.TestCase):
         sel2 = controller.decide(h_t, ctx, metrics={"latency": 1, "throughput": 1, "cost": 1})
         print("second cadence selection:", sel2)
         self.assertTrue(set(sel2).issubset(set(names)))
+
+    def test_dwell_bonus(self):
+        dc.BUDGET_LIMIT = 3.0
+        dc.DWELL_BONUS = 1.0
+        dc.DWELL_COUNT.clear()
+        h_t = {"A": {"cost": 2}, "B": {"cost": 2}}
+        x_t = {"A": "on", "B": "on"}
+        history = []
+        sel1 = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
+        sel2 = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
+        print("first selection:", sel1)
+        print("second selection with dwell bonus:", sel2)
+        self.assertEqual(sel1, {"A": "on"})
+        self.assertEqual(sel2, {"A": "on"})
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -70,6 +70,10 @@
   Number of walk steps between successive decisions of the controller. Actions
   are only reconsidered on steps that are multiples of this cadence. Must be at
   least 1.
+- decision_controller.dwell_bonus (float, default: 0.1)
+  Cost reduction applied for each consecutive step a plugin remains active.
+  Larger values encourage persistence by making long-running plugins
+  progressively cheaper under the budget constraint.
 
 ## Reward Shaper Settings
 


### PR DESCRIPTION
## Summary
- reward persistent plugins with dwell-time bonus in decision controller
- add dwell_bonus config and documentation
- fix ActorCritic plugin docstring escape and add dwell bonus test

## Testing
- `python -m unittest -v tests.test_decision_controller`
- `python -m unittest -v tests.test_actor_critic_plugin`


------
https://chatgpt.com/codex/tasks/task_e_68b9774585408327b9dc39ccc8456420