### PR TITLE
Fix cycle detection in synapse transmit

### DIFF
--- a/marble/graph.py
+++ b/marble/graph.py
@@ -359,6 +359,7 @@ class Synapse(_DeviceHelper):
                 raise ValueError("This synapse does not allow forward transmission")
             dest = self.target
             if isinstance(dest, Synapse):
+                visited[self] = None
                 out_neuron = dest.transmit(val, direction="forward", visited=visited)
             else:
                 dest.receive(val)
@@ -368,6 +369,7 @@ class Synapse(_DeviceHelper):
                 raise ValueError("This synapse does not allow backward transmission")
             dest = self.source
             if isinstance(dest, Synapse):
+                visited[self] = None
                 out_neuron = dest.transmit(val, direction="backward", visited=visited)
             else:
                 dest.receive(val)


### PR DESCRIPTION
## Summary
- avoid infinite recursion by marking a synapse as visited before recursive transmit calls

## Testing
- `python -m pytest tests/test_graph.py -q`
- `python -m pytest tests/test_wanderer_helper_and_synapse.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80f23ecec832782c1cfdfb7a22cd1