### PR TITLE
Align action and reward logs when metrics skipped

### DIFF
--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -1081,7 +1081,11 @@ class DecisionController:
             self._activation_log.append(act_vec)
             self._reward_log.append(float(reward))
             self._prev_reward = float(reward)
-        self._prev_action_vec = act_vec
+            # Only advance the cached action vector when we also log a reward so
+            # that ``_prev_action_vec`` and ``_prev_reward`` always describe the
+            # same decision. Skipping this update keeps the pair aligned when
+            # metrics are missing and no reward is produced.
+            self._prev_action_vec = act_vec
         if isinstance(self._h_t, tuple):
             self._h_t = tuple(t.detach() for t in self._h_t)
         else:

--- a/tests/test_decision_controller_metrics_skip.py
+++ b/tests/test_decision_controller_metrics_skip.py
@@ -1,0 +1,36 @@
+import unittest
+import torch
+import marble.decision_controller as dc
+from marble.decision_controller import DecisionController
+
+
+class TestDecisionControllerMetricsSkip(unittest.TestCase):
+    def test_action_reward_alignment(self) -> None:
+        dc.PLUGIN_GRAPH.reset()
+        dc.LAST_STATE_CHANGE.clear()
+        dc.TAU_THRESHOLD = 0.0
+        name = list(dc.PLUGIN_ID_REGISTRY.keys())[0]
+        h_t = {name: {"cost": 1.0}}
+        ctx = torch.zeros(1, 1, 16)
+        ctrl = DecisionController(top_k=1)
+
+        sel1 = ctrl.decide(h_t, ctx, metrics={"latency": 1, "throughput": 1, "cost": 1})
+        print("sel1", sel1)
+        prev_action_vec = ctrl._prev_action_vec.clone()
+        prev_reward = ctrl._prev_reward
+
+        sel2 = ctrl.decide(h_t, ctx, metrics=None)
+        print("sel2", sel2)
+        self.assertTrue(torch.equal(ctrl._prev_action_vec, prev_action_vec))
+        self.assertEqual(ctrl._prev_reward, prev_reward)
+
+        sel3 = ctrl.decide(h_t, ctx, metrics={"latency": 1, "throughput": 1, "cost": 1})
+        print("sel3", sel3)
+        self.assertEqual(len(ctrl._activation_log), 2)
+        self.assertEqual(len(ctrl._reward_log), 2)
+        self.assertTrue(torch.equal(ctrl._prev_action_vec, ctrl._activation_log[-1]))
+        self.assertEqual(ctrl._prev_reward, ctrl._reward_log[-1])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep action and reward history aligned by only advancing cached action when logging a reward
- add regression test covering decision steps without metrics

## Testing
- `python -m unittest -v tests.test_decision_controller`
- `python -m unittest -v tests.test_decision_controller_divergence`
- `python -m unittest -v tests.test_decision_controller_dwell`
- `python -m unittest -v tests.test_decision_controller_pending`
- `python -m unittest -v tests.test_decision_controller_phase`
- `python -m unittest -v tests.test_decision_controller_deterministic`
- `python -m unittest -v tests.test_decision_watchers`
- `python -m unittest -v tests.test_history_encoder_state`
- `python -m unittest -v tests.test_reward_shaper`
- `python -m unittest -v tests.test_contribution_regressor`
- `python -m unittest -v tests.test_decision_controller_contrib`
- `python -m unittest -v tests.test_decision_controller_metrics_skip`


------
https://chatgpt.com/codex/tasks/task_e_68be7d6fc9308327b84fe4e76a230fe7