### PR TITLE
Add learnable toggles and resource allocator metrics

### DIFF
--- a/marble/__init__.py
+++ b/marble/__init__.py
@@ -6,7 +6,12 @@ except Exception:
     pass
 
 from .auto_param import enable_auto_param_learning
-from .learnables_yaml import updatelearnablesyaml
+from .learnables_yaml import (
+    learnableIsOn,
+    learnableOFF,
+    learnableON,
+    updatelearnablesyaml,
+)
 from .plugin_encoder import PluginEncoder
 from .action_sampler import compute_logits, sample_actions, select_plugins
 from .offpolicy import Trajectory, importance_weights, doubly_robust
@@ -27,4 +32,7 @@ __all__ = [
     "BUDGET_LIMIT",
     "snapshot_to_image",
     "updatelearnablesyaml",
+    "learnableON",
+    "learnableOFF",
+    "learnableIsOn",
 ]

--- a/marble/decision_controller.py
+++ b/marble/decision_controller.py
@@ -940,6 +940,7 @@ class DecisionController:
         # plugin contribution scores and feed them back into future selections.
         self._activation_log: List[torch.Tensor] = []
         self._reward_log: List[float] = []
+        self._decision_count = 0
         self._log_event(
             "controller_initialized",
             {
@@ -1061,6 +1062,7 @@ class DecisionController:
         metrics: Optional[Dict[str, Any]],
         dwell_blocked: bool,
         watch_vals: Dict[str, float],
+        decision_count: int,
     ) -> None:
         """Mirror core controller metrics into the reporter/TensorBoard."""
 
@@ -1077,6 +1079,7 @@ class DecisionController:
         try:
             ready_list = list(ready)
             _emit_scalar("step", float(STEP_COUNTER))
+            _emit_scalar("decisions_made", float(decision_count))
             _emit_scalar("history_len", float(len(self.history)))
             _emit_scalar("step_cost", float(step_cost))
             _emit_scalar("budget", float(self.budget))
@@ -1615,6 +1618,7 @@ class DecisionController:
             },
         )
 
+        self._decision_count += 1
         self._log_tensorboard_metrics(
             plugin_names=plugin_names,
             ready=ready,
@@ -1629,6 +1633,7 @@ class DecisionController:
             metrics=metrics,
             dwell_blocked=dwell_blocked,
             watch_vals=watch_vals,
+            decision_count=self._decision_count,
         )
 
         return selected


### PR DESCRIPTION
## Summary
- add targeted helpers in the learnables registry for toggling and querying individual entries and expose them via the package init
- add coverage for the new helpers while surfacing per-decision counts in the controller tensorboard logs
- extend the wanderer resource allocator with tensor inventory reporting and ensure disk offloads release the in-memory payload

## Testing
- pip install --index-url https://download.pytorch.org/whl/cpu torch
- python -m unittest tests.test_update_learnables_yaml
- python -m unittest tests.test_wanderer_resource_allocator
- python -m unittest tests.test_resource_allocator_disk_usage
- python -m unittest tests.test_resource_allocator_ram_pressure

------
https://chatgpt.com/codex/tasks/task_e_68ca9ec6354483279cb2242b5a2a0986