### PR TITLE
Fix snapshot saving for dynamic brains

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -1833,16 +1833,30 @@ class Brain:
                 pass
             return [float(x) for x in (t if isinstance(t, (list, tuple)) else [t])]
 
+        size_attr = getattr(self, "size", None)
+        if size_attr is None:
+            size_list: List[Any] = []
+        else:
+            size_list = list(size_attr)
+
+        def _listify_bounds(value: Any) -> List[List[Any]]:
+            if value is None:
+                return []
+            try:
+                return [list(b) for b in value]
+            except TypeError:
+                return []
+
         data: Dict[str, Any] = {
             "version": 1,
             "n": self.n,
             "mode": self.mode,
-            "size": list(getattr(self, "size", [])),
-            "bounds": [list(b) for b in getattr(self, "bounds", [])],
+            "size": size_list,
+            "bounds": _listify_bounds(getattr(self, "bounds", None)),
             "formula": getattr(self, "formula", None),
             "max_iters": getattr(self, "max_iters", None),
             "escape_radius": getattr(self, "escape_radius", None),
-            "sparse_bounds": [list(b) for b in getattr(self, "sparse_bounds", [])],
+            "sparse_bounds": _listify_bounds(getattr(self, "sparse_bounds", None)),
             "neurons": [],
             "synapses": [],
         }

--- a/tests/test_brain_snapshot.py
+++ b/tests/test_brain_snapshot.py
@@ -25,6 +25,16 @@ class TestBrainSnapshot(unittest.TestCase):
         decoded = loaded.codec.decode(tokens)
         self.assertEqual(decoded, "foo bar foo bar")
 
+    def test_snapshot_dynamic_brain_without_size(self):
+        clear_report_group("brain")
+        tmp = tempfile.mkdtemp()
+        b = Brain(1, size=None, store_snapshots=True, snapshot_path=tmp, snapshot_freq=1)
+        b.add_neuron((0,), tensor=[0.0])
+        b.add_neuron((1,), tensor=[1.0], connect_to=(0,), direction="uni")
+        snap_path = b.save_snapshot()
+        self.assertTrue(os.path.exists(snap_path))
+        self.assertIn(os.path.basename(snap_path), os.listdir(tmp))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- prevent `Brain.save_snapshot` from raising when size/bounds are unset so periodic snapshots work for dynamic brains
- cover snapshot saving for size-less brains with a regression test

## Testing
- PYTHONPATH=. pytest tests/test_brain_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68ca4f0ee584832784c196993bfd8e10