### PR TITLE
feat: optional auto cost profiling

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ decision_controller:
   watch_metrics: []  # reporter paths to monitor automatically
   watch_variables: []  # module.variable paths to observe
   policy_mode: policy-gradient  # 'policy-gradient' or 'bayesian'
+  auto_cost_profile: false  # profile plugin runtime to infer missing costs
   linear_constraints:
     A: []  # constraint matrix; columns follow sorted plugin names
     b: []  # upper bounds paired with rows in A

--- a/marble/plugin_cost_profiler.py
+++ b/marble/plugin_cost_profiler.py
@@ -11,6 +11,14 @@ from typing import Dict
 
 _ALPHA = 0.5
 _cost_ema: Dict[str, float] = {}
+_ENABLED = False
+
+
+def enable() -> None:
+    """Activate cost profiling."""
+
+    global _ENABLED
+    _ENABLED = True
 
 
 def record(plugin_name: str, elapsed: float) -> None:
@@ -23,6 +31,9 @@ def record(plugin_name: str, elapsed: float) -> None:
     elapsed:
         Elapsed execution time in seconds.
     """
+
+    if not _ENABLED:
+        return
 
     val = float(elapsed)
     prev = _cost_ema.get(plugin_name)
@@ -48,4 +59,4 @@ def get_cost(plugin_name: str, default: float = float("nan")) -> float:
     return float(_cost_ema.get(plugin_name, default))
 
 
-__all__ = ["record", "get_cost"]
+__all__ = ["record", "get_cost", "enable"]

--- a/tests/test_call_safely_profiler.py
+++ b/tests/test_call_safely_profiler.py
@@ -10,6 +10,7 @@ class CallSafelyProfilerTests(unittest.TestCase):
     def setUp(self) -> None:
         importlib.reload(cp)
         importlib.reload(mm)
+        cp.enable()
 
     def test_records_cost_when_plugin_name_provided(self) -> None:
         def dummy() -> None:

--- a/tests/test_decision_controller_auto_cost.py
+++ b/tests/test_decision_controller_auto_cost.py
@@ -1,0 +1,35 @@
+import importlib
+import unittest
+
+from marble import plugin_cost_profiler as cp
+import marble.decision_controller as dc
+
+
+class DecisionControllerAutoCostTests(unittest.TestCase):
+    def setUp(self) -> None:
+        importlib.reload(cp)
+        importlib.reload(dc)
+        dc.AUTO_COST_PROFILE = True
+        dc.BUDGET_LIMIT = 0.5
+
+    def test_profiled_cost_used(self) -> None:
+        dc.LAST_STATE_CHANGE.clear()
+        x_t = {"A": "on"}
+        h_t = {"A": {}}
+        history: list[dict] = []
+        # Instantiating the controller enables the profiler when the flag is set
+        dc.DecisionController(top_k=1)
+        sel1 = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
+        print("first selection", sel1)
+        self.assertEqual(sel1, {"A": "on"})
+        # Simulate plugin execution and its measured cost
+        cp.record("A", 1.0)
+        history.append({"A": {"action": "on", "cost": 1.0}})
+        sel2 = dc.decide_actions(h_t, x_t, history, all_plugins=h_t.keys())
+        print("second selection", sel2)
+        self.assertEqual(sel2, {})
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_get_plugin_cost_profiler.py
+++ b/tests/test_get_plugin_cost_profiler.py
@@ -11,6 +11,7 @@ class GetPluginCostProfilerTests(unittest.TestCase):
     def setUp(self) -> None:
         importlib.reload(cp)
         sys.modules.pop("marble.plugins.fakeplugin", None)
+        cp.enable()
 
     def test_profiler_priority_and_zero_init(self) -> None:
         mod = types.ModuleType("marble.plugins.fakeplugin")
@@ -23,6 +24,7 @@ class GetPluginCostProfilerTests(unittest.TestCase):
         self.assertEqual(cost, 2.5)
 
         importlib.reload(cp)
+        cp.enable()
         sys.modules["marble.plugins.fakeplugin"] = mod
         cost = get_plugin_cost("fakeplugin")
         stored = cp.get_cost("fakeplugin")

--- a/tests/test_plugin_cost_profiler.py
+++ b/tests/test_plugin_cost_profiler.py
@@ -8,6 +8,7 @@ from marble import plugin_cost_profiler as cp
 class PluginCostProfilerTests(unittest.TestCase):
     def setUp(self) -> None:
         importlib.reload(cp)
+        cp.enable()
 
     def test_record_and_get_cost(self) -> None:
         cp.record("test", 10.0)

--- a/tests/test_plugin_timing_wrapper.py
+++ b/tests/test_plugin_timing_wrapper.py
@@ -11,6 +11,7 @@ class PluginTimingWrapperTests(unittest.TestCase):
         importlib.reload(cp)
         importlib.reload(w)
         importlib.reload(p)
+        cp.enable()
 
     def test_method_records_cost(self) -> None:
         plugin = w.WANDERER_TYPES_REGISTRY["wanderalongsynapseweights"]

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -100,6 +100,12 @@
   Selects the controller's action-selection algorithm. ``policy-gradient``
   trains a stochastic policy via gradient updates, while ``bayesian`` enables a
   Thompson sampler with per-plugin Gaussian posteriors.
+- decision_controller.auto_cost_profile (bool, default: false)
+  When ``true`` the decision controller activates the plugin cost profiler and
+  refreshes per-plugin cost estimates on every decision. This allows execution
+  times measured at runtime to influence future selections, disabling plugins
+  whose measured cost would exceed the remaining budget. When ``false`` no
+  profiling occurs and static cost hints are used.
 - decision_controller.linear_constraints.A (list[list[float]], default: [])
   Matrix ``A`` defining linear inequality constraints ``A @ a <= b`` applied
   to the binary action vector ``a``. Each row represents one constraint.


### PR DESCRIPTION
## Summary
- add `auto_cost_profile` toggle to decision controller config and docs
- enable plugin cost profiling in `DecisionController` only when configured and refresh plugin costs each decision
- cover profiling behaviour with dedicated test and update existing profiler tests

## Testing
- `python -m pytest tests/test_plugin_cost_profiler.py -q`
- `python -m pytest tests/test_plugin_timing_wrapper.py -q`
- `python -m pytest tests/test_get_plugin_cost_profiler.py -q`
- `python -m pytest tests/test_call_safely_profiler.py -q`
- `python -m pytest tests/test_decision_controller_auto_cost.py -q`
- `python -m pytest tests/test_decision_controller.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be9afeb88883279eb264ca1ede1ccd