### PR TITLE
refactor: centralize contribution estimation in controller

### DIFF
--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -622,9 +622,13 @@ class DecisionController:
             try:
                 activation = torch.stack(self._activation_log)
                 outcomes = torch.tensor(self._reward_log, dtype=torch.float32)
-                all_names = list(PLUGIN_ID_REGISTRY.keys())
-                contrib_map = estimate_plugin_contributions(
-                    activation, outcomes, all_names
+                # ``compute_contributions`` encapsulates both the classical
+                # and Bayesian estimators defined in this module.  Using it
+                # here avoids duplicating estimator selection logic in the
+                # controller and makes future estimator extensions instantly
+                # available to the decision loop.
+                contrib_map = self.compute_contributions(
+                    activation, outcomes, list(PLUGIN_ID_REGISTRY.keys())
                 )
                 contrib_scores = {
                     n: contrib_map.get(n, 0.0) for n in plugin_names if n in contrib_map


### PR DESCRIPTION
## Summary
- reuse `compute_contributions` inside `DecisionController.decide` to avoid duplicated estimator logic and enable Bayesian extensions

## Testing
- `python -m unittest tests.test_decision_controller -v`
- `python -m unittest tests.test_decision_controller_contrib -v`
- `python -m unittest tests.test_decision_watchers -v`


------
https://chatgpt.com/codex/tasks/task_e_68b989042c5c832785eb0fd71070a1df