### PR TITLE
feat: add history encoder for stateful decisions

### DIFF
--- a/marble/history_encoder.py
+++ b/marble/history_encoder.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Recurrent encoder for decision history.
+
+This module provides :class:`HistoryEncoder` which maintains a recurrent
+summary of past interactions.  At each decision step the encoder receives the
+current observation ``o_t``, the previous action vector ``a_{t-1}`` and the
+previous reward ``r_{t-1}``.  These inputs are concatenated and processed by a
+small GRU (or LSTM) to yield the new hidden state ``h_t`` which can be fed into
+policy networks.
+"""
+
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+
+class HistoryEncoder(nn.Module):
+    """Encode ``(o_t, a_{t-1}, r_{t-1})`` into a hidden state ``h_t``.
+
+    Parameters
+    ----------
+    obs_dim:
+        Dimensionality of the observation vector ``o_t``.
+    action_dim:
+        Length of the one-hot action vector ``a_{t-1}``.
+    hidden_dim:
+        Size of the recurrent hidden state ``h_t``.
+    use_lstm:
+        If ``True`` an :class:`~torch.nn.LSTM` is used instead of a GRU.
+    """
+
+    def __init__(
+        self,
+        obs_dim: int,
+        action_dim: int,
+        hidden_dim: int,
+        *,
+        use_lstm: bool = False,
+    ) -> None:
+        super().__init__()
+        rnn_cls = nn.LSTM if use_lstm else nn.GRU
+        self.rnn = rnn_cls(obs_dim + action_dim + 1, hidden_dim, batch_first=True)
+
+    def forward(
+        self,
+        o_t: torch.Tensor,
+        a_prev: torch.Tensor,
+        r_prev: torch.Tensor,
+        h_prev: Optional[torch.Tensor | Tuple[torch.Tensor, torch.Tensor]] = None,
+    ) -> torch.Tensor | Tuple[torch.Tensor, torch.Tensor]:
+        """Return updated hidden state ``h_t``.
+
+        ``o_t`` and ``a_prev`` are expected to be one-dimensional tensors while
+        ``r_prev`` is a scalar tensor.  ``h_prev`` represents the previous hidden
+        state and may be ``None`` for zero-initialisation.
+        """
+
+        x = torch.cat([o_t, a_prev, r_prev.view(1)], dim=-1)
+        x = x.unsqueeze(0).unsqueeze(0)  # (1, 1, input_dim)
+        _, h_t = self.rnn(x, h_prev)
+        return h_t
+
+
+__all__ = ["HistoryEncoder"]

--- a/tests/test_history_encoder_state.py
+++ b/tests/test_history_encoder_state.py
@@ -1,0 +1,23 @@
+import unittest
+import torch
+
+from marble.decision_controller import DecisionController
+from marble.plugins import PLUGIN_ID_REGISTRY
+
+
+class TestHistoryEncoderState(unittest.TestCase):
+    def test_state_updates_over_decisions(self):
+        names = list(PLUGIN_ID_REGISTRY.keys())[:2]
+        controller = DecisionController()
+        hints = {n: {"cost": 1} for n in names}
+        ctx = torch.zeros(1, 1, controller.encoder.ctx_rnn.hidden_size)
+        controller.decide(hints, ctx)
+        h1 = controller._h_t[0, 0].detach().clone()
+        controller.decide(hints, ctx)
+        h2 = controller._h_t[0, 0].detach().clone()
+        print("h1 norm:", float(h1.norm()), "h2 norm:", float(h2.norm()))
+        self.assertFalse(torch.allclose(h1, h2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Add reusable `HistoryEncoder` GRU/LSTM to summarize observation, previous action, and reward
- Use `HistoryEncoder` in `DecisionController` to compute policy logits and track hidden state
- Test decision history updates across multiple calls

## Testing
- `python -m pytest tests/test_decision_controller.py -q`
- `python -m pytest tests/test_decision_controller_contrib.py -q`
- `python -m pytest tests/test_decision_watchers.py -q`
- `python -m pytest tests/test_history_encoder_state.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b994463e38832795796fc0249c062e