### PR TITLE
Optimize UniversalTensorCodec encoding

### DIFF
--- a/marble/codec.py
+++ b/marble/codec.py
@@ -99,28 +99,33 @@ class UniversalTensorCodec:
 
     def _bytes_to_tokens(self, data: bytes) -> List[int]:
         self._ensure_base_vocab()
-        dict_ = self._seq_to_token
-        token_to_seq = self._token_to_seq
         tokens: List[int] = []
         if not data:
             return tokens
-        w = _BYTE_TABLE[data[0]]
+        dict_ = self._seq_to_token
+        token_to_seq = self._token_to_seq
+        byte_table = _BYTE_TABLE
         tokens_append = tokens.append
         token_to_seq_append = token_to_seq.append
+        dict_get = dict_.get
+        w = byte_table[data[0]]
+        w_token = dict_[w]
         next_token = len(token_to_seq)
-        for b in data[1:]:
-            c = _BYTE_TABLE[b]
+        for i in range(1, len(data)):
+            c = byte_table[data[i]]
             wc = w + c
-            token = dict_.get(wc)
+            token = dict_get(wc)
             if token is not None:
                 w = wc
+                w_token = token
             else:
-                tokens_append(dict_[w])
+                tokens_append(w_token)
                 dict_[wc] = next_token
                 token_to_seq_append(wc)
                 next_token += 1
                 w = c
-        tokens_append(dict_[w])
+                w_token = dict_[w]
+        tokens_append(w_token)
         return tokens
 
     def _tokens_to_bytes(self, tokens: Iterable[int]) -> bytes:

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -87,6 +87,17 @@ class TestUniversalTensorCodec(unittest.TestCase):
         print("package import ok; module:", marble.__file__)
         self.assertTrue(hasattr(marblemain, "UniversalTensorCodec"))
 
+    def test_encode_performance(self):
+        from marble.marblemain import UniversalTensorCodec
+        codec = UniversalTensorCodec()
+        obj = list(range(100000))
+        import time
+        start = time.perf_counter()
+        codec.encode(obj)
+        duration = time.perf_counter() - start
+        print("encode time:", duration)
+        self.assertGreater(duration, 0.0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- speed up UniversalTensorCodec.encode by avoiding intermediate byte copies and caching token lookups
- add a unit test that prints encoding time for a large payload

## Testing
- `python -m unittest -v tests.test_codec`

------
https://chatgpt.com/codex/tasks/task_e_68c274dd5b408327bf6d9fe13fc482f6