### PR TITLE
feat: adapt lambdas with running averages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,7 @@ decision_controller:
   tau_threshold: 1.0  # minimum seconds between state changes before penalty
   cadence: 1  # walk steps between controller decisions
   dwell_bonus: 0.1  # cost reduction per consecutive active step
+  lambda_lr: 0.1  # learning rate for constraint multipliers
   watch_metrics: []  # reporter paths to monitor automatically
   watch_variables: []  # module.variable paths to observe
   linear_constraints:

--- a/tests/test_policy_gradient.py
+++ b/tests/test_policy_gradient.py
@@ -39,6 +39,20 @@ class TestPolicyGradient(unittest.TestCase):
         print("constraint initial", init_probs.tolist(), "constraint updated", new_probs.tolist())
         self.assertLess(new_probs[1], init_probs[1])
 
+    def test_lambda_updates_increase_on_violation(self) -> None:
+        torch.manual_seed(0)
+        g1 = lambda a: (a == 1).float()
+        agent = PolicyGradientAgent(
+            state_dim=1, action_dim=2, lambdas=[0.0], constraints=[g1], lambda_lr=0.5
+        )
+        actions = torch.tensor([1])
+        agent.lambda_updates(actions)
+        first = agent.lambdas[0]
+        agent.lambda_updates(actions)
+        second = agent.lambdas[0]
+        print("lambda after updates", first, second)
+        self.assertGreater(second, first)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -75,6 +75,10 @@
   Cost reduction applied for each consecutive step a plugin remains active.
   Larger values encourage persistence by making long-running plugins
   progressively cheaper under the budget constraint.
+- decision_controller.lambda_lr (float, default: 0.1)
+  Learning rate ``η`` for the adaptive Lagrange multipliers enforcing
+  constraints in the policy-gradient agent. Higher values make penalties
+  respond more aggressively to repeated constraint violations.
 - decision_controller.watch_metrics (list[str], default: [])
   Reporter item paths (``group[/subgroup]/item``) automatically queried each
   decision step. Numeric values are merged into the ``metrics`` dict supplied


### PR DESCRIPTION
## Summary
- adapt PolicyGradientAgent with running average lambda updates
- surface lambda learning rate in DecisionController and config
- test lambda multipliers respond to violations

## Testing
- `pytest tests/test_policy_gradient.py -q -s`
- `PYTHONPATH=. pytest tests/test_decision_controller.py -q -s`
- `PYTHONPATH=. pytest tests/test_decision_controller_contrib.py -q -s`
- `PYTHONPATH=. pytest tests/test_decision_watchers.py -q -s`
- `PYTHONPATH=. pytest tests/test_history_encoder_state.py -q -s`
- `PYTHONPATH=. pytest tests/test_contribution_regressor.py -q -s`
- `PYTHONPATH=. pytest tests/test_reward_shaper.py -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68b996a401848327a22878e8bd246114