### PR TITLE
Add helpers to toggle learnable parameter states

### DIFF
--- a/tests/test_update_learnables_yaml.py
+++ b/tests/test_update_learnables_yaml.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import yaml
 
-from marble.learnables_yaml import updatelearnablesyaml
+from marble.learnables_yaml import learnablesOFF, learnablesON, updatelearnablesyaml
 
 
 class UpdateLearnablesYamlTests(unittest.TestCase):
@@ -22,6 +22,36 @@ class UpdateLearnablesYamlTests(unittest.TestCase):
         self.assertTrue("Wanderer.dyn_query" in data)
         self.assertTrue("Wanderer.latent_vector" in data)
         self.assertGreater(len(data), 100)
+
+    def test_learnablesoff_turns_everything_off(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = Path(tmpdir) / "learnables.yaml"
+
+            learnablesOFF(yaml_path)
+
+            with yaml_path.open("r", encoding="utf8") as fh:
+                data = yaml.safe_load(fh) or {}
+
+        self.assertTrue(data)
+        self.assertTrue(all(value == "OFF" for value in data.values()))
+
+    def test_learnableson_enables_non_loss_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yaml_path = Path(tmpdir) / "learnables.yaml"
+
+            learnablesOFF(yaml_path)
+            learnablesON(yaml_path)
+
+            with yaml_path.open("r", encoding="utf8") as fh:
+                data = yaml.safe_load(fh) or {}
+
+        non_loss = {key for key in data if "loss" not in key.lower()}
+        loss_related = {key for key in data if "loss" in key.lower()}
+
+        self.assertTrue(non_loss)
+        self.assertTrue(loss_related)
+        self.assertTrue(all(data[key] == "ON" for key in non_loss))
+        self.assertTrue(all(data[key] == "OFF" for key in loss_related))
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- add helper methods to toggle learnable parameter optimisation states in learnables.yaml
- expose learnablesON/learnablesOFF helpers and integrate them with the registry
- extend learnables YAML tests to cover the new helpers

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `PYTHONPATH=. pytest tests/test_update_learnables_yaml.py`


------
https://chatgpt.com/codex/tasks/task_e_68ca8fd164288327842540edd7442ae8