### PR TITLE
Handle CUDA OOM by triggering resource allocator fallback

### DIFF
--- a/tests/test_resource_allocator_vram_overflow.py
+++ b/tests/test_resource_allocator_vram_overflow.py
@@ -43,6 +43,60 @@ class ResourceAllocatorOOMTests(unittest.TestCase):
         self.assertGreater(obj.weight.numel(), 0)
         self.assertIsNone(getattr(obj, "_weight_offload"))
 
+    def test_handle_cuda_oom_moves_low_hit_tensors(self):
+        plug = ResourceAllocatorPlugin()
+        dummy = types.SimpleNamespace()
+        dummy.weight = torch.ones(8)
+        module = importlib.import_module("marble.plugins.wanderer_resource_allocator")
+
+        base_tensor = torch.ones(8)
+
+        class FakeCudaTensor:
+            def __init__(self, base):
+                self._base = base
+
+            def __getattr__(self, item):
+                return getattr(self._base, item)
+
+            @property
+            def device(self):
+                class _FakeDevice:
+                    def __str__(self_inner):
+                        return "cuda:0"
+
+                    def lower(self_inner):
+                        return "cuda:0"
+
+                return _FakeDevice()
+
+        fake_tensor = FakeCudaTensor(base_tensor)
+        dummy.weight = fake_tensor
+        fake_entries = [(dummy, "weight", fake_tensor, 0.05)]
+        transfers: list[tuple[str, str]] = []
+
+        def fake_transfer(obj, attr, tensor, target):
+            transfers.append((attr, target))
+
+        orig_is_tensor = torch.is_tensor
+
+        def fake_is_tensor(obj):
+            if isinstance(obj, FakeCudaTensor):
+                return True
+            return orig_is_tensor(obj)
+
+        with patch.object(module.TENSOR_REGISTRY, "iter_tensors", return_value=fake_entries):
+            with patch("marble.plugins.wanderer_resource_allocator.torch.cuda.is_available", return_value=True):
+                with patch("marble.plugins.wanderer_resource_allocator.torch.cuda.empty_cache"):
+                    with patch.object(ResourceAllocatorPlugin, "_system_metrics", return_value={"gpu": 1.0, "vram": 0.0, "cpu": 0.0, "ram": 0.2, "disk": 0.1}):
+                        with patch("marble.plugins.wanderer_resource_allocator.torch.is_tensor", new=fake_is_tensor):
+                            with patch.object(ResourceAllocatorPlugin, "_safe_transfer", side_effect=fake_transfer):
+                                handled = plug.handle_cuda_oom(None, torch.cuda.OutOfMemoryError("Tried to allocate 64.00 MiB"))
+
+        print("oom handled transfers:", transfers)
+        self.assertTrue(handled)
+        self.assertGreater(len(transfers), 0)
+        self.assertEqual(transfers[0][1], "cpu")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a CUDA out-of-memory recovery hook in the resource allocator that evicts low-hit tensors to CPU or disk and logs evictions
- wire Wanderer backward passes to trigger the allocator on CUDA OOM and retry the gradient step if memory is reclaimed
- cover the new behaviour with unit tests that simulate allocator-driven OOM recovery

## Testing
- python -m unittest -v tests.test_resource_allocator_vram_overflow
- python -m unittest -v tests.test_wanderer

------
https://chatgpt.com/codex/tasks/task_e_68cac089e14083278d3efb8a553ec859