### PR TITLE
Record plugin runtime in call_safely

### DIFF
--- a/tests/test_call_safely_profiler.py
+++ b/tests/test_call_safely_profiler.py
@@ -1,0 +1,25 @@
+import importlib
+import time
+import unittest
+
+import marble.marblemain as mm
+from marble import plugin_cost_profiler as cp
+
+
+class CallSafelyProfilerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        importlib.reload(cp)
+        importlib.reload(mm)
+
+    def test_records_cost_when_plugin_name_provided(self) -> None:
+        def dummy() -> None:
+            time.sleep(0.01)
+
+        mm._call_safely(dummy, plugin_name="dummy")
+        cost = cp.get_cost("dummy")
+        print("recorded cost", cost)
+        self.assertGreater(cost, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `plugin_name` parameter to `_call_safely` and record runtime with `PluginCostProfiler`
- forward plugin names through training helpers so `_call_safely` can profile plugins
- test that `_call_safely` records plugin cost when `plugin_name` is provided

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `PYTHONPATH=. python tests/test_plugin_cost_profiler.py`
- `PYTHONPATH=. python tests/test_plugin_timing_wrapper.py`
- `PYTHONPATH=. python tests/test_call_safely_profiler.py`


------
https://chatgpt.com/codex/tasks/task_e_68be8f174dcc8327ba8bb2327a997dec