### PR TITLE
Add phase-dependent gating to DecisionController

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ decision_controller:
   cadence: 1  # walk steps between controller decisions
   dwell_bonus: 0.1  # cost reduction per consecutive active step
   lambda_lr: 0.1  # learning rate for constraint multipliers
+  phase_count: 1  # number of discrete phases for gating
   watch_metrics: []  # reporter paths to monitor automatically
   watch_variables: []  # module.variable paths to observe
   linear_constraints:

--- a/tests/test_decision_controller_phase.py
+++ b/tests/test_decision_controller_phase.py
@@ -1,0 +1,43 @@
+import unittest
+import torch
+import marble.decision_controller as dc
+from marble.plugins import PLUGIN_ID_REGISTRY
+
+
+class TestDecisionControllerPhase(unittest.TestCase):
+    def _build(self, bias):
+        ctrl = dc.DecisionController(
+            top_k=1,
+            sampler_mode="gumbel-top-k",
+            phase_count=2,
+        )
+        ctrl.phase_proj.weight.data.zero_()
+        ctrl.phase_proj.bias.data = torch.tensor(bias, dtype=torch.float32)
+        ctrl.phase_bias.weight.data = torch.tensor(
+            [[20.0, 0.0], [0.0, 20.0]], dtype=torch.float32
+        )
+        return ctrl
+
+    def test_phase_bias_shifts_selection(self):
+        names = list(PLUGIN_ID_REGISTRY.keys())[:2]
+        h_t = {names[0]: {"cost": 1}, names[1]: {"cost": 1}}
+        ctx = torch.zeros(1, 1, 16)
+
+        ctrl0 = self._build([10.0, 0.0])
+        sel0 = ctrl0.decide(
+            h_t, ctx, metrics={"latency": 1, "throughput": 1, "cost": 1}
+        )
+        print("phase 0 selection:", sel0)
+
+        ctrl1 = self._build([0.0, 10.0])
+        sel1 = ctrl1.decide(
+            h_t, ctx, metrics={"latency": 1, "throughput": 1, "cost": 1}
+        )
+        print("phase 1 selection:", sel1)
+
+        self.assertEqual(set(sel0.keys()), {names[0]})
+        self.assertEqual(set(sel1.keys()), {names[1]})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main(verbosity=2)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -79,6 +79,10 @@
   Learning rate ``η`` for the adaptive Lagrange multipliers enforcing
   constraints in the policy-gradient agent. Higher values make penalties
   respond more aggressively to repeated constraint violations.
+- decision_controller.phase_count (int, default: 1)
+  Number of discrete phases the decision controller predicts. Each phase can
+  bias action logits and rescale reward weights via an internal classifier.
+  Setting this above ``1`` enables phase-dependent behaviour.
 - decision_controller.watch_metrics (list[str], default: [])
   Reporter item paths (``group[/subgroup]/item``) automatically queried each
   decision step. Numeric values are merged into the ``metrics`` dict supplied


### PR DESCRIPTION
## Summary
- add configurable phase classifier to DecisionController for biasing logits and reward weights
- expose `decision_controller.phase_count` in config and docs
- cover phase-based gating with a dedicated unit test

## Testing
- `PYTHONPATH=. pytest tests/test_decision_controller.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_phase.py -q`
- `PYTHONPATH=. pytest tests/test_reward_shaper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b999671bb48327a7f1bf8f5cfedcf1