### PR TITLE
Call rebalance_all after each Wanderer step

### DIFF
--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -823,6 +823,12 @@ class Wanderer(_DeviceHelper):
             carried_value = out
             steps += 1
             moved_last = True
+            for plug in getattr(self, "_wplugins", []) or []:
+                try:
+                    if hasattr(plug, "rebalance_all"):
+                        plug.rebalance_all(self)  # type: ignore[attr-defined]
+                except Exception:
+                    pass
 
         try:
             if moved_last and current is not None:


### PR DESCRIPTION
## Summary
- Ensure Wanderer.walk rebalances memory at the end of every step via `rebalance_all`

## Testing
- `pytest tests/test_wanderer.py`
- `pytest tests/test_wanderer_resource_allocator.py`
- `pytest tests/test_wanderer_walk_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68c80ad7568c8327b8366b053162c360