### PR TITLE
Sort plugin discovery for stable IDs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -178,6 +178,7 @@ Packaging and Layout
   - The default `BaseNeuroplasticityPlugin` resides in `marble/plugins/neuroplasticity_base.py` and self-registers under type name `base`.
   - Advanced neuroplasticity plugins (`synapse_scaler`, `random_pruner`, `bias_shift`, `connection_rewire`, `spectral_normalizer`) explore unconventional growth, pruning, and rewiring strategies. Each lives in `marble/plugins/` and exposes its tunables via `expose_learnable_params`.
   - Wanderer and brain-training plugin implementations (e.g., L2 penalty, curriculum, warmup-decay) are also hosted in their own modules under `marble/plugins/`.
+  - Plugin IDs are allocated by scanning the `marble/plugins` package in name-sorted order, guaranteeing deterministic identifiers as long as the set of plugin files remains unchanged.
 
 Operational Policy Update
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 2025-09-05
+- Load plugins in deterministic order and document that plugin IDs remain stable when the set of plugin files is unchanged.
 - Use a bounded budget when `config.yaml` is absent or invalid and expose `BUDGET_LIMIT` at the package root.
 
 2025-09-19

--- a/marble/plugins/__init__.py
+++ b/marble/plugins/__init__.py
@@ -1,10 +1,12 @@
 """Plugin package auto-loader with automatic registration.
 
 All modules inside this package are imported and inspected for plugin
-classes. Any class whose name ends with ``Plugin`` or ``Routine`` is
+classes. Modules are processed in name-sorted order so that registration is
+deterministic. Any class whose name ends with ``Plugin`` or ``Routine`` is
 registered automatically based on the module's name. This means dropping a
 new module into :mod:`marble.plugins` immediately exposes the plugin without
-any manual ``register_*`` calls.
+any manual ``register_*`` calls.  As long as the set of plugin files remains
+unchanged, every plugin retains the same numeric identifier across runs.
 """
 
 from __future__ import annotations
@@ -51,7 +53,7 @@ def _find_plugin_class(module: Any) -> Optional[Type[Any]]:
 
 __all__: List[str] = []
 
-for mod in pkgutil.iter_modules(__path__):
+for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
     if mod.name.startswith("_"):
         continue
     module = importlib.import_module(f"{__name__}.{mod.name}")


### PR DESCRIPTION
## Summary
- load plugins in sorted order for deterministic IDs
- document deterministic plugin IDs when the file set stays the same

## Testing
- `python -m unittest -v tests.test_plugin_encoder`
- `python -m unittest -v tests.test_decision_controller`
- `python -m unittest -v tests.test_decision_controller_phase`
- `python -m unittest -v tests.test_history_encoder_state`


------
https://chatgpt.com/codex/tasks/task_e_68ba98a1f9dc8327aac173b1fc053a2d