### PR TITLE
Fix synapse tensor tracking to use weakref-friendly holder

### DIFF
--- a/marble/graph.py
+++ b/marble/graph.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Deque, Dict, List, Optional, Sequence, Tuple, Union, TYPE_CHECKING
 from collections import deque
+from types import SimpleNamespace
 
 import torch
 import numpy as np
@@ -330,33 +331,33 @@ class Synapse(_DeviceHelper):
             return visited[self]
 
         val = self._ensure_tensor(value)
-        holder = {"val": val}
+        holder = SimpleNamespace(val=val)
         applied = False
         try:
             from .plugins.wanderer_resource_allocator import track_tensor as _tt
             with _tt(holder, "val"):
-                if self._torch is not None and self._is_torch_tensor(holder["val"]):
-                    out = holder["val"] * float(self.weight)
+                if self._torch is not None and self._is_torch_tensor(holder.val):
+                    out = holder.val * float(self.weight)
                     out.add_(float(self.bias))
-                    holder["val"] = out
+                    holder.val = out
                 else:
-                    vl = np.array(holder["val"], dtype=np.float32, copy=True)
+                    vl = np.array(holder.val, dtype=np.float32, copy=True)
                     vl *= float(self.weight)
                     vl += float(self.bias)
-                    holder["val"] = vl
+                    holder.val = vl
                 applied = True
         except Exception:
             if not applied:
-                if self._torch is not None and self._is_torch_tensor(holder["val"]):
-                    out = holder["val"] * float(self.weight)
+                if self._torch is not None and self._is_torch_tensor(holder.val):
+                    out = holder.val * float(self.weight)
                     out.add_(float(self.bias))
-                    holder["val"] = out
+                    holder.val = out
                 else:
-                    vl = np.array(holder["val"], dtype=np.float32, copy=True)
+                    vl = np.array(holder.val, dtype=np.float32, copy=True)
                     vl *= float(self.weight)
                     vl += float(self.bias)
-                    holder["val"] = vl
-        val = holder["val"]
+                    holder.val = vl
+        val = holder.val
 
         if direction == "forward":
             if self.direction not in ("uni", "bi"):


### PR DESCRIPTION
## Summary
- use a SimpleNamespace wrapper when tracking temporary synapse tensors so the allocator can weakref the holder

## Testing
- `pytest tests/test_graph.py`
- `pytest tests/test_advanced_synapse_plugins.py`
- `pytest tests/test_plugin_timing_wrapper.py`


------
https://chatgpt.com/codex/tasks/task_e_68c90568c0708327ae9e711406a2c658