### PR TITLE
Align quality_loss across HF image quality scripts

### DIFF
--- a/examples/run_hf_image_quality_neuroplasticity.py
+++ b/examples/run_hf_image_quality_neuroplasticity.py
@@ -68,9 +68,16 @@ class QualityAwareRoutine:
 
 def quality_loss(pred: torch.Tensor, target: torch.Tensor, delta: float = 0.5) -> torch.Tensor:
     """Huber-style loss for quality scores."""
+    # ``pred`` carries the neuron's output which, depending on the encoded
+    # payload size, may be a high dimensional tensor.  ``target`` on the other
+    # hand encodes a single float quality score.  Subtracting mismatched shapes
+    # would raise and silently yield a zero loss upstream.  Flatten both sides
+    # to scalars so the Huber loss always operates on compatible shapes.
+    pred = pred.float().view(-1).mean()
+    target = target.float().view(-1).mean()
     diff = pred - target
     abs_diff = torch.abs(diff)
-    return torch.mean(torch.where(abs_diff < delta, 0.5 * diff ** 2, delta * (abs_diff - 0.5 * delta)))
+    return torch.where(abs_diff < delta, 0.5 * diff ** 2, delta * (abs_diff - 0.5 * delta))
 
 
 def _sample_pairs(ds, max_pairs: int | None = None) -> Iterator:


### PR DESCRIPTION
## Summary
- unify `quality_loss` across HF image-quality examples
- drop unused AutoTargetScaler plumbing from plugin-based variants

## Testing
- `python -m py_compile examples/run_hf_image_quality.py examples/run_hf_image_quality_dc.py examples/run_hf_image_quality_neuroplasticity.py examples/run_hf_image_quality_noplugins.py`
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest -v tests.test_reporter`


------
https://chatgpt.com/codex/tasks/task_e_68c271bb9a7c8327a4a6978f1f742cc4