### PR TITLE
ensure plugin cost hints are cached

### DIFF
--- a/tests/test_decision_controller.py
+++ b/tests/test_decision_controller.py
@@ -148,6 +148,20 @@ class TestDecisionController(unittest.TestCase):
         print("selection under tight linear constraint:", selected)
         self.assertEqual(selected, {"B": "on"})
 
+    def test_missing_cost_populates_and_caches(self):
+        dc.LAST_STATE_CHANGE.clear()
+        dc.TAU_THRESHOLD = 0.0
+        dc.BUDGET_LIMIT = 5.0
+        dc.PLUGIN_COST_CACHE.clear()
+        name = list(PLUGIN_ID_REGISTRY.keys())[0]
+        h_t: dict[str, dict] = {}
+        x_t = {name: "on"}
+        history: list[dict] = []
+        selected = dc.decide_actions(h_t, x_t, history, all_plugins=x_t.keys())
+        print("selected with implicit cost:", selected)
+        self.assertIn("cost", h_t[name])
+        self.assertEqual(h_t[name]["cost"], dc.PLUGIN_COST_CACHE.get(name))
+
     def test_multiple_selection_learning(self):
         dc.LAST_STATE_CHANGE.clear()
         dc.TAU_THRESHOLD = 0.0


### PR DESCRIPTION
## Summary
- record plugin costs in a module-level cache and populate missing `h_t[name]['cost']` entries
- persist actual costs after each selection so later decisions have up-to-date values
- test cost caching and implicit cost assignment

## Testing
- `PYTHONPATH=$PWD python tests/test_decision_controller.py`
- `PYTHONPATH=$PWD python tests/test_contribution_regressor.py`
- `PYTHONPATH=$PWD python tests/test_decision_controller_deterministic.py`


------
https://chatgpt.com/codex/tasks/task_e_68be996326788327a49c9ff4df746c1c