### PR TITLE
feat: enforce soft budget via policy gradient

### DIFF
--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -58,7 +58,8 @@
 - decision_controller.budget (float, default: 10.0)
   Maximum cumulative cost allowed for plugin actions during a single decision
   step. Actions exceeding the remaining budget are discarded starting with the
-  highest cost.
+  highest cost. The same limit normalises the soft budget penalty used by the
+  decision controller's policy-gradient learner.
 - decision_controller.contribution_l1 (float, default: 0.01)
   L1 penalty strength applied when training the plugin contribution regressor.
   Higher values yield sparser contribution weights.


### PR DESCRIPTION
## Summary
- integrate plugin cost vector into DecisionController
- apply soft budget constraint in policy-gradient agent and document usage

## Testing
- `PYTHONPATH=. pytest tests/test_decision_controller.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_contrib.py -q`
- `PYTHONPATH=. pytest tests/test_decision_watchers.py -q`
- `PYTHONPATH=. pytest tests/test_autoplugin_decision_interval.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9833fefa08327bcdfb12f48251945