### PR TITLE
feat(decision): track last metrics

### DIFF
--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -525,6 +525,10 @@ class DecisionController:
         self.watch_variables = set(
             watch_variables if watch_variables is not None else WATCH_VARIABLES
         )
+        # Store the most recent metrics observed via ``decide`` so callers can
+        # inspect them even before the first decision step has been executed.
+        # ``decide`` updates this mapping in-place when new metrics arrive.
+        self.last_metrics: Dict[str, float] = {}
         # Logs used by the contribution regressor. Each entry in
         # ``_activation_log`` is a binary vector of length equal to the number
         # of registered plugins indicating which plugins were active during a


### PR DESCRIPTION
## Summary
- track most recent metrics in DecisionController

## Testing
- `python -m pytest tests/test_action_sampler.py -q`
- `python -m pytest tests/test_plugin_encoder.py -q`
- `python -m pytest tests/test_reward_shaper.py -q`
- `python -m pytest tests/test_offpolicy.py -q`
- `python -m pytest tests/test_policy_gradient.py -q`
- `python -m pytest tests/test_decision_controller.py -q`
- `python -m pytest tests/test_decision_controller_contrib.py -q`
- `python -m pytest tests/test_decision_watchers.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b986db53488327af634480a2752ee7