### PR TITLE
Add test for UniversalTensorCodec re-encode guard

### DIFF
--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -73,6 +73,21 @@ class TestUniversalTensorCodec(unittest.TestCase):
             if out_path.exists():
                 os.remove(out_path)
 
+    def test_reencode_rejected(self):
+        codec = self.Codec()
+        payload = {"payload": [1, 2, 3], "label": "encoded"}
+        tokens = codec.encode(payload)
+        try:
+            ln = int(tokens.numel()) if hasattr(tokens, "numel") else len(tokens)
+        except Exception:
+            ln = len(tokens)
+        print("re-encode guard tokens:", ln)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Trying to re-encode an object that was already encoded using this or another instance of UniversalTensorCodec",
+        ):
+            codec.encode(tokens)
+
     def test_repeating_sequence_compression(self):
         codec = self.Codec()
         data = b"A" * 100


### PR DESCRIPTION
## Summary
- add a unit test that confirms `UniversalTensorCodec.encode` raises its re-encode guard when passed an already encoded payload

## Testing
- python -m unittest -v tests.test_codec

------
https://chatgpt.com/codex/tasks/task_e_68c96c225ee08327976468a0508c09f6