### PR TITLE
Ensure learnable-controlled plugins are activated automatically

### DIFF
--- a/tests/test_autoplugin_bias.py
+++ b/tests/test_autoplugin_bias.py
@@ -25,6 +25,58 @@ class TestAutoPluginBias(unittest.TestCase):
         self.assertFalse(active)
         self.assertIn("EpsilonGreedyChooserPlugin", stack)
 
+    def test_plugin_learnables_force_activation(self):
+        from marble.marblemain import Brain, Wanderer
+        from marble.plugins.wanderer_autoplugin import AutoPlugin
+        import torch
+
+        b = Brain(1, size=(1,))
+        idx = b.available_indices()[0]
+        b.add_neuron(idx, tensor=[1.0], type_name="autoneuron")
+        w = Wanderer(
+            b,
+            type_name="autoplugin,actorcritic",
+            neuroplasticity_type="base",
+            seed=0,
+        )
+        auto = next(p for p in w._wplugins if isinstance(p, AutoPlugin))
+        bias_name = "autoplugin_bias_ActorCriticPlugin"
+        bias = w.get_learnable_param_tensor(bias_name)
+        bias.data.fill_(-100.0)
+
+        original_sample = torch.distributions.MultivariateNormal.sample
+
+        def fake_sample(self, sample_shape=torch.Size()):
+            return torch.zeros_like(self.loc)
+
+        torch.distributions.MultivariateNormal.sample = fake_sample  # type: ignore[assignment]
+        try:
+            w.set_param_optimization(bias_name, enabled=False)
+            auto._gate_cache.clear()
+            active_before = auto.is_active(w, "ActorCriticPlugin", None)
+            self.assertFalse(active_before)
+
+            w.set_param_optimization(bias_name, enabled=True)
+            auto._gate_cache.clear()
+            active_after_bias = auto.is_active(w, "ActorCriticPlugin", None)
+            self.assertTrue(active_after_bias)
+
+            # Disable bias optimisation again and enable a plugin-specific learnable.
+            w.set_param_optimization(bias_name, enabled=False)
+            actor = next(
+                getattr(p, "_plugin", p)
+                for p in w._wplugins
+                if getattr(getattr(p, "_plugin", p), "__class__").__name__ == "ActorCriticPlugin"
+            )
+            actor._params(w)  # ensure learnables are registered
+            w.set_param_optimization("w_loss", enabled=True)
+            bias.data.fill_(-100.0)
+            auto._gate_cache.clear()
+            active_after_param = auto.is_active(w, "ActorCriticPlugin", None)
+            self.assertTrue(active_after_param)
+        finally:
+            torch.distributions.MultivariateNormal.sample = original_sample  # type: ignore[assignment]
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- track learnable-to-plugin associations in the learnables registry and expose a helper to query whether any associated learnables are enabled
- teach `expose_learnable_params` and the AutoPlugin bootstrap paths to register these associations so that gating can respond to YAML toggles
- force AutoPlugin to keep plugins active whenever any of their learnables are switched ON and cover the behaviour with a regression test

## Testing
- python -m unittest -v tests.test_autoplugin_bias
- python -m unittest -v tests.test_update_learnables_yaml

------
https://chatgpt.com/codex/tasks/task_e_68ca91dd36348327a0af6e3f978bb77e