### PR TITLE
fix: connect neurons in hf quality example

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -342,7 +342,13 @@ def main(
         if idx in getattr(br, "neurons", {}):
             n = br.neurons[idx]
         else:
-            n = br.add_neuron(idx, tensor=0.0, type_name="autoneuron")
+            existing = next(iter(br.neurons)) if getattr(br, "neurons", None) else None
+            n = br.add_neuron(
+                idx,
+                tensor=0.0,
+                type_name="autoneuron",
+                connect_to=existing,
+            )
         n.receive(enc)
         return n
     


### PR DESCRIPTION
## Summary
- ensure new neurons in the Hugging Face image quality example connect to an existing neuron at creation

## Testing
- `PYTHONPATH=. pytest tests/test_neuron_connectivity.py -q`
- `python - <<'PY'
from examples.run_hf_image_quality import UniversalTensorCodec, Brain
brain=Brain(1, formula="n1>=0")
codec=UniversalTensorCodec()
def start(br):
    payload=("prompt", None)
    enc=codec.encode(payload)
    idx=br.available_indices()[0]
    if idx in br.neurons:
        n=br.neurons[idx]
    else:
        existing=next(iter(br.neurons)) if br.neurons else None
        n=br.add_neuron(idx, tensor=0.0, type_name="autoneuron", connect_to=existing)
    n.receive(enc)
    return n
start(brain); start(brain); print('neurons', len(brain.neurons))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68c7a4df121483278ad0d8c992488c0c