### PR TITLE
Fix progress bar singleton initialization

### DIFF
--- a/marble/progressbar.py
+++ b/marble/progressbar.py
@@ -96,8 +96,11 @@ class ProgressBar(ProgressBarBase):
     """Concrete progress bar replicating Wanderer's original output."""
 
     def __init__(self) -> None:
+        if getattr(self, "_initialized", False):
+            return
         self._bar: Optional[Any] = None
         self.verbose = False
+        self._initialized = True
 
     # ---- ProgressBarBase API -------------------------------------------------
     def start(self, total: int, *, leave: bool = False, verbose: bool = False, **meta: Any) -> None:

--- a/tests/test_progressbar_labels.py
+++ b/tests/test_progressbar_labels.py
@@ -21,5 +21,12 @@ class TestProgressBarLabels(unittest.TestCase):
         self.assertIn("neurons=1/2", postfix)
         p.end(cur_ep=1, tot_ep=1, cur_walk=1, tot_walks=1, loss=0.0, steps=1)
 
+    def test_singleton_does_not_reset_existing_bar(self):
+        p = ProgressBar()
+        p.start(1)
+        with self.assertRaises(RuntimeError):
+            ProgressBar().start(1)
+        p.end(cur_ep=1, tot_ep=1, cur_walk=1, tot_walks=1, loss=0.0, steps=1)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- make the progress bar singleton guard against repeated __init__ runs so one instance survives multiple lookups
- cover the singleton behaviour with a regression test that refuses to start a second bar while one is active

## Testing
- python -m unittest tests.test_progressbar_labels -v

------
https://chatgpt.com/codex/tasks/task_e_68c93dcf78448327856ae19e46cfbe25