### PR TITLE
Integrate contribution learning into DecisionController

### DIFF
--- a/tests/test_decision_controller_contrib.py
+++ b/tests/test_decision_controller_contrib.py
@@ -1,0 +1,29 @@
+import unittest
+import torch
+import marble.decision_controller as dc
+from marble.plugins import PLUGIN_ID_REGISTRY
+
+
+class TestDecisionControllerContribution(unittest.TestCase):
+    def test_controller_uses_contributions(self):
+        torch.manual_seed(0)
+        controller = dc.DecisionController(cadence=1, top_k=2)
+        names = list(PLUGIN_ID_REGISTRY.keys())[:2]
+        id0 = PLUGIN_ID_REGISTRY[names[0]]
+        id1 = PLUGIN_ID_REGISTRY[names[1]]
+        n = len(PLUGIN_ID_REGISTRY)
+        act1 = torch.zeros(n); act1[id0] = 1
+        act2 = torch.zeros(n); act2[id1] = 1
+        act3 = torch.zeros(n); act3[id0] = 1; act3[id1] = 1
+        controller._activation_log = [act1, act2, act3]
+        controller._reward_log = [2.0, -1.0, 1.0]
+        dc.BUDGET_LIMIT = 5.0
+        h_t = {names[0]: {'cost': 5.0}, names[1]: {'cost': 4.0}}
+        ctx = torch.zeros(1, 1, controller.encoder.embedding.embedding_dim)
+        sel = controller.decide(h_t, ctx, metrics={'latency': 1, 'throughput': 1, 'cost': 1})
+        print('selected with auto contributions:', sel)
+        self.assertEqual(sel, {names[0]: 'on'})
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- log plugin activations and rewards inside `DecisionController` and compute contribution scores from history
- use those scores to bias future action selection and keep logs updated
- add regression test covering contribution-aware decisions

## Testing
- `python -m pytest -q tests/test_decision_controller.py`
- `python -m pytest -q tests/test_contribution_regressor.py`
- `python -m pytest -q tests/test_decision_controller_contrib.py`


------
https://chatgpt.com/codex/tasks/task_e_68b980d876548327902a4e5620cae68b