### PR TITLE
Call rebalance_all during walk

### DIFF
--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -524,6 +524,12 @@ class Wanderer(_DeviceHelper):
                         pass
             except Exception:
                 pass
+            try:
+                for plug in getattr(self, "_wplugins", []) or []:
+                    if hasattr(plug, "rebalance_all"):
+                        plug.rebalance_all(self)
+            except Exception:
+                pass
             self._visited.append(current)
             w_param, b_param = params_for(current)
 


### PR DESCRIPTION
## Summary
- trigger rebalancing on every wanderer step to respond to large allocations immediately

## Testing
- `python -m unittest -v tests.test_wanderer_resource_allocator`
- `python -m unittest -v tests.test_wanderer`


------
https://chatgpt.com/codex/tasks/task_e_68c8091dffb083279994af9f35defb7a