### PR TITLE
Add TensorBoard reporting pipeline

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,11 @@ resource_allocator:
   ram_offload_threshold: 0.9  # offload tensors to disk when RAM usage exceeds this ratio
   vram_offload_threshold: 0.9  # move tensors off GPU when VRAM usage exceeds this ratio
   disk_usage_threshold: 0.95  # stop offloading when disk usage exceeds this ratio
+reporter:
+  tensorboard:
+    enabled: true  # write all reporter updates to TensorBoard
+    log_dir: null  # default SummaryWriter location when null
+    flush_interval_steps: 5  # flush writer every N reporter updates
 autoplugin:
   decision_interval: 1  # steps between plugin selector decisions
 decision_controller:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "kuzu",
   "pyyaml",
   "Pillow",
+  "tensorboard",
 ]
 
 [project.urls]

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -47,6 +47,23 @@
   Maximum allowed disk usage ratio before tensors are offloaded. Prevents disk
   exhaustion; value must be between 0 and 1.
 
+## Reporter Settings
+
+- reporter.tensorboard.enabled (bool, default: true)
+  When set to ``true`` the central reporter mirrors every update into a live
+  TensorBoard event stream. Scalars are recorded as individual time series,
+  tensors and numeric sequences become histograms, and other payloads are
+  emitted as text snippets so dashboards always reflect the most recent state.
+- reporter.tensorboard.log_dir (str | null, default: null)
+  Filesystem path passed directly to :class:`torch.utils.tensorboard.SummaryWriter`.
+  Keeping the default ``null`` delegates directory creation to the writer,
+  producing timestamped folders under ``runs/``. Set a custom path to aggregate
+  multiple training runs in a single dashboard.
+- reporter.tensorboard.flush_interval_steps (int, default: 5)
+  Number of reporter updates processed before the writer flushes buffered
+  events to disk. Lower values provide lower latency visualisations at the cost
+  of more frequent disk synchronisation.
+
 ## AutoPlugin Settings
 
 - autoplugin.decision_interval (int, default: 1)


### PR DESCRIPTION
## Summary
- add TensorBoard defaults to the global configuration and document them
- enhance the central Reporter so every update is mirrored into TensorBoard with scalars, histograms, or text fallback
- extend reporter tests to assert TensorBoard event files are produced and add tensorboard dependency

## Testing
- python -m unittest -v tests.test_reporter

------
https://chatgpt.com/codex/tasks/task_e_68ca4a0df9ac83278800b15d59d20ddb