### PR TITLE
Handle backward transmit on uni-directional synapses

### DIFF
--- a/marble/graph.py
+++ b/marble/graph.py
@@ -304,6 +304,32 @@ class Synapse(_DeviceHelper):
         except Exception:
             pass
 
+    def make_bidirectional(self) -> None:
+        """Upgrade the synapse to bidirectional connectivity if needed."""
+        if self.direction == "bi":
+            return
+
+        self.direction = "bi"
+
+        if isinstance(self.source, Synapse):
+            if self not in self.source.incoming_synapses:
+                self.source.incoming_synapses.append(self)
+        else:
+            if self not in self.source.incoming:
+                self.source.incoming.append(self)
+
+        if isinstance(self.target, Synapse):
+            if self not in self.target.outgoing_synapses:
+                self.target.outgoing_synapses.append(self)
+        else:
+            if self not in self.target.outgoing:
+                self.target.outgoing.append(self)
+
+        try:
+            self._report("synapse", "direction_changed", {"direction": self.direction}, "events")
+        except Exception:
+            pass
+
     # Disallow copying to maintain graph immutability during training
     def __copy__(self):
         raise TypeError("Synapse instances are immutable and cannot be copied")


### PR DESCRIPTION
## Summary
- add a helper on Synapse to promote a connection to bidirectional safely
- teach Wanderer to upgrade synapses and warn when a backward transmit is requested on a uni-directional edge
- add a regression test that covers the automatic upgrade path and warning message

## Testing
- python -m unittest tests.test_wanderer
- python -m unittest tests.test_graph

------
https://chatgpt.com/codex/tasks/task_e_68caaa69e54c83278734c3c5eb9fb4bd