### PR TITLE
Handle batched datapairs in HF quality examples

### DIFF
--- a/examples/run_hf_image_quality.py
+++ b/examples/run_hf_image_quality.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 print("Importing packages..")
 
 from typing import Iterator, Any, Dict
+from collections.abc import Mapping
 import io
 import os
 import re
@@ -429,12 +430,35 @@ def main(
         else:
             print("Kuzu Explorer could not be started")
 
-    def _start_neuron(left: Dict[str, Any], br):
+    def _start_neuron(left: Any, br):
         if PREP_TIMES:
             latency = time.perf_counter() - PREP_TIMES.pop(0)
             print(f"prep-to-train latency: {latency:.4f}s")
-        payload = (left.get("prompt"), left.get("image"))
-        enc = codec.encode(payload)
+        sentinel = object()
+        enc: Any = left
+        if torch.is_tensor(left):
+            enc = left
+        else:
+            prompt = sentinel
+            image = sentinel
+            if isinstance(left, Mapping):
+                prompt = left.get("prompt", sentinel)
+                image = left.get("image", sentinel)
+            else:
+                try:
+                    prompt = left["prompt"]  # type: ignore[index]
+                    image = left["image"]  # type: ignore[index]
+                except Exception:
+                    if isinstance(left, (list, tuple)) and len(left) == 2:
+                        prompt, image = left
+                    else:
+                        prompt = image = sentinel
+            if prompt is not sentinel or image is not sentinel:
+                if prompt is sentinel:
+                    prompt = None
+                if image is sentinel:
+                    image = None
+                enc = codec.encode((prompt, image))
         try:
             idx = br.available_indices()[0]
         except Exception:

--- a/examples/run_hf_image_quality_dc.py
+++ b/examples/run_hf_image_quality_dc.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 print("Importing packages..")
 
 from typing import Iterator, Any, Dict
+from collections.abc import Mapping
 import io
 import os
 import re
@@ -442,13 +443,35 @@ def main(
         else:
             print("Kuzu Explorer could not be started")
 
-    def _start_neuron(left: Dict[str, Any], br):
+    def _start_neuron(left: Any, br):
         if PREP_TIMES:
             latency = time.perf_counter() - PREP_TIMES.pop(0)
             print(f"prep-to-train latency: {latency:.4f}s")
-        # Combine the raw prompt with the already encoded image
-        payload = (left.get("prompt"), left.get("image"))
-        enc = codec.encode(payload)
+        sentinel = object()
+        enc: Any = left
+        if torch.is_tensor(left):
+            enc = left
+        else:
+            prompt = sentinel
+            image = sentinel
+            if isinstance(left, Mapping):
+                prompt = left.get("prompt", sentinel)
+                image = left.get("image", sentinel)
+            else:
+                try:
+                    prompt = left["prompt"]  # type: ignore[index]
+                    image = left["image"]  # type: ignore[index]
+                except Exception:
+                    if isinstance(left, (list, tuple)) and len(left) == 2:
+                        prompt, image = left
+                    else:
+                        prompt = image = sentinel
+            if prompt is not sentinel or image is not sentinel:
+                if prompt is sentinel:
+                    prompt = None
+                if image is sentinel:
+                    image = None
+                enc = codec.encode((prompt, image))
         try:
             idx = br.available_indices()[0]
         except Exception:

--- a/examples/run_hf_image_quality_neuroplasticity.py
+++ b/examples/run_hf_image_quality_neuroplasticity.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 print("Importing packages..")
 
 from typing import Iterator, Any, Dict
+from collections.abc import Mapping
 import io
 import os
 import re
@@ -298,12 +299,35 @@ def main(
         else:
             print("Kuzu Explorer could not be started")
 
-    def _start_neuron(left: Dict[str, Any], br):
+    def _start_neuron(left: Any, br):
         if PREP_TIMES:
             latency = time.perf_counter() - PREP_TIMES.pop(0)
             print(f"prep-to-train latency: {latency:.4f}s")
-        payload = (left.get("prompt"), left.get("image"))
-        enc = codec.encode(payload)
+        sentinel = object()
+        enc: Any = left
+        if torch.is_tensor(left):
+            enc = left
+        else:
+            prompt = sentinel
+            image = sentinel
+            if isinstance(left, Mapping):
+                prompt = left.get("prompt", sentinel)
+                image = left.get("image", sentinel)
+            else:
+                try:
+                    prompt = left["prompt"]  # type: ignore[index]
+                    image = left["image"]  # type: ignore[index]
+                except Exception:
+                    if isinstance(left, (list, tuple)) and len(left) == 2:
+                        prompt, image = left
+                    else:
+                        prompt = image = sentinel
+            if prompt is not sentinel or image is not sentinel:
+                if prompt is sentinel:
+                    prompt = None
+                if image is sentinel:
+                    image = None
+                enc = codec.encode((prompt, image))
         try:
             idx = br.available_indices()[0]
         except Exception:


### PR DESCRIPTION
## Summary
- make the Hugging Face image quality examples resilient to batched datapairs by accepting tensors that are already encoded
- fall back to encoding only when prompt/image data is available and reuse existing tensors otherwise

## Testing
- python -m compileall examples/run_hf_image_quality.py examples/run_hf_image_quality_noplugins.py examples/run_hf_image_quality_neuroplasticity.py examples/run_hf_image_quality_dc.py

------
https://chatgpt.com/codex/tasks/task_e_68cabc36d55c832793aa5a51500bfb30