### PR TITLE
Track plugin costs across history for accurate budgeting

### DIFF
--- a/tests/test_decision_controller.py
+++ b/tests/test_decision_controller.py
@@ -33,6 +33,24 @@ class TestDecisionController(unittest.TestCase):
         print("selected with per-plugin budget:", selected)
         self.assertEqual(selected, {"B": "on"})
 
+    def test_cost_change_respected(self):
+        dc.BUDGET_LIMIT = 3.5
+        h_t1 = {"A": {"cost": 3}}
+        x_t1 = {"A": "on"}
+        history: list[dict] = []
+        recorder: dict[str, float] = {}
+        sel1 = dc.decide_actions(
+            h_t1, x_t1, history, all_plugins=h_t1.keys(), cost_recorder=recorder
+        )
+        history.append(
+            {n: {"action": a, "cost": recorder.get(n, 0.0)} for n, a in sel1.items()}
+        )
+        h_t2 = {"A": {"cost": 1}}
+        x_t2 = {"A": "on"}
+        sel2 = dc.decide_actions(h_t2, x_t2, history, all_plugins=h_t2.keys())
+        print("second selection under budget after cost change:", sel2)
+        self.assertEqual(sel2, {})
+
     def test_tau_penalty(self):
         dc.BUDGET_LIMIT = 5.0
         dc.TAU_THRESHOLD = 5.0


### PR DESCRIPTION
## Summary
- record actual plugin costs in decision history
- base budget checks on stored costs so past actions use original pricing
- test that budget violations are detected when costs change later

## Testing
- `pytest tests/test_decision_controller.py::TestDecisionController::test_incompatibility_and_capacity -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_budget_limit -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_per_plugin_running_cost -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_cost_change_respected -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_tau_penalty -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_decision_controller_cadence -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_dwell_bonus -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_linear_constraints_accept -q`
- `pytest tests/test_decision_controller.py::TestDecisionController::test_linear_constraints_reject -q`
- `pytest tests/test_history_encoder_state.py -q`
- `pytest tests/test_decision_controller_dwell.py -q`
- `pytest tests/test_decision_watchers.py -q`
- `pytest tests/test_decision_controller_contrib.py -q`
- `pytest tests/test_decision_controller_phase.py -q`
- `pytest tests/test_decision_controller_divergence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9a540cdc8327b1c25628867a26ad