### PR TITLE
Add test for UniversalTensorCodec custom text roundtrip

### DIFF
--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -137,6 +137,18 @@ class TestUniversalTensorCodec(unittest.TestCase):
         print("image encode time:", duration)
         self.assertLess(duration, 0.009)
 
+    def test_encode_decode_custom_text(self):
+        codec = self.Codec()
+        text = "The cat is dancing in a moonlight shadow"
+        tokens = codec.encode(text)
+        decoded = codec.decode(tokens)
+        try:
+            ln = int(tokens.numel()) if hasattr(tokens, "numel") else len(tokens)
+        except Exception:
+            ln = -1
+        print("custom text roundtrip tokens:", ln)
+        self.assertEqual(decoded, text)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add regression test checking UniversalTensorCodec can encode and decode a sample sentence

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest -v tests.test_codec`


------
https://chatgpt.com/codex/tasks/task_e_68c29c6f829c8327bb63d15f6e0c0d2e