### PR TITLE
Guard reward history when metrics missing

### DIFF
--- a/tests/test_history_encoder_state.py
+++ b/tests/test_history_encoder_state.py
@@ -18,9 +18,11 @@ class TestHistoryEncoderState(unittest.TestCase):
         print("h1 norm:", float(h1.norm()), "h2 norm:", float(h2.norm()))
         print("metric window after no metrics:", list(controller._metric_window))
         print("last metrics after no metrics:", controller.last_metrics)
+        print("reward log after no metrics:", controller._reward_log)
         self.assertFalse(torch.allclose(h1, h2))
         self.assertEqual(len(controller._metric_window), 0)
         self.assertEqual(controller.last_metrics, {})
+        self.assertEqual(len(controller._reward_log), 0)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- Avoid populating metrics and reward logs when no metrics are available
- Skip reward shaping and trajectory logging in those cases
- Extend history encoder test to assert reward log stays empty without metrics

## Testing
- `pytest tests/test_history_encoder_state.py -q`
- `pytest tests/test_decision_controller.py -q`
- `pytest tests/test_decision_controller_divergence.py -q`
- `pytest tests/test_decision_controller_pending.py -q`
- `pytest tests/test_decision_controller_dwell.py -q`
- `pytest tests/test_decision_controller_contrib.py -q`
- `pytest tests/test_decision_controller_phase.py -q`
- `pytest tests/test_decision_watchers.py -q`
- `pytest tests/test_reward_shaper.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be6d9330208327a683a8cfa4912acc