### PR TITLE
Avoid selecting plugins when prerequisites are unmet

### DIFF
--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -838,6 +838,13 @@ class DecisionController:
 
         plugin_names = list(h_t.keys())
         ready = set(PLUGIN_GRAPH.recommend_next_plugin(self._last_phase))
+        # If the plugin graph still contains pending nodes but none are ready
+        # to run, we return an empty selection instead of considering all
+        # plugins.  This prevents executing plugins whose prerequisites have
+        # not yet been satisfied.
+        if not ready and getattr(PLUGIN_GRAPH, "_deps", {}):
+            self.history.append({})
+            return {}
         if ready:
             plugin_names = [n for n in plugin_names if n in ready]
         if not plugin_names:

--- a/tests/test_decision_controller_dwell.py
+++ b/tests/test_decision_controller_dwell.py
@@ -13,6 +13,7 @@ class TestDecisionControllerDwell(unittest.TestCase):
     def test_dwell_suppresses_quick_switch(self) -> None:
         torch.manual_seed(0)
         dc.PLUGIN_GRAPH.recommend_next_plugin = lambda _: set()
+        dc.PLUGIN_GRAPH._deps.clear()
         ctrl = DecisionController(dwell_threshold=2)
         ctx = torch.zeros(1, 1, 16)
         first = ctrl.decide({"auto_target_scaler": {"action": "on"}}, ctx)

--- a/tests/test_decision_controller_pending.py
+++ b/tests/test_decision_controller_pending.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import torch
+import marble.decision_controller as dc
+from marble.decision_controller import DecisionController
+
+
+class TestDecisionControllerPending(unittest.TestCase):
+    def test_pending_graph_returns_empty_selection(self) -> None:
+        torch.manual_seed(0)
+        dc.PLUGIN_GRAPH.reset()
+        # Create a dependency cycle so that no plugin becomes ready
+        dc.PLUGIN_GRAPH.add_dependency("auto_target_scaler", "autoneuron")
+        dc.PLUGIN_GRAPH.add_dependency("autoneuron", "auto_target_scaler")
+        ctrl = DecisionController()
+        ctx = torch.zeros(1, 1, 16)
+        selection = ctrl.decide(
+            {
+                "auto_target_scaler": {"action": "on"},
+                "autoneuron": {"action": "on"},
+            },
+            ctx,
+        )
+        print("selection", selection)
+        self.assertEqual(selection, {})
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- avoid selecting plugins when no graph nodes are ready but pending nodes remain
- adjust dwell test to clear pending nodes when mocking plugin recommendation
- test that unmet prerequisites lead to an empty plugin selection

## Testing
- `pytest tests/test_decision_controller_pending.py -q`
- `pytest tests/test_decision_controller_dwell.py -q`
- `PYTHONPATH=. pytest tests/test_plugin_graph.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68baafb6fe1083278748096da9766bf0