### PR TITLE
Ensure lambda updates ignore satisfied constraints

### DIFF
--- a/marble/policy_gradient.py
+++ b/marble/policy_gradient.py
@@ -130,11 +130,12 @@ class PolicyGradientAgent:
         with torch.no_grad():
             for j, g in enumerate(self.constraints):
                 g_val = g(actions).detach().to("cpu").mean().item()
+                violation = max(0.0, g_val)
                 self._g_count[j] += 1
                 count = self._g_count[j]
-                avg = self._g_avg[j] + (g_val - self._g_avg[j]) / count
+                avg = self._g_avg[j] + (violation - self._g_avg[j]) / count
                 self._g_avg[j] = avg
-                new_lam = self.lambdas[j] + self.lambda_lr * avg
+                new_lam = self.lambdas[j] + self.lambda_lr * violation
                 self.lambdas[j] = max(0.0, new_lam)
 
 

--- a/tests/test_policy_gradient.py
+++ b/tests/test_policy_gradient.py
@@ -53,6 +53,26 @@ class TestPolicyGradient(unittest.TestCase):
         print("lambda after updates", first, second)
         self.assertGreater(second, first)
 
+    def test_update_lambdas_stay_constant_when_satisfied(self) -> None:
+        torch.manual_seed(0)
+        g1 = lambda a: -torch.ones_like(a, dtype=torch.float)
+        agent = PolicyGradientAgent(
+            state_dim=1,
+            action_dim=2,
+            lambdas=[0.5],
+            constraints=[g1],
+            lambda_lr=0.5,
+        )
+        actions = torch.tensor([0])
+        before = agent.lambdas[0]
+        agent.update_lambdas(actions)
+        first = agent.lambdas[0]
+        agent.update_lambdas(actions)
+        second = agent.lambdas[0]
+        print("lambda satisfied", before, first, second)
+        self.assertAlmostEqual(first, before)
+        self.assertAlmostEqual(second, before)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Clamp constraint penalties to non-negative violations before averaging
- Update Lagrange multipliers only when constraints are violated
- Add regression test ensuring lambdas stay constant when budget respected

## Testing
- `python tests/test_policy_gradient.py`

------
https://chatgpt.com/codex/tasks/task_e_68be7594c7908327be265c7a85e9c283