### PR TITLE
Discount plugin costs by contributions before penalties

### DIFF
--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -618,8 +618,13 @@ def decide_actions(
 
     for name, action in ordered:
         base_cost = float(h_t.get(name, {}).get("cost", get_plugin_cost(name)))
+        if contrib_scores:
+            disc_cost = base_cost - float(contrib_scores.get(name, 0.0))
+            disc_cost = max(disc_cost, 0.0)
+        else:
+            disc_cost = base_cost
         pen = penalty(name)
-        real_cost = base_cost + pen
+        real_cost = disc_cost + pen
         if not check_throughput(name, usage, CAPACITY_LIMITS):
             continue
         if not check_budget(name, real_cost, remaining, running_costs, BUDGET_LIMIT):

--- a/tests/test_contribution_regressor.py
+++ b/tests/test_contribution_regressor.py
@@ -17,6 +17,24 @@ class TestContributionRegressor(unittest.TestCase):
         print("selected with contribs:", selected)
         self.assertEqual(selected, {"A": "on"})
 
+    def test_excess_contribution_does_not_increase_budget(self):
+        dc.LAST_STATE_CHANGE.clear()
+        dc.TAU_THRESHOLD = 0.0
+        dc.BUDGET_LIMIT = 1.0
+        h_t1 = {"A": {"cost": 1.0}}
+        x_t1 = {"A": "on"}
+        contribs = {"A": 2.0}
+        rec: dict[str, float] = {}
+        sel1 = dc.decide_actions(h_t1, x_t1, [], contrib_scores=contribs, cost_recorder=rec)
+        history = [{n: {"action": a, "cost": rec.get(n, 0.0)} for n, a in sel1.items()}]
+        h_t2 = {"B": {"cost": 2.0}}
+        x_t2 = {"B": "on"}
+        sel2 = dc.decide_actions(h_t2, x_t2, history, all_plugins=h_t2.keys())
+        print("cost recorded for A:", rec.get("A"))
+        print("second selection after excessive contribution:", sel2)
+        self.assertEqual(rec.get("A"), 0.0)
+        self.assertEqual(sel2, {})
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- compute discounted cost from base cost minus contribution, clamp at zero, then add penalties in `decide_actions`
- test that excessive contribution never increases budget

## Testing
- `pytest tests/test_contribution_regressor.py::TestContributionRegressor::test_contribution_influences_selection -q`
- `pytest tests/test_contribution_regressor.py::TestContributionRegressor::test_excess_contribution_does_not_increase_budget -q`
- `pytest tests/test_decision_controller.py -q`
- `pytest tests/test_decision_controller_contrib.py -q`
- `pytest tests/test_decision_controller_dwell.py -q`
- `pytest tests/test_decision_controller_pending.py -q`
- `pytest tests/test_decision_controller_phase.py -q`
- `pytest tests/test_decision_controller_divergence.py -q`
- `pytest tests/test_decision_watchers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be7006a13c8327ae4eba6bc3c9e28d