### PR TITLE
Launch inline TensorBoard when notebook mode enabled

### DIFF
--- a/marble/wanderer.py
+++ b/marble/wanderer.py
@@ -434,9 +434,15 @@ class Wanderer(_DeviceHelper):
                 tot_ep=tot_ep,
             )
         elif tensorboard_dir and not getattr(self.brain, "_tensorboard_announced", False):
-            print(
-                f"[marble] TensorBoard logging active — run `%tensorboard --logdir {tensorboard_dir}`"
-            )
+            inline_active = bool(getattr(self.brain, "_tensorboard_inline_active", False))
+            if inline_active:
+                print(
+                    f"[marble] TensorBoard inline display active for logdir: {tensorboard_dir}"
+                )
+            else:
+                print(
+                    f"[marble] TensorBoard logging active — run `%tensorboard --logdir {tensorboard_dir}`"
+                )
             try:
                 self.brain._tensorboard_announced = True
             except Exception:

--- a/tests/test_tensorboard_progressbar.py
+++ b/tests/test_tensorboard_progressbar.py
@@ -23,7 +23,10 @@ class TestTensorBoardProgressBar(unittest.TestCase):
         self.assertFalse(brain.enable_progressbar)
         self.assertIsNotNone(brain.tensorboard_logdir)
         self.assertGreaterEqual(stats.get("steps", 0), 0)
-        self.assertIn("%tensorboard --logdir", output)
+        self.assertTrue(
+            "TensorBoard inline display active" in output
+            or "%tensorboard --logdir" in output
+        )
         self.assertTrue(getattr(brain, "_tensorboard_announced", False))
 
 


### PR DESCRIPTION
## Summary
- automatically attempt to launch an inline TensorBoard widget when a `Brain` is created with `tensorboard=True`
- adjust the wanderer notification and tensorboard progress-bar test to accommodate the inline display behaviour

## Testing
- python -m unittest -v tests.test_tensorboard_progressbar

------
https://chatgpt.com/codex/tasks/task_e_68ca53913f588327bf85f1bf29e52953