### PR TITLE
Add tests for plugin timing wrapper pass-through behavior

### DIFF
--- a/tests/test_plugin_timing_wrapper.py
+++ b/tests/test_plugin_timing_wrapper.py
@@ -22,6 +22,27 @@ class PluginTimingWrapperTests(unittest.TestCase):
         plugin.choose_next(None, None, [(DummySynapse(1.0), "f"), (DummySynapse(2.0), "b")])
         self.assertGreater(cp.get_cost("wanderalongsynapseweights"), 0.0)
 
+    def test_return_value_preserved(self) -> None:
+        class Dummy:
+            def echo(self, x: int) -> int:
+                return x
+
+        inst = Dummy()
+        p._wrap_public_methods(inst, "dummy")
+        self.assertEqual(inst.echo(123), 123)
+        self.assertGreater(cp.get_cost("dummy"), 0.0)
+
+    def test_exception_passthrough(self) -> None:
+        class Dummy:
+            def boom(self) -> None:
+                raise RuntimeError("boom")
+
+        inst = Dummy()
+        p._wrap_public_methods(inst, "dummy")
+        with self.assertRaises(RuntimeError):
+            inst.boom()
+        self.assertGreater(cp.get_cost("dummy"), 0.0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- test plugin wrappers preserve return values and propagate exceptions

## Testing
- `python -m unittest -v tests.test_plugin_timing_wrapper`
- `python -m unittest -v tests.test_plugin_cost_profiler`


------
https://chatgpt.com/codex/tasks/task_e_68be8cabb770832787b6eb9828504704