### PR TITLE
Add configurable reward penalties and windowed metric shaping

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,3 +23,10 @@ auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs
 reward_shaper:
   window_size: 10  # number of recent steps for OLS
+  w1: 1.0  # weight for latency slope
+  w2: 1.0  # weight for throughput slope
+  w3: 1.0  # weight for cost slope
+  w4: 1.0  # weight for throughput-normalized drop
+  w5: 1.0  # weight for divergence indicator
+  w6: 1.0  # weight for action penalties
+  M_div: 0.1  # divergence threshold for throughput drop

--- a/marble/reward_shaper.py
+++ b/marble/reward_shaper.py
@@ -9,42 +9,51 @@ rewards while increasing throughput is rewarded.
 
 from __future__ import annotations
 
-from collections import deque
-from typing import Deque, Dict, Tuple
+from typing import Dict, List, Tuple
 import os
 import torch
 
 
-def _config_window_size() -> int:
-    """Load ``reward_shaper.window_size`` from ``config.yaml``.
+def _load_reward_config() -> Dict[str, float]:
+    """Load reward-shaper parameters from ``config.yaml``.
 
-    Returns a value of at least ``2``. Falls back to ``10`` if the file or entry
-    is missing or invalid.
+    The configuration section ``reward_shaper`` may define ``window_size``,
+    weights ``w1`` through ``w6`` and the divergence threshold ``M_div``. Missing
+    entries fall back to sensible defaults. ``window_size`` is clamped to at
+    least ``2`` to ensure meaningful slope estimates.
     """
 
+    defaults: Dict[str, float] = {
+        "window_size": 10,
+        "w1": 1.0,
+        "w2": 1.0,
+        "w3": 1.0,
+        "w4": 1.0,
+        "w5": 1.0,
+        "w6": 1.0,
+        "M_div": 0.1,
+    }
     try:
         base = os.path.dirname(os.path.dirname(__file__))
         with open(os.path.join(base, "config.yaml"), "r", encoding="utf-8") as fh:
-            in_section = False
+            section: str | None = None
             for raw in fh:
-                line = raw.split("#", 1)[0].strip().lower()
+                line = raw.split("#", 1)[0].rstrip()
                 if not line:
                     continue
-                if line.startswith("reward_shaper:"):
-                    in_section = True
+                if not line.startswith(" ") and line.endswith(":"):
+                    section = line[:-1].strip()
                     continue
-                if in_section:
-                    if line.startswith("window_size:"):
-                        try:
-                            val = int(line.split(":", 1)[1])
-                            return max(2, val)
-                        except Exception:
-                            return 10
-                    if line[0] not in (" ", "\t"):
-                        break
+                if section == "reward_shaper" and ":" in line:
+                    k, v = line.split(":", 1)
+                    try:
+                        defaults[k.strip()] = float(v.strip())
+                    except Exception:
+                        continue
     except Exception:
         pass
-    return 10
+    defaults["window_size"] = max(2, int(defaults.get("window_size", 10)))
+    return defaults
 
 
 class RewardShaper:
@@ -53,30 +62,47 @@ class RewardShaper:
     Parameters
     ----------
     window_size:
-        Number of recent samples kept for trend estimation. Defaults to the
+        Number of recent samples used when computing slopes. Defaults to the
         ``reward_shaper.window_size`` value from :mod:`config.yaml`.
+    w1..w6:
+        Optional overrides for reward weights. When ``None`` the corresponding
+        value from configuration is used.
+    M_div:
+        Divergence threshold for the throughput-normalised drop indicator.
     """
 
-    def __init__(self, window_size: int | None = None) -> None:
-        size = window_size if window_size is not None else _config_window_size()
+    def __init__(
+        self,
+        window_size: int | None = None,
+        *,
+        w1: float | None = None,
+        w2: float | None = None,
+        w3: float | None = None,
+        w4: float | None = None,
+        w5: float | None = None,
+        w6: float | None = None,
+        M_div: float | None = None,
+    ) -> None:
+        cfg = _load_reward_config()
+        size = window_size if window_size is not None else cfg["window_size"]
         self.window_size = max(2, int(size))
-        self._lat: Deque[float] = deque(maxlen=self.window_size)
-        self._thr: Deque[float] = deque(maxlen=self.window_size)
-        self._cost: Deque[float] = deque(maxlen=self.window_size)
+        self.w1 = float(cfg["w1"] if w1 is None else w1)
+        self.w2 = float(cfg["w2"] if w2 is None else w2)
+        self.w3 = float(cfg["w3"] if w3 is None else w3)
+        self.w4 = float(cfg["w4"] if w4 is None else w4)
+        self.w5 = float(cfg["w5"] if w5 is None else w5)
+        self.w6 = float(cfg["w6"] if w6 is None else w6)
+        self.M_div = float(cfg["M_div"] if M_div is None else M_div)
 
     @staticmethod
-    def _ols_beta(values: Deque[float]) -> float:
-        """Return the slope of ``values`` over their indices using OLS.
+    def _ols_beta(x_vals: List[float], y_vals: List[float]) -> float:
+        """Return the slope of ``y_vals`` over ``x_vals`` using OLS."""
 
-        The computation is performed using ``torch`` tensors to comply with the
-        repository policy that torch is imported when numerical work occurs.
-        """
-
-        n = len(values)
+        n = len(x_vals)
         if n < 2:
             return 0.0
-        x = torch.arange(float(n))
-        y = torch.tensor(list(values), dtype=torch.float32)
+        x = torch.tensor(x_vals, dtype=torch.float32)
+        y = torch.tensor(y_vals, dtype=torch.float32)
         x_mean = x.mean()
         y_mean = y.mean()
         cov = ((x - x_mean) * (y - y_mean)).sum()
@@ -84,32 +110,91 @@ class RewardShaper:
         beta = cov / var if var != 0 else torch.tensor(0.0)
         return float(beta)
 
-    def update(self, latency: float, throughput: float, cost: float) -> Tuple[float, Dict[str, float]]:
-        """Add a new observation and return shaped reward and betas.
+    @staticmethod
+    def _ema(values: List[float], alpha: float = 0.5) -> float:
+        """Return the exponential moving average of ``values``."""
+
+        if not values:
+            return 0.0
+        ema = float(values[0])
+        for v in values[1:]:
+            ema = alpha * float(v) + (1.0 - alpha) * ema
+        return ema
+
+    def update(
+        self,
+        window: List[Dict[str, float]],
+        action_mask: Dict[str, int],
+        action_deltas: Dict[str, int],
+        h_t: Dict[str, Dict[str, float]],
+        incompat: Dict[str, set] | None = None,
+    ) -> Tuple[float, Dict[str, float]]:
+        """Compute shaped reward from ``window`` and action information.
 
         Parameters
         ----------
-        latency, throughput, cost:
-            Latest performance statistics.
-
-        Returns
-        -------
-        reward, betas:
-            A tuple containing the shaped reward and a dictionary mapping metric
-            names to their corresponding OLS slopes.
+        window:
+            List of recent metric dictionaries. Each entry may contain
+            ``latency``, ``throughput``, ``cost`` and ``wall_time``.
+        action_mask:
+            Mapping of plugin names to ``1`` if active in the current step.
+        action_deltas:
+            Mapping of plugin names to ``1`` when their activation state toggled
+            in this step.
+        h_t:
+            Plugin metadata containing at least per-plugin ``cost`` values.
+        incompat:
+            Optional incompatibility mapping used to penalise conflicting
+            activations.
         """
 
-        self._lat.append(float(latency))
-        self._thr.append(float(throughput))
-        self._cost.append(float(cost))
+        incompat = incompat or {}
+        lat = [m.get("latency", 0.0) for m in window]
+        thr = [m.get("throughput", 0.0) for m in window]
+        cst = [m.get("cost", 0.0) for m in window]
+        times = [m.get("wall_time", i) for i, m in enumerate(window)]
 
-        beta_lat = self._ols_beta(self._lat)
-        beta_thr = self._ols_beta(self._thr)
-        beta_cost = self._ols_beta(self._cost)
+        ema_thr = self._ema(thr)
+        beta_lat = self._ols_beta(times, lat)
+        beta_thr = self._ols_beta(times, thr)
+        beta_cost = self._ols_beta(times, cst)
 
-        reward = -beta_lat + beta_thr - beta_cost
-        betas = {"latency": beta_lat, "throughput": beta_thr, "cost": beta_cost}
-        return reward, betas
+        drop = 0.0
+        if ema_thr > 0.0:
+            drop = max(0.0, -beta_thr) / max(ema_thr, 1e-6)
+        divergence = 1.0 if drop > self.M_div else 0.0
+
+        toggle_pen = float(sum(abs(v) for v in action_deltas.values()))
+        active = [n for n, v in action_mask.items() if v]
+        compat_pen = 0.0
+        for i, a in enumerate(active):
+            for b in active[i + 1 :]:
+                if b in incompat.get(a, set()):
+                    compat_pen += 1.0
+        compute_pen = float(sum(h_t.get(n, {}).get("cost", 0.0) for n in active))
+        total_pen = toggle_pen + compat_pen + compute_pen
+
+        reward = (
+            self.w1 * (-beta_lat)
+            + self.w2 * beta_thr
+            + self.w3 * (-beta_cost)
+            + self.w4 * (-drop)
+            + self.w5 * (-divergence)
+            + self.w6 * (-total_pen)
+        )
+
+        components = {
+            "latency_slope": beta_lat,
+            "throughput_slope": beta_thr,
+            "cost_slope": beta_cost,
+            "throughput_drop": drop,
+            "divergence": divergence,
+            "toggle_penalty": toggle_pen,
+            "compatibility_penalty": compat_pen,
+            "compute_cost_penalty": compute_pen,
+            "reward": reward,
+        }
+        return reward, components
 
 
 __all__ = ["RewardShaper"]

--- a/tests/test_reward_shaper.py
+++ b/tests/test_reward_shaper.py
@@ -2,30 +2,40 @@ import unittest
 import torch
 
 from marble.reward_shaper import RewardShaper
+from marble.decision_controller import INCOMPATIBILITY_SETS
 
 
 class TestRewardShaper(unittest.TestCase):
-    def test_reward_and_window(self):
+    def test_components_and_penalties(self):
         rs = RewardShaper(window_size=3)
-        data = [
-            (3.0, 1.0, 3.0),
-            (2.0, 2.0, 2.0),
-            (1.0, 3.0, 1.0),
-            (0.0, 4.0, 0.0),
+        window = [
+            {"latency": 3.0, "throughput": 1.0, "cost": 3.0, "wall_time": 0.0},
+            {"latency": 2.0, "throughput": 2.0, "cost": 2.0, "wall_time": 1.0},
+            {"latency": 1.0, "throughput": 3.0, "cost": 1.0, "wall_time": 2.0},
         ]
-        rewards = []
-        for lat, thr, cost in data:
-            r, betas = rs.update(lat, thr, cost)
-            print("step", len(rewards), "reward", r, "betas", betas)
-            rewards.append(r)
-        # After initial fill, latency and cost decreasing -> negative betas
-        self.assertLess(betas["latency"], 0.0)
-        self.assertLess(betas["cost"], 0.0)
-        self.assertGreater(betas["throughput"], 0.0)
-        self.assertGreater(rewards[-1], 0.0)
-        # Sliding window size should not exceed 3
-        self.assertEqual(rs._lat.maxlen, 3)
-        self.assertEqual(len(rs._lat), 3)
+        action_mask = {"A": 1, "C": 1}
+        delta_mask = {"A": 1, "C": 1}
+        h_t = {"A": {"cost": 2.0}, "C": {"cost": 1.0}}
+        reward, comps = rs.update(
+            window, action_mask, delta_mask, h_t, INCOMPATIBILITY_SETS
+        )
+        self.assertLess(comps["latency_slope"], 0.0)
+        self.assertGreater(comps["throughput_slope"], 0.0)
+        self.assertLess(comps["cost_slope"], 0.0)
+        self.assertEqual(comps["toggle_penalty"], 2.0)
+        self.assertEqual(comps["compatibility_penalty"], 1.0)
+        self.assertEqual(comps["compute_cost_penalty"], 3.0)
+        self.assertIsInstance(reward, float)
+
+    def test_divergence_indicator(self):
+        rs = RewardShaper(window_size=3, M_div=0.1)
+        window = [
+            {"latency": 1.0, "throughput": 3.0, "cost": 1.0, "wall_time": 0.0},
+            {"latency": 2.0, "throughput": 2.0, "cost": 2.0, "wall_time": 1.0},
+            {"latency": 3.0, "throughput": 1.0, "cost": 3.0, "wall_time": 2.0},
+        ]
+        r, comps = rs.update(window, {}, {}, {})
+        self.assertEqual(comps["divergence"], 1.0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -95,3 +95,13 @@
 - reward_shaper.window_size (int, default: 10)
   Number of recent performance samples kept for computing OLS trends used to
   shape actor-critic rewards. Must be at least 2.
+- reward_shaper.w1..w6 (float, default: 1.0)
+  Weights applied to individual reward components: latency slope (w1),
+  throughput slope (w2), cost slope (w3), throughput-normalised drop (w4),
+  divergence indicator (w5) and combined action penalties (w6). Adjusting these
+  values emphasises or diminishes the respective component's influence on the
+  total shaped reward.
+- reward_shaper.M_div (float, default: 0.1)
+  Threshold for activating the divergence indicator based on the
+  throughput-normalised drop. When the drop exceeds this value, an additional
+  penalty is applied to the reward.


### PR DESCRIPTION
## Summary
- compute EMA-based OLS slopes and penalties in `RewardShaper`
- expose reward weights and divergence threshold via `config.yaml`
- pass windowed metrics and action deltas from `DecisionController`
- test reward components and penalties

## Testing
- `python -m unittest -v tests.test_reward_shaper`
- `python -m unittest -v tests.test_decision_controller`
- `python -m unittest -v tests.test_decision_controller_contrib`
- `python -m unittest -v tests.test_decision_watchers`


------
https://chatgpt.com/codex/tasks/task_e_68b9904a7ea8832798312fa8d91abf1d