### PR TITLE
Fix snapshot naming collisions

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -29,6 +29,7 @@ import hashlib
 import importlib
 import itertools
 import gc
+import datetime
 from . import plugin_cost_profiler as _pcp
 from .learnable_param import LearnableParam
 from .learnables_yaml import log_learnable_values, register_learnable
@@ -1918,8 +1919,17 @@ class Brain:
         if target is None:
             if not self.snapshot_path:
                 raise ValueError("snapshot_path is not configured")
-            ts = int(time.time())
-            target = os.path.join(self.snapshot_path, f"snapshot_{ts}.marble")
+            ts = datetime.datetime.fromtimestamp(time.time())
+            base = ts.strftime("%Y%m%d_%H%M%S_%f")
+            candidate = os.path.join(self.snapshot_path, f"snapshot_{base}.marble")
+            if os.path.exists(candidate):
+                suffix = 1
+                while os.path.exists(candidate):
+                    candidate = os.path.join(
+                        self.snapshot_path, f"snapshot_{base}_{suffix}.marble"
+                    )
+                    suffix += 1
+            target = candidate
         if not str(target).endswith(".marble"):
             target = str(target) + ".marble"
 

--- a/tests/test_brain_snapshot.py
+++ b/tests/test_brain_snapshot.py
@@ -35,6 +35,22 @@ class TestBrainSnapshot(unittest.TestCase):
         self.assertTrue(os.path.exists(snap_path))
         self.assertIn(os.path.basename(snap_path), os.listdir(tmp))
 
+    def test_snapshot_unique_filenames_when_saving_quickly(self):
+        clear_report_group("brain")
+        tmp = tempfile.mkdtemp()
+        b = Brain(
+            1,
+            size=3,
+            store_snapshots=True,
+            snapshot_path=tmp,
+            snapshot_freq=1,
+            snapshot_keep=50,
+        )
+        paths = [b.save_snapshot() for _ in range(3)]
+        basenames = [os.path.basename(p) for p in paths]
+        self.assertEqual(len(basenames), len(set(basenames)))
+        self.assertGreaterEqual(len(os.listdir(tmp)), 3)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- ensure `Brain.save_snapshot` generates unique filenames using microsecond timestamps and suffix fallback to avoid overwriting
- add a regression test that rapidly saves snapshots and checks for unique files

## Testing
- `pip install --index-url https://download.pytorch.org/whl/cpu torch`
- `python -m unittest tests.test_brain_snapshot`


------
https://chatgpt.com/codex/tasks/task_e_68cbad2b53fc8327a869106ac4933eef