### PR TITLE
Preserve gradients during allocator tensor moves

### DIFF
--- a/marble/plugins/wanderer_resource_allocator.py
+++ b/marble/plugins/wanderer_resource_allocator.py
@@ -804,8 +804,9 @@ def restore_tensor(obj: Any, attr: str, device: torch.device | str):
     if torch.is_tensor(tensor):
         try:
             moved = tensor.to(device)
-            if getattr(tensor, "requires_grad", False) and not moved.requires_grad:
-                moved.requires_grad_(True)
+            moved = ResourceAllocatorPlugin._finalize_tensor(
+                moved, bool(getattr(tensor, "requires_grad", False))
+            )
             moved = ResourceAllocatorPlugin._preserve_grad(tensor, moved)
             setattr(obj, attr, moved)
             return moved


### PR DESCRIPTION
## Summary
- add a helper that preserves gradients when the resource allocator replaces tensor objects during transfers
- wire the gradient preservation helper through disk/GPU/CPU transfer paths, including fallbacks and restore helpers
- ensure the public `restore_tensor` utility keeps gradient buffers when moving tensors manually, detaching fallback transfers before copying gradients

## Testing
- python -m pytest tests/test_wanderer.py

------
https://chatgpt.com/codex/tasks/task_e_68c90ab7415883279a3fe8700178ab10