### PR TITLE
Adjust wanderer progress metrics and reporting

### DIFF
--- a/marble/dashboard.py
+++ b/marble/dashboard.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import json, os, threading, time, datetime, tempfile
 from pathlib import Path
 from collections import defaultdict
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 # Global path to share metrics between training process and Streamlit app
 _METRICS_FILE = Path(tempfile.gettempdir()) / "marble_dashboard_metrics.json"
@@ -48,6 +48,7 @@ def update_metrics(
     cuda_available: bool,
     available_plugins: int,
     neuron_types_available: int,
+    path_index: Optional[int] = None,
 ) -> None:
     """Write latest training metrics to the shared metrics file."""
     global _plugin_actions
@@ -96,6 +97,7 @@ def update_metrics(
         "cuda": bool(cuda_available),
         "last_snapshot_time": snapshot_time,
         "last_snapshot_size_mb": snapshot_size,
+        "path_index": (int(path_index) if path_index is not None else None),
     }
     try:
         _METRICS_FILE.write_text(json.dumps(data))

--- a/tests/test_wanderer_alternate_paths_creator.py
+++ b/tests/test_wanderer_alternate_paths_creator.py
@@ -9,7 +9,7 @@ class TestAlternatePathsCreator(unittest.TestCase):
         it = iter(b.available_indices())
         i1 = next(it); i2 = next(it)
         n1 = b.add_neuron(i1, tensor=0.0)
-        n2 = b.add_neuron(i2, tensor=0.0)
+        n2 = b.add_neuron(i2, tensor=0.0, connect_to=i1)
         b.connect(i1, i2, direction="uni")
         w = Wanderer(b, type_name="alternatepathscreator", neuro_config={"altpaths_min_len": 2, "altpaths_max_len": 3})
         before = len(b.neurons)

--- a/tests/test_wanderer_tiling.py
+++ b/tests/test_wanderer_tiling.py
@@ -10,7 +10,7 @@ class TestWandererTiling(unittest.TestCase):
     def test_wanderer_tiling_basic(self):
         b = self.Brain(2, mode="sparse", sparse_bounds=((0.0, None), (0.0, None)))
         n1 = b.add_neuron((0.0, 0.0), tensor=[1.0, 2.0], weight=1.0, bias=0.5)
-        n2 = b.add_neuron((1.0, 0.0), tensor=[0.5, 1.5], weight=0.8, bias=-0.2)
+        n2 = b.add_neuron((1.0, 0.0), tensor=[0.5, 1.5], weight=0.8, bias=-0.2, connect_to=(0.0, 0.0), direction="bi")
         b.connect((0.0, 0.0), (1.0, 0.0), direction="bi")
 
         orig = {id(n1): (n1.weight, n1.bias), id(n2): (n2.weight, n2.bias)}


### PR DESCRIPTION
## Summary
- track aggregate loss statistics across all completed walks and reuse them for reporter, dashboard, and progress output
- refresh the progress bar to show path indices and persisted loss metrics only when a walk finishes
- connect helper tests' setup neurons immediately so add_neuron invariants remain satisfied

## Testing
- `python -m unittest -v tests.test_wanderer`
- `python -m unittest -v tests.test_wanderer_walk_summary`
- `python -m unittest -v tests.test_wanderer_bestpath_weights`
- `python -m unittest -v tests.test_wanderer_alternate_paths_creator`
- `python -m unittest -v tests.test_wanderer_wayfinder_plugin`
- `python -m unittest -v tests.test_wanderer_flat_delta`
- `python -m unittest -v tests.test_wanderer_helper_and_synapse`
- `python -m unittest -v tests.test_wanderer_lock_timeout`
- `python -m unittest -v tests.test_wanderer_pre_forward`
- `python -m unittest -v tests.test_wanderer_resource_allocator`
- `python -m unittest -v tests.test_wanderer_tiling`


------
https://chatgpt.com/codex/tasks/task_e_68c942c4c9408327a674ced7931e7151