### PR TITLE
Enforce instance-bound decode for UniversalTensorCodec

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -1870,9 +1870,14 @@ class Brain:
                     "weight": syn.weight,
                 }
             )
-        if getattr(self, "codec", None) is not None:
+        codec_obj = getattr(self, "codec", None)
+        if codec_obj is not None:
             try:
-                data["codec_vocab"] = self.codec.dump_vocab()
+                data["codec_state"] = codec_obj.export_state()
+            except Exception:
+                pass
+            try:
+                data["codec_vocab"] = codec_obj.dump_vocab()
             except Exception:
                 pass
         with open(target, "wb") as f:
@@ -1960,14 +1965,23 @@ class Brain:
                 type_name=syn.get("type_name"),
                 weight=syn.get("weight", 1.0),
             )
-        vocab = data.get("codec_vocab")
-        if vocab is not None:
+        codec_state = data.get("codec_state")
+        if codec_state is not None:
             try:
                 codec = UniversalTensorCodec()
-                codec.load_vocab(vocab)
+                codec.import_state(codec_state)
                 brain.codec = codec
             except Exception:
                 pass
+        else:
+            vocab = data.get("codec_vocab")
+            if vocab is not None:
+                try:
+                    codec = UniversalTensorCodec()
+                    codec.load_vocab(vocab)
+                    brain.codec = codec
+                except Exception:
+                    pass
         return brain
 
     # --- Occupancy/grid helpers ---


### PR DESCRIPTION
## Summary
- add a per-instance secret token to `UniversalTensorCodec` payloads and validate it during decode, plus helper export/import APIs
- persist the codec state (including the secret token) inside brain snapshots so restored brains keep decoding capability
- adjust the codec tests to cover large sequence round-trips and expect failures when decoding with a different codec instance

## Testing
- `PYTHONPATH=. pytest tests/test_codec.py`
- `PYTHONPATH=. pytest tests/test_datapair.py`
- `PYTHONPATH=. pytest tests/test_brain_snapshot.py`
- `PYTHONPATH=. pytest tests/test_streaming_memory_cleanup.py`
- `PYTHONPATH=. pytest tests/test_training_with_datapairs.py`
- `PYTHONPATH=. pytest tests/test_brain_status.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9647dc3648327a38f5e022ce51ff2