### PR TITLE
Add surrogate reward model for decision controller contributions

### DIFF
--- a/tests/test_decision_controller_contrib.py
+++ b/tests/test_decision_controller_contrib.py
@@ -24,6 +24,21 @@ class TestDecisionControllerContribution(unittest.TestCase):
         print('selected with auto contributions:', sel)
         self.assertEqual(sel, {names[0]: 'on'})
 
+    def test_pairwise_scores(self):
+        torch.manual_seed(0)
+        controller = dc.DecisionController(cadence=1)
+        activation = torch.tensor([
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [1.0, 1.0],
+        ])
+        outcomes = torch.tensor([0.0, 1.0, 1.0, 5.0])
+        contribs = controller.compute_contributions(activation, outcomes, ["A", "B"])
+        pair = contribs["pairwise"][("A", "B")]
+        print('pairwise contribution:', pair)
+        self.assertAlmostEqual(pair, 3.0, delta=0.1)
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- learn quadratic reward surrogate q_omega(h,a) to model rewards from activation vectors
- expose individual and pairwise contribution deltas via `compute_contributions`
- test pairwise contribution scoring behaviour

## Testing
- `python -m pytest tests/test_contribution_regressor.py -q`
- `python -m pytest tests/test_decision_controller.py -q`
- `python -m pytest tests/test_decision_controller_contrib.py -q`
- `python -m pytest tests/test_decision_controller_phase.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba859c4d58832797f1122883a79076