### PR TITLE
Add plugin cost profiler with EMA tracking

### DIFF
--- a/marble/plugin_cost_profiler.py
+++ b/marble/plugin_cost_profiler.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Helpers for tracking per-plugin execution cost.
+
+This module maintains an exponential moving average (EMA) of the elapsed time
+for each plugin.  Call :func:`record` after a plugin finishes executing and use
+:func:`get_cost` to retrieve the current average cost.
+"""
+
+from typing import Dict
+
+_ALPHA = 0.5
+_cost_ema: Dict[str, float] = {}
+
+
+def record(plugin_name: str, elapsed: float) -> None:
+    """Record ``elapsed`` time for ``plugin_name``.
+
+    Parameters
+    ----------
+    plugin_name:
+        Name of the plugin whose cost is being tracked.
+    elapsed:
+        Elapsed execution time in seconds.
+    """
+
+    val = float(elapsed)
+    prev = _cost_ema.get(plugin_name)
+    if prev is None:
+        _cost_ema[plugin_name] = val
+    else:
+        _cost_ema[plugin_name] = _ALPHA * val + (1.0 - _ALPHA) * prev
+
+
+def get_cost(plugin_name: str, default: float = 0.0) -> float:
+    """Return the current cost estimate for ``plugin_name``.
+
+    Parameters
+    ----------
+    plugin_name:
+        Name of the plugin.
+    default:
+        Value returned if no cost has been recorded yet.
+    """
+
+    return float(_cost_ema.get(plugin_name, default))
+
+
+__all__ = ["record", "get_cost"]

--- a/tests/test_plugin_cost_profiler.py
+++ b/tests/test_plugin_cost_profiler.py
@@ -1,0 +1,22 @@
+import importlib
+import unittest
+
+from marble import plugin_cost_profiler as cp
+
+
+class PluginCostProfilerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        importlib.reload(cp)
+
+    def test_record_and_get_cost(self) -> None:
+        cp.record("test", 10.0)
+        self.assertEqual(cp.get_cost("test"), 10.0)
+        cp.record("test", 6.0)
+        self.assertEqual(cp.get_cost("test"), 8.0)
+
+    def test_default_value(self) -> None:
+        self.assertEqual(cp.get_cost("missing", 1.23), 1.23)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track per-plugin execution times with an exponential moving average
- expose helper to read back average costs
- add unit tests for cost profiler behaviour

## Testing
- `python -m unittest -v tests.test_plugin_cost_profiler`

------
https://chatgpt.com/codex/tasks/task_e_68be8789a02c8327a622227cbed67404