### PR TITLE
Ensure HF quality example saves scheduled snapshots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pyyaml",
   "Pillow",
   "tensorboard",
+  "datasets",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- add snapshot path/frequency/retention overrides to the HF image quality DecisionController example and resolve relative paths relative to the script when provided
- count processed datapairs when scheduling snapshots so configured cadences fire and log the walk counts during training
- harden the resource allocator tensor registry for objects without writable attributes and add the missing `datasets` dependency

## Testing
- python - <<'PY'
from examples.run_hf_image_quality_dc import main
main(max_pairs=11, epochs=1, snapshot_path="snapshots", snapshot_freq=10, snapshot_keep=10)
PY

------
https://chatgpt.com/codex/tasks/task_e_68cbc053db1483279c06b1087b60e813