### PR TITLE
feat: add decide_with_pred helper

### DIFF
--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,5 @@
+"""Example utilities package."""
+
+from .utils import decide_with_pred
+
+__all__ = ["decide_with_pred"]

--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1,0 +1,46 @@
+"""Utility helpers for example scripts.
+
+This module exposes convenience functions shared by example scripts.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+__all__ = ["decide_with_pred"]
+
+
+def decide_with_pred(
+    dc: Any,
+    h_t: Dict[str, Dict[str, float]],
+    pred: Any,
+    target: Optional[Any] = None,
+    metrics: Optional[Dict[str, float]] = None,
+) -> Dict[str, Any]:
+    """Invoke a decision controller using a prediction tensor.
+
+    Parameters
+    ----------
+    dc:
+        Decision controller instance providing a :meth:`decide` method.
+    h_t:
+        Mapping of plugin names to per-step hint dictionaries.
+    pred:
+        Prediction tensor used to build the context sequence.
+    target:
+        Optional target tensor concatenated with ``pred`` to form the context.
+    metrics:
+        Optional reporter metrics passed through to :meth:`dc.decide`.
+
+    Returns
+    -------
+    Dict[str, Any]
+        The decision information returned by the controller.
+
+    Examples
+    --------
+    >>> # Assuming ``controller`` is a DecisionController
+    >>> hints = {"plugin": {"cost": 1.0}}
+    >>> decide_with_pred(controller, hints, pred_tensor)
+    {{'plugin': 'selected'}}
+    """
+    return dc.decide(h_t, pred=pred, target=target, metrics=metrics)


### PR DESCRIPTION
## Summary
- add reusable `decide_with_pred` helper and export from examples package

## Testing
- `python -m pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python - <<'PY'
from examples import decide_with_pred
class DummyDC:
    def __init__(self):
        self.last_args=None
    def decide(self,h_t,*,pred=None,target=None,metrics=None):
        self.last_args=(h_t,pred,target,metrics)
        return {"called":True,"hints":h_t,"pred":pred}
dc=DummyDC()
hints={"plugin":{"cost":1.0}}
res=decide_with_pred(dc,hints,pred=1.23)
print(res)
print(dc.last_args)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68bea22847248327b791e6d3855564a7