### PR TITLE
Add decision controller logging with JSONL output

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,6 +23,7 @@ decision_controller:
   watch_variables: []  # module.variable paths to observe
   policy_mode: policy-gradient  # 'policy-gradient' or 'bayesian'
   auto_cost_profile: false  # profile plugin runtime to infer missing costs
+  log_path: null  # optional newline-delimited JSON log written every decision
   linear_constraints:
     A: []  # constraint matrix; columns follow sorted plugin names
     b: []  # upper bounds paired with rows in A

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -113,6 +113,11 @@
   times measured at runtime to influence future selections, disabling plugins
   whose measured cost would exceed the remaining budget. When ``false`` no
   profiling occurs and static cost hints are used.
+- decision_controller.log_path (str | null, default: null)
+  Filesystem path to a newline-delimited JSON log capturing every decision the
+  controller makes. When set to ``null`` logging stays disabled. The file is
+  opened in append mode with line buffering so observers can ``tail`` the log
+  while training is running.
 - decision_controller.linear_constraints.A (list[list[float]], default: [])
   Matrix ``A`` defining linear inequality constraints ``A @ a <= b`` applied
   to the binary action vector ``a``. Each row represents one constraint.


### PR DESCRIPTION
## Summary
- add a `decision_controller.log_path` config option and JSONL logger that tracks controller lifecycle events
- stream decision, skip, and budget update events with sanitized payloads so the log can be tailed during training
- document the new option and cover it with a regression test that inspects the JSONL output

## Testing
- `python -m unittest -v tests.test_decision_controller`


------
https://chatgpt.com/codex/tasks/task_e_68ca3d09fea08327950455d8f8810422