### PR TITLE
Add snapshot topology visualization utility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2025-10-01
+- Added ``snapshot_to_image`` helper to render network topology PNGs from
+  ``.marble`` snapshot files.
+
 2025-09-11
 - Benchmarked zlib compression levels 1-9 and selected level 2 as the best
   speed/size compromise for `UniversalTensorCodec`, improving encode times

--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ with resource_allocator.track_tensor(holder, "buf"):
 
 After the context exits the buffer is registered and may be moved between GPU,
 CPU or even disk automatically.
+
+## Visualising brain snapshots
+
+You can turn a ``.marble`` snapshot into a quick topology image using
+``snapshot_to_image``.
+
+```python
+from marble import snapshot_to_image
+
+png_path = snapshot_to_image("snapshot_123.marble", "topology.png")
+print("saved image to", png_path)
+```
+
+The helper arranges neurons in a circle and draws synapses as straight lines,
+which is handy for debugging and inspecting small brains.

--- a/marble/__init__.py
+++ b/marble/__init__.py
@@ -11,6 +11,7 @@ from .action_sampler import compute_logits, sample_actions, select_plugins
 from .offpolicy import Trajectory, importance_weights, doubly_robust
 from .policy_gradient import PolicyGradientAgent
 from .decision_controller import BUDGET_LIMIT
+from .snapshot_viz import snapshot_to_image
 
 __all__ = [
     "enable_auto_param_learning",
@@ -23,4 +24,5 @@ __all__ = [
     "doubly_robust",
     "PolicyGradientAgent",
     "BUDGET_LIMIT",
+    "snapshot_to_image",
 ]

--- a/marble/snapshot_viz.py
+++ b/marble/snapshot_viz.py
@@ -1,0 +1,71 @@
+"""Utilities for visualizing network topology from snapshots.
+
+This module provides a helper that loads a brain snapshot and
+renders its neuron/synapse topology to a simple PNG image.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, Tuple
+
+from PIL import Image, ImageDraw
+
+from .marblemain import Brain
+
+
+__all__ = ["snapshot_to_image"]
+
+
+def snapshot_to_image(snapshot_path: str, output_path: str, *, size: int = 512) -> str:
+    """Render a brain snapshot to an image and return the written path.
+
+    Parameters
+    ----------
+    snapshot_path:
+        Path to the ``.marble`` snapshot file to visualize.
+    output_path:
+        Destination path for the rendered PNG image.
+    size:
+        Width and height of the generated image in pixels. Defaults to ``512``.
+
+    The function arranges neurons on a circle and draws synapses as straight
+    lines between them. It is intended for quick debugging and topology
+    inspection rather than publication‑quality figures.
+    """
+
+    brain = Brain.load_snapshot(snapshot_path)
+    neurons = list(brain.neurons.values())
+    n = len(neurons)
+
+    img = Image.new("RGB", (size, size), "white")
+    draw = ImageDraw.Draw(img)
+
+    if n == 0:
+        img.save(output_path)
+        return output_path
+
+    center = size / 2
+    radius = size * 0.4
+    positions: Dict[int, Tuple[float, float]] = {}
+    for idx, neuron in enumerate(neurons):
+        angle = 2 * math.pi * idx / n
+        x = center + radius * math.cos(angle)
+        y = center + radius * math.sin(angle)
+        positions[id(neuron)] = (x, y)
+
+    # Draw synapses first so neurons overlay them
+    for syn in brain.synapses:
+        src = positions.get(id(syn.source))
+        dst = positions.get(id(syn.target))
+        if src and dst:
+            draw.line([src, dst], fill="black", width=1)
+
+    # Draw neurons as blue circles
+    r = 5
+    for x, y in positions.values():
+        draw.ellipse((x - r, y - r, x + r, y + r), fill="blue")
+
+    img.save(output_path)
+    return output_path
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
   "tqdm",
   "kuzu",
   "pyyaml",
+  "Pillow",
 ]
 
 [project.urls]

--- a/tests/test_snapshot_visualization.py
+++ b/tests/test_snapshot_visualization.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+import unittest
+
+from marble import snapshot_to_image
+from marble.marblemain import Brain
+from marble.reporter import clear_report_group
+
+
+class TestSnapshotVisualization(unittest.TestCase):
+    def test_snapshot_to_image_creates_file(self):
+        clear_report_group("brain")
+        tmp = tempfile.mkdtemp()
+        b = Brain(1, size=3, store_snapshots=True, snapshot_path=tmp, snapshot_freq=1)
+        b.add_neuron((0,), tensor=[0.0])
+        b.add_neuron((1,), tensor=[1.0], connect_to=(0,), direction="uni")
+        snap = b.save_snapshot()
+        out_png = os.path.join(tmp, "topology.png")
+        result = snapshot_to_image(snap, out_png)
+        print("snapshot image:", result, "size", os.path.getsize(result))
+        self.assertTrue(os.path.exists(result))
+        self.assertGreater(os.path.getsize(result), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add `snapshot_to_image` helper to render brain topology PNGs from snapshot files
- expose snapshot visualization in package init and document in README
- record new visualization helper in changelog and project dependencies

## Testing
- `python -m unittest -v tests.test_snapshot_visualization`


------
https://chatgpt.com/codex/tasks/task_e_68c7adb55a608327b337ae53adf8eb7d