### PR TITLE
Prioritize profiled plugin costs over static estimates

### DIFF
--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -532,7 +532,7 @@ def get_plugin_cost(name: str) -> float:
     """Return intrinsic cost for ``name`` by inspecting its plugin module."""
 
     # Prefer dynamic measurements from ``plugin_cost_profiler``.
-    prof_cost = _pcp.get_cost(name, float("nan"))
+    prof_cost = _pcp.get_cost(name)
     if not math.isnan(prof_cost):
         return prof_cost
 

--- a/marble/plugin_cost_profiler.py
+++ b/marble/plugin_cost_profiler.py
@@ -32,7 +32,7 @@ def record(plugin_name: str, elapsed: float) -> None:
         _cost_ema[plugin_name] = _ALPHA * val + (1.0 - _ALPHA) * prev
 
 
-def get_cost(plugin_name: str, default: float = 0.0) -> float:
+def get_cost(plugin_name: str, default: float = float("nan")) -> float:
     """Return the current cost estimate for ``plugin_name``.
 
     Parameters
@@ -40,7 +40,9 @@ def get_cost(plugin_name: str, default: float = 0.0) -> float:
     plugin_name:
         Name of the plugin.
     default:
-        Value returned if no cost has been recorded yet.
+        Value returned if no cost has been recorded yet.  Defaults to ``NaN`` so
+        callers can detect whether the cost is unknown and fall back to
+        alternative logic.
     """
 
     return float(_cost_ema.get(plugin_name, default))

--- a/tests/test_plugin_cost_profiler.py
+++ b/tests/test_plugin_cost_profiler.py
@@ -1,4 +1,5 @@
 import importlib
+import math
 import unittest
 
 from marble import plugin_cost_profiler as cp
@@ -22,6 +23,11 @@ class PluginCostProfilerTests(unittest.TestCase):
         default = cp.get_cost("missing", 1.23)
         print("default cost:", default)
         self.assertEqual(default, 1.23)
+
+    def test_missing_returns_nan(self) -> None:
+        val = cp.get_cost("unknown")
+        print("missing cost:", val)
+        self.assertTrue(math.isnan(val))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `PluginCostProfiler.get_cost` default to NaN so callers can detect missing data
- decision controller uses profiled plugin costs first and falls back to constants/estimates
- ensure plugin cost profiler tests cover missing-cost NaN behavior

## Testing
- `python -m pytest tests/test_plugin_cost_profiler.py -q`
- `python -m pytest tests/test_get_plugin_cost_profiler.py -q`
- `python -m pytest tests/test_call_safely_profiler.py -q`
- `python -m pytest tests/test_plugin_timing_wrapper.py -q`
- `python -m pytest tests/test_decision_watchers.py -q`
- `python -m pytest tests/test_decision_controller.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be945833c483278cd640f5b848f578