### PR TITLE
Improve UniversalTensorCodec encoding speed

### DIFF
--- a/marble/codec.py
+++ b/marble/codec.py
@@ -40,7 +40,7 @@ class UniversalTensorCodec:
         return len(self._token_to_seq)
 
     def encode(self, obj: Any) -> TensorLike:
-        data = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL)
+        data = pickle.dumps(obj, protocol=pickle.HIGHEST_PROTOCOL, fix_imports=False)
         tokens = self._bytes_to_tokens(data)
         out = self._to_tensor(tokens)
         try:

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -87,6 +87,19 @@ class TestUniversalTensorCodec(unittest.TestCase):
         print("package import ok; module:", marble.__file__)
         self.assertTrue(hasattr(marblemain, "UniversalTensorCodec"))
 
+    def test_encode_deterministic(self):
+        codec = self.Codec()
+        obj = [1, 2, 3, {"k": "v"}]
+        t1 = codec.encode(obj)
+        t2 = codec.encode(obj)
+        try:
+            self.assertEqual(t1.tolist(), t2.tolist())
+            ln = t1.numel()
+        except Exception:
+            self.assertEqual(list(t1), list(t2))
+            ln = len(t1)
+        print("deterministic tokens:", ln)
+
     def test_encode_performance(self):
         from marble.marblemain import UniversalTensorCodec
         codec = UniversalTensorCodec()


### PR DESCRIPTION
## Summary
- speed up `UniversalTensorCodec.encode` by disabling pickle import fixes
- add determinism test for the codec

## Testing
- `PYTHONPATH=. pytest tests/test_codec.py::TestUniversalTensorCodec::test_encode_performance -q -s`
- `PYTHONPATH=. pytest tests/test_codec.py -q -s`


------
https://chatgpt.com/codex/tasks/task_e_68c27ddaee488327becd68e773b06b43