### PR TITLE
feat: auto plugin cost and metric watching

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,8 @@ decision_controller:
   tau_threshold: 1.0  # minimum seconds between state changes before penalty
   cadence: 1  # walk steps between controller decisions
   dwell_bonus: 0.1  # cost reduction per consecutive active step
+  watch_metrics: []  # reporter paths to monitor automatically
+  watch_variables: []  # module.variable paths to observe
 max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection
 auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs

--- a/tests/test_decision_watchers.py
+++ b/tests/test_decision_watchers.py
@@ -1,0 +1,41 @@
+import sys
+import types
+import unittest
+
+from marble.decision_controller import (
+    DecisionController,
+    L1_PENALTY,
+    get_plugin_cost,
+)
+from marble.reporter import REPORTER, clear_report_group
+
+
+class TestDecisionWatchers(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_report_group("metrics")
+
+    def test_watchers_collect_values(self) -> None:
+        REPORTER.item["latency", "metrics"] = 5.0
+        dc = DecisionController(
+            watch_metrics=["metrics/latency"],
+            watch_variables=["marble.decision_controller.L1_PENALTY"],
+        )
+        values = dc._gather_watchables()
+        print("watcher collected:", values)
+        self.assertEqual(values["metrics/latency"], 5.0)
+        self.assertEqual(
+            values["marble.decision_controller.L1_PENALTY"], L1_PENALTY
+        )
+
+    def test_plugin_cost_autodetect(self) -> None:
+        mod = types.ModuleType("marble.plugins.fakeplugin")
+        mod.PLUGIN_COST = 7.5
+        sys.modules["marble.plugins.fakeplugin"] = mod
+        cost = get_plugin_cost("fakeplugin")
+        print("auto detected cost:", cost)
+        self.assertEqual(cost, 7.5)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)
+

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -74,6 +74,14 @@
   Cost reduction applied for each consecutive step a plugin remains active.
   Larger values encourage persistence by making long-running plugins
   progressively cheaper under the budget constraint.
+- decision_controller.watch_metrics (list[str], default: [])
+  Reporter item paths (``group[/subgroup]/item``) automatically queried each
+  decision step. Numeric values are merged into the ``metrics`` dict supplied
+  to :meth:`DecisionController.decide`.
+- decision_controller.watch_variables (list[str], default: [])
+  Fully qualified ``module.attr`` names of numeric variables to observe. Their
+  current values are sampled every decision and merged into the ``metrics``
+  dictionary.
 
 ## Reward Shaper Settings
 


### PR DESCRIPTION
## Summary
- let DecisionController auto-compute plugin cost when absent
- support automatic watching of reporter metrics and module variables
- document new watch settings in config

## Testing
- `pytest tests/test_decision_watchers.py::TestDecisionWatchers::test_watchers_collect_values -q`
- `pytest tests/test_decision_watchers.py::TestDecisionWatchers::test_plugin_cost_autodetect -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_dwell_bonus -q`
- `python count_numeric_parameters.py config.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68b97ba243b483279db9cbe9e2e4674d