### PR TITLE
Sort plugin list for deterministic constraints

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -20,8 +20,8 @@ decision_controller:
   watch_variables: []  # module.variable paths to observe
   policy_mode: policy-gradient  # 'policy-gradient' or 'bayesian'
   linear_constraints:
-    A: []  # constraint matrix for actions
-    b: []  # upper bounds for linear constraints
+    A: []  # constraint matrix; columns follow sorted plugin names
+    b: []  # upper bounds paired with rows in A
 max_flat_steps: 5  # consecutive zero-delta steps before pruning/connection
 auto_scale_targets: false  # scale tiny targets to match output magnitude
 auto_max_steps_interval: 10  # recompute wanderer max_steps every N datapairs

--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -592,7 +592,7 @@ def decide_actions(
 
     now = time.time()
 
-    plugin_list = list(all_plugins or x_t.keys())
+    plugin_list = sorted(all_plugins or x_t.keys())
     name_to_idx = {n: i for i, n in enumerate(plugin_list)}
     action_vec = [0.0] * len(plugin_list)
 

--- a/tests/test_decision_controller_deterministic.py
+++ b/tests/test_decision_controller_deterministic.py
@@ -1,0 +1,35 @@
+import os
+import subprocess
+import sys
+import unittest
+
+
+class TestDecisionControllerDeterministic(unittest.TestCase):
+    def test_constraint_determinism(self):
+        code = (
+            "import json, os\n"
+            "import marble.decision_controller as dc\n"
+            "dc.LAST_STATE_CHANGE.clear()\n"
+            "dc.TAU_THRESHOLD = 0.0\n"
+            "dc.BUDGET_LIMIT = 5.0\n"
+            "dc.LINEAR_CONSTRAINTS_A = [[1, 1]]\n"
+            "dc.LINEAR_CONSTRAINTS_B = [1]\n"
+            "h_t = {'B': {'cost': 1}, 'A': {'cost': 1}}\n"
+            "x_t = {'B': 'on', 'A': 'on'}\n"
+            "res = dc.decide_actions(h_t, x_t, [], all_plugins=set(h_t.keys()))\n"
+            "print(json.dumps(res, sort_keys=True))\n"
+        )
+        outputs = []
+        for seed in ['1', '2', '3']:
+            env = os.environ.copy()
+            env['PYTHONHASHSEED'] = seed
+            result = subprocess.run(
+                [sys.executable, '-c', code], capture_output=True, text=True, env=env
+            )
+            outputs.append(result.stdout.strip())
+        print('subprocess outputs:', outputs)
+        self.assertTrue(all(o == outputs[0] for o in outputs))
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main(verbosity=2)

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -103,6 +103,7 @@
 - decision_controller.linear_constraints.A (list[list[float]], default: [])
   Matrix ``A`` defining linear inequality constraints ``A @ a <= b`` applied
   to the binary action vector ``a``. Each row represents one constraint.
+  Columns must follow the alphabetically sorted list of plugin names.
 - decision_controller.linear_constraints.b (list[float], default: [])
   Upper bounds ``b`` paired with rows of ``linear_constraints.A``. When both
   lists are empty, no linear constraints are enforced.


### PR DESCRIPTION
## Summary
- sort DecisionController plugin list for consistent constraint application
- note sorted order in config and docs
- test that constraint enforcement remains deterministic across runs

## Testing
- `PYTHONPATH=. pytest tests/test_decision_controller.py -q`
- `PYTHONPATH=. pytest tests/test_decision_controller_deterministic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be738544d48327ae9622c7d3ae761d