### PR TITLE
Use in-place math ops for synapse transmit and wanderer pre-forward

### DIFF
--- a/marble/graph.py
+++ b/marble/graph.py
@@ -324,17 +324,21 @@ class Synapse(_DeviceHelper):
             holder = {"val": val}
             with _tt(holder, "val"):
                 if self._torch is not None and self._is_torch_tensor(holder["val"]):
-                    holder["val"] = holder["val"] * float(self.weight) + float(self.bias)
+                    holder["val"].mul_(float(self.weight)).add_(float(self.bias))
                 else:
                     vl = np.asarray(holder["val"], dtype=np.float32)
-                    holder["val"] = vl * float(self.weight) + float(self.bias)
+                    vl *= float(self.weight)
+                    vl += float(self.bias)
+                    holder["val"] = vl
             val = holder["val"]
         except Exception:
             if self._torch is not None and self._is_torch_tensor(val):
-                val = val * float(self.weight) + float(self.bias)
+                val.mul_(float(self.weight)).add_(float(self.bias))
             else:
                 vl = np.asarray(val, dtype=np.float32)
-                val = vl * float(self.weight) + float(self.bias)
+                vl *= float(self.weight)
+                vl += float(self.bias)
+                val = vl
 
         if direction == "forward":
             if self.direction not in ("uni", "bi"):

--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -761,7 +761,7 @@ class Wanderer(_DeviceHelper):
                 try:
                     start_dev = time.perf_counter()
                     dev_val = out.detach().to(self._device)
-                    dev_val = dev_val * float(getattr(next_syn, "weight", 1.0)) + float(getattr(next_syn, "bias", 0.0))
+                    dev_val.mul_(float(getattr(next_syn, "weight", 1.0))).add_(float(getattr(next_syn, "bias", 0.0)))
                     compute_time = time.perf_counter() - start_dev
                     start_transfer = time.perf_counter()
                     _ = dev_val.to(self._device)


### PR DESCRIPTION
## Summary
- speed up `Synapse.transmit` by using in-place `mul_`/`add_` operations when tensor-based
- tighten wanderer pre-forward path with in-place weight/bias application

## Testing
- `pytest tests/test_graph.py -q`
- `pytest tests/test_wanderer_pre_forward.py -q`
- `pytest tests/test_wanderer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c804bf8a9c83278129ca12194935bf