### PR TITLE
Ensure batchtrainer stays enabled in HF quality example

### DIFF
--- a/examples/run_hf_image_quality_dc.py
+++ b/examples/run_hf_image_quality_dc.py
@@ -484,6 +484,12 @@ def main(
         enabled = [n for n, state in actions.items() if state != "off"]
         if not enabled:
             enabled = wplugins
+        if "batchtrainer" not in enabled:
+            # ``run_training_with_datapairs`` requires the batchtrainer plugin
+            # when ``batch_size`` exceeds 1.  The DecisionController may decide
+            # to disable it temporarily, but the training loop must keep it
+            # active so batched execution stays valid.
+            enabled.append("batchtrainer")
 
         pairs = _sample_pairs(ds, max_pairs=max_pairs)
         start_time = time.perf_counter()


### PR DESCRIPTION
## Summary
- force the DecisionController-driven training loop in `run_hf_image_quality_dc.py` to always include the `batchtrainer` plugin
- add an explanatory comment describing why the plugin must remain active when batch training

## Testing
- not run (example-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cab67f4d348327aeefe8fe4c5d4a80