### PR TITLE
Ensure budget ignores pruned actions

### DIFF
--- a/marble/action_sampler.py
+++ b/marble/action_sampler.py
@@ -57,7 +57,7 @@ def _project_constraints(
             spent = torch.tensor(0.0, device=relaxed.device)
             for idx in order:
                 c = costs[idx]
-                if spent + c <= budget:
+                if hard[idx] > 0 and spent + c <= budget:
                     new_hard[idx] = hard[idx]
                     spent = spent + c
             hard = new_hard


### PR DESCRIPTION
## Summary
- Guard budget spending on actions that survive incompatibility pruning
- Add regression test to ensure lower-ranked valid actions can be funded

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest tests.test_action_sampler -v`


------
https://chatgpt.com/codex/tasks/task_e_68be74c65a4883279575176552884c59