### PR TITLE
Rebuild decision cost vector each step

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2025-09-26
+- Decision controller now rebuilds its cost vector each step from real ``h_t``
+  costs so budget penalties and policy sampling use up-to-date spending.
+
 2025-09-05
 - Load plugins in deterministic order and document that plugin IDs remain stable when the set of plugin files is unchanged.
 - Use a bounded budget when `config.yaml` is absent or invalid and expose `BUDGET_LIMIT` at the package root.

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -58,8 +58,9 @@
 - decision_controller.budget (float, default: 10.0)
   Maximum cumulative cost allowed for plugin actions during a single decision
   step. Actions exceeding the remaining budget are discarded starting with the
-  highest cost. The same limit normalises the soft budget penalty used by the
-  decision controller's policy-gradient learner.
+  highest cost. The controller recomputes plugin costs on every decision from
+  the provided ``h_t[name]['cost']`` values, and the same limit normalises the
+  soft budget penalty used by the decision controller's policy-gradient learner.
 - decision_controller.contribution_l1 (float, default: 0.01)
   L1 penalty strength applied when training the plugin contribution regressor.
   Higher values yield sparser contribution weights.


### PR DESCRIPTION
## Summary
- rebuild DecisionController cost_vec every step from real `h_t[name]['cost']`
- budget constraint now uses updated cost data via g_budget
- document per-step cost handling and test dynamic cost vector

## Testing
- `PYTHONPATH=. pytest tests/test_decision_controller.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_divergence.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_dwell.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_phase.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_pending.py -q`
- `PYTHONPATH=. pytest tests/test_history_encoder_state.py -q`
- `PYTHONPATH=. pytest tests/test_decision_watchers.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_contrib.py -q`
- `PYTHONPATH=. pytest tests/test_action_sampler.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be71e01a548327b8d1cb0ff3b317a9