### PR TITLE
Avoid in-place synapse scaling

### DIFF
--- a/marble/graph.py
+++ b/marble/graph.py
@@ -336,9 +336,11 @@ class Synapse(_DeviceHelper):
             from .plugins.wanderer_resource_allocator import track_tensor as _tt
             with _tt(holder, "val"):
                 if self._torch is not None and self._is_torch_tensor(holder["val"]):
-                    holder["val"].mul_(float(self.weight)).add_(float(self.bias))
+                    out = holder["val"] * float(self.weight)
+                    out.add_(float(self.bias))
+                    holder["val"] = out
                 else:
-                    vl = np.asarray(holder["val"], dtype=np.float32)
+                    vl = np.array(holder["val"], dtype=np.float32, copy=True)
                     vl *= float(self.weight)
                     vl += float(self.bias)
                     holder["val"] = vl
@@ -346,9 +348,11 @@ class Synapse(_DeviceHelper):
         except Exception:
             if not applied:
                 if self._torch is not None and self._is_torch_tensor(holder["val"]):
-                    holder["val"].mul_(float(self.weight)).add_(float(self.bias))
+                    out = holder["val"] * float(self.weight)
+                    out.add_(float(self.bias))
+                    holder["val"] = out
                 else:
-                    vl = np.asarray(holder["val"], dtype=np.float32)
+                    vl = np.array(holder["val"], dtype=np.float32, copy=True)
                     vl *= float(self.weight)
                     vl += float(self.bias)
                     holder["val"] = vl


### PR DESCRIPTION
## Summary
- prevent Synapse.transmit from in-place scaling its input by creating a scaled copy of the tensor or array
- maintain VRAM safety with `track_tensor` while avoiding extra temporaries

## Testing
- `pytest tests/test_graph.py -q`
- `pytest tests/test_synapse_plugins.py -q`
- `pytest tests/test_wanderer_helper_and_synapse.py -q`
- `pytest tests/test_wanderer_resource_allocator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8134df38c8327adbfb84f0c2c1902