### PR TITLE
Ensure HF image quality examples save snapshots

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -514,6 +514,12 @@ def main(
         if cnt == 0:
             raise RuntimeError("run_training_with_datapairs returned count=0")
         clear_resources()
+    if getattr(brain, "store_snapshots", False):
+        try:
+            snapshot_file = brain.save_snapshot()
+            print(f"saved final brain snapshot to {snapshot_file}")
+        except Exception as err:
+            print(f"failed to save final snapshot: {err}")
     print("streamed quality training complete")
     clear_resources()
 

--- a/examples/run_hf_image_quality_dc.py
+++ b/examples/run_hf_image_quality_dc.py
@@ -458,6 +458,12 @@ def main(
         step_metrics = last_hist.get("step_metrics", [])
         prev_dt = float(step_metrics[-1].get("dt", 0.0)) if step_metrics else 0.0
         clear_resources()
+    if getattr(brain, "store_snapshots", False):
+        try:
+            snapshot_file = brain.save_snapshot()
+            print(f"saved final brain snapshot to {snapshot_file}")
+        except Exception as err:
+            print(f"failed to save final snapshot: {err}")
     print("streamed quality training complete")
     clear_resources()
 

--- a/examples/run_hf_image_quality_neuroplasticity.py
+++ b/examples/run_hf_image_quality_neuroplasticity.py
@@ -344,6 +344,12 @@ def main(
         print(f"processed datapairs: {cnt} in {duration:.2f}s ({duration/walks:.2f}s per walk)")
         if cnt == 0:
             raise RuntimeError("run_training_with_datapairs returned count=0")
+    if getattr(brain, "store_snapshots", False):
+        try:
+            snapshot_file = brain.save_snapshot()
+            print(f"saved final brain snapshot to {snapshot_file}")
+        except Exception as err:
+            print(f"failed to save final snapshot: {err}")
     print(
         "streamed quality training complete",
         f"neurons={len(getattr(brain, 'neurons', {}))}",

--- a/examples/run_hf_image_quality_noplugins.py
+++ b/examples/run_hf_image_quality_noplugins.py
@@ -333,6 +333,12 @@ def main(
         print(f"processed datapairs: {cnt} in {duration:.2f}s ({duration/walks:.2f}s per walk)")
         if cnt == 0:
             raise RuntimeError("run_training_with_datapairs returned count=0")
+    if getattr(brain, "store_snapshots", False):
+        try:
+            snapshot_file = brain.save_snapshot()
+            print(f"saved final brain snapshot to {snapshot_file}")
+        except Exception as err:
+            print(f"failed to save final snapshot: {err}")
     print("streamed quality training complete")
 
 


### PR DESCRIPTION
## Summary
- save a final brain snapshot at the end of each Hugging Face image quality example run
- report the snapshot path or surface errors so users know whether the save succeeded

## Testing
- python -m compileall examples/run_hf_image_quality.py examples/run_hf_image_quality_dc.py examples/run_hf_image_quality_neuroplasticity.py examples/run_hf_image_quality_noplugins.py

------
https://chatgpt.com/codex/tasks/task_e_68ca4dd23ebc8327bd1114c03ac0be80