### PR TITLE
Add TensorBoard logging for learnable parameters

### DIFF
--- a/marble/learnable_param.py
+++ b/marble/learnable_param.py
@@ -19,6 +19,7 @@ class LearnableParam:
     lr: Optional[float] = None
     min_value: Optional[float] = None
     max_value: Optional[float] = None
+    display_name: Optional[str] = None
 
     def apply_constraints(self) -> None:
         """Clamp and cast the underlying tensor in-place."""


### PR DESCRIPTION
## Summary
- tag each `LearnableParam` with its display name and extend the learnables registry to emit TensorBoard updates for active parameters
- add a helper for logging learnable values and call it from Wanderer, Brain, and SelfAttention so every ON learnable streams into the `learnables` TensorBoard category

## Testing
- `python -m unittest tests.test_learnable_params`
- `python -m unittest tests.test_reporter`


------
https://chatgpt.com/codex/tasks/task_e_68ca8348ed188327a8dc6616cbca9914