### PR TITLE
Instrument plugin methods with cost tracking

### DIFF
--- a/tests/test_plugin_timing_wrapper.py
+++ b/tests/test_plugin_timing_wrapper.py
@@ -1,0 +1,27 @@
+import importlib
+import unittest
+
+from marble import plugin_cost_profiler as cp
+import marble.wanderer as w
+import marble.plugins as p
+
+
+class PluginTimingWrapperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        importlib.reload(cp)
+        importlib.reload(w)
+        importlib.reload(p)
+
+    def test_method_records_cost(self) -> None:
+        plugin = w.WANDERER_TYPES_REGISTRY["wanderalongsynapseweights"]
+
+        class DummySynapse:
+            def __init__(self, weight: float) -> None:
+                self.weight = weight
+
+        plugin.choose_next(None, None, [(DummySynapse(1.0), "f"), (DummySynapse(2.0), "b")])
+        self.assertGreater(cp.get_cost("wanderalongsynapseweights"), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wrap every plugin instance's public methods to record execution time via PluginCostProfiler
- add regression test verifying timing data is captured for a wanderer plugin

## Testing
- `python count_numeric_parameters.py config.yaml`
- `python -m unittest -v tests.test_plugin_timing_wrapper`
- `python -m unittest -v tests.test_plugin_cost_profiler`


------
https://chatgpt.com/codex/tasks/task_e_68be8b16cab883279fe537cfaf8a07ce