### PR TITLE
Prioritize profiled plugin costs

### DIFF
--- a/tests/test_get_plugin_cost_profiler.py
+++ b/tests/test_get_plugin_cost_profiler.py
@@ -1,0 +1,35 @@
+import importlib
+import sys
+import types
+import unittest
+
+from marble.decision_controller import get_plugin_cost
+from marble import plugin_cost_profiler as cp
+
+
+class GetPluginCostProfilerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        importlib.reload(cp)
+        sys.modules.pop("marble.plugins.fakeplugin", None)
+
+    def test_profiler_priority_and_zero_init(self) -> None:
+        mod = types.ModuleType("marble.plugins.fakeplugin")
+        mod.PLUGIN_COST = 7.5
+        sys.modules["marble.plugins.fakeplugin"] = mod
+
+        cp.record("fakeplugin", 2.5)
+        cost = get_plugin_cost("fakeplugin")
+        print("cost from profiler:", cost)
+        self.assertEqual(cost, 2.5)
+
+        importlib.reload(cp)
+        sys.modules["marble.plugins.fakeplugin"] = mod
+        cost = get_plugin_cost("fakeplugin")
+        stored = cp.get_cost("fakeplugin")
+        print("fallback cost and stored cost:", cost, stored)
+        self.assertEqual(cost, 7.5)
+        self.assertEqual(stored, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_cost_profiler.py
+++ b/tests/test_plugin_cost_profiler.py
@@ -10,12 +10,18 @@ class PluginCostProfilerTests(unittest.TestCase):
 
     def test_record_and_get_cost(self) -> None:
         cp.record("test", 10.0)
-        self.assertEqual(cp.get_cost("test"), 10.0)
+        cost1 = cp.get_cost("test")
+        print("first cost:", cost1)
+        self.assertEqual(cost1, 10.0)
         cp.record("test", 6.0)
-        self.assertEqual(cp.get_cost("test"), 8.0)
+        cost2 = cp.get_cost("test")
+        print("ema cost:", cost2)
+        self.assertEqual(cost2, 8.0)
 
     def test_default_value(self) -> None:
-        self.assertEqual(cp.get_cost("missing", 1.23), 1.23)
+        default = cp.get_cost("missing", 1.23)
+        print("default cost:", default)
+        self.assertEqual(default, 1.23)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Use PluginCostProfiler values before static plugin cost estimates
- Initialize unknown plugin costs to zero so they can run once
- Test cost profiler integration and add diagnostic prints

## Testing
- `python -m tests.test_plugin_cost_profiler`
- `python -m tests.test_decision_watchers`
- `python -m tests.test_get_plugin_cost_profiler`


------
https://chatgpt.com/codex/tasks/task_e_68be912de03483279bf474c2d5112926