### PR TITLE
feat: add auto budget inference

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,10 @@ resource_allocator:
 autoplugin:
   decision_interval: 1  # steps between plugin selector decisions
 decision_controller:
-  budget: 10.0  # maximum total cost for selected actions
+  budget: null  # null -> auto-mode
+  warmup_steps: 10
+  safety_factor: 1.2
+  recalc_interval: 100
   contribution_l1: 0.01  # L1 penalty for contribution regressor
   tau_threshold: 1.0  # minimum seconds between state changes before penalty
   cadence: 1  # walk steps between controller decisions

--- a/tests/test_dc_auto_budget.py
+++ b/tests/test_dc_auto_budget.py
@@ -1,0 +1,28 @@
+import unittest
+import torch
+import marble.decision_controller as dc
+import marble.plugin_cost_profiler as pcp
+from marble.plugins import PLUGIN_ID_REGISTRY
+
+
+class DecisionControllerAutoBudgetTests(unittest.TestCase):
+    def test_auto_budget_inference_and_recalc(self):
+        pcp.enable()
+        dc.STEP_COUNTER = 0
+        dc.PLUGIN_GRAPH.reset()
+        name = list(PLUGIN_ID_REGISTRY.keys())[0]
+        ctrl = dc.DecisionController(budget=None, warmup_steps=2, safety_factor=1.2, recalc_interval=2)
+        ctx = torch.zeros(1, 1, 16)
+        h = {name: {"cost": 1.0}}
+        for _ in range(2):
+            ctrl.decide(h, ctx, metrics={"latency": 1, "throughput": 1, "cost": 1})
+            pcp.record(name, h[name]["cost"])
+        print("budget after warmup:", dc.BUDGET_LIMIT)
+        self.assertAlmostEqual(dc.BUDGET_LIMIT, 1.0 * 1.2, delta=0.05)
+        h[name]["cost"] = 2.0
+        for _ in range(2):
+            ctrl.decide(h, ctx, metrics={"latency": 1, "throughput": 1, "cost": 1})
+            pcp.record(name, h[name]["cost"])
+        print("budget after recalibration:", dc.BUDGET_LIMIT)
+        self.assertAlmostEqual(dc.BUDGET_LIMIT, 2.0 * 1.2, delta=0.05)
+        dc.PLUGIN_GRAPH.reset()

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -55,12 +55,19 @@
 
 ## Decision Controller Settings
 
-- decision_controller.budget (float, default: 10.0)
+- decision_controller.budget (float | null, default: null)
   Maximum cumulative cost allowed for plugin actions during a single decision
-  step. Actions exceeding the remaining budget are discarded starting with the
-  highest cost. The controller recomputes plugin costs on every decision from
-  the provided ``h_t[name]['cost']`` values, and the same limit normalises the
-  soft budget penalty used by the decision controller's policy-gradient learner.
+  step. When set to ``null`` the controller infers the limit automatically from
+  observed plugin costs during a warmup phase.
+- decision_controller.warmup_steps (int, default: 10)
+  Number of initial steps executed without a budget limit to measure typical
+  plugin costs. Must be at least 1.
+- decision_controller.safety_factor (float, default: 1.2)
+  Multiplier applied to the measured average cost when determining the budget
+  in auto-mode. Values above ``1`` provide extra slack.
+- decision_controller.recalc_interval (int, default: 100)
+  Interval in steps after which the controller recalculates the budget from the
+  recent average cost. A drift greater than 20% triggers an earlier update.
 - decision_controller.contribution_l1 (float, default: 0.01)
   L1 penalty strength applied when training the plugin contribution regressor.
   Higher values yield sparser contribution weights.


### PR DESCRIPTION
## Summary
- allow DecisionController to infer budget after warmup and periodic recalibration
- expose auto-budget options in config and YAML manual
- cover automatic budget behaviour with new unit test

## Testing
- `python -m unittest -v tests.test_dc_auto_budget`
- `python -m unittest -v tests.test_decision_controller`


------
https://chatgpt.com/codex/tasks/task_e_68bea498962c8327a35f06a7a2d99699