### PR TITLE
Use bounded default budget and export limit

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2025-09-05
+- Use a bounded budget when `config.yaml` is absent or invalid and expose `BUDGET_LIMIT` at the package root.
+
 2025-09-19
 - Added optional CPU pre-forward pass for `Wanderer` via `pre_forward=True`,
   recording CPU compute and GPU transfer times to help tune VRAM usage.

--- a/marble/__init__.py
+++ b/marble/__init__.py
@@ -10,6 +10,7 @@ from .plugin_encoder import PluginEncoder
 from .action_sampler import compute_logits, sample_actions, select_plugins
 from .offpolicy import Trajectory, importance_weights, doubly_robust
 from .policy_gradient import PolicyGradientAgent
+from .decision_controller import BUDGET_LIMIT
 
 __all__ = [
     "enable_auto_param_learning",
@@ -21,4 +22,5 @@ __all__ = [
     "importance_weights",
     "doubly_robust",
     "PolicyGradientAgent",
+    "BUDGET_LIMIT",
 ]

--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -95,7 +95,7 @@ def _load_policy_mode() -> str:
 
 
 def _load_budget() -> float:
-    """Load budget limit from ``config.yaml``."""
+    """Load budget limit from ``config.yaml``; default to ``10.0``."""
     base = os.path.dirname(os.path.dirname(__file__))
     cfg: Dict[str, Dict[str, Any]] = {}
     try:
@@ -116,12 +116,12 @@ def _load_budget() -> float:
                     except Exception:
                         cfg[section][k.strip()] = v.strip()
     except Exception:
-        return float("inf")
+        return 10.0
     dc = cfg.get("decision_controller", {})
     try:
-        return float(dc.get("budget", float("inf")))
+        return float(dc.get("budget", 10.0))
     except Exception:
-        return float("inf")
+        return 10.0
 
 
 BUDGET_LIMIT = _load_budget()


### PR DESCRIPTION
## Summary
- Default to 10.0 budget when `config.yaml` is missing or malformed
- Re-export `BUDGET_LIMIT` at package root
- Document bounded budget behavior

## Testing
- `python -m unittest -v tests.test_decision_controller`
- `python -m unittest -v tests.test_decision_controller_contrib`
- `python -m unittest -v tests.test_contribution_regressor`
- `python -m unittest -v tests.test_decision_controller_divergence`
- `python -m unittest -v tests.test_decision_controller_phase`
- `python -m unittest -v tests.test_decision_controller_dwell`
- `python -m unittest -v tests.test_decision_watchers`
- `python -m unittest -v tests.test_reward_shaper`


------
https://chatgpt.com/codex/tasks/task_e_68ba947d1f14832789293bb6bea2eafd