### PR TITLE
Compress brain snapshots and add legacy load coverage

### DIFF
--- a/tests/test_brain_snapshot.py
+++ b/tests/test_brain_snapshot.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import tempfile
 import unittest
 
@@ -17,6 +18,9 @@ class TestBrainSnapshot(unittest.TestCase):
         b.add_neuron((1,), tensor=[0.0])
         b.add_neuron((0,), tensor=[1.0], connect_to=(1,), direction="uni")
         snap_path = b.save_snapshot()
+        with open(snap_path, "rb") as saved:
+            header = saved.read(2)
+        self.assertEqual(header, b"\x1f\x8b")
         print("snapshot path:", snap_path)
         loaded = Brain.load_snapshot(snap_path)
         print("loaded brain neurons:", len(loaded.neurons))
@@ -24,6 +28,45 @@ class TestBrainSnapshot(unittest.TestCase):
         self.assertTrue(hasattr(loaded, "codec"))
         decoded = loaded.codec.decode(tokens)
         self.assertEqual(decoded, "foo bar foo bar")
+
+    def test_load_legacy_uncompressed_snapshot(self):
+        clear_report_group("brain")
+        tmp = tempfile.mkdtemp()
+        legacy_path = os.path.join(tmp, "legacy_snapshot.marble")
+        legacy_data = {
+            "version": 1,
+            "n": 1,
+            "mode": "grid",
+            "size": [3],
+            "bounds": [[0.0, 1.0]],
+            "formula": None,
+            "max_iters": 50,
+            "escape_radius": 2.0,
+            "sparse_bounds": [],
+            "neurons": [
+                {
+                    "position": [0],
+                    "weight": 0.5,
+                    "bias": 0.1,
+                    "age": 1,
+                    "type_name": "default",
+                    "tensor": [0.25],
+                }
+            ],
+            "synapses": [],
+        }
+        with open(legacy_path, "wb") as f:
+            pickle.dump(legacy_data, f, protocol=pickle.HIGHEST_PROTOCOL)
+        loaded = Brain.load_snapshot(legacy_path)
+        self.assertEqual(len(loaded.neurons), 1)
+        neuron = next(iter(loaded.neurons.values()))
+        tensor_value = neuron.tensor
+        if hasattr(tensor_value, "detach") and hasattr(tensor_value, "tolist"):
+            tensor_payload = tensor_value.detach().to("cpu").tolist()
+        else:
+            tensor_payload = list(tensor_value)
+        self.assertEqual(tensor_payload, [0.25])
+        self.assertEqual(neuron.type_name, "default")
 
     def test_snapshot_dynamic_brain_without_size(self):
         clear_report_group("brain")


### PR DESCRIPTION
## Summary
- compress brain snapshots when saving by writing the pickle payload through gzip
- auto-detect compressed snapshots during loading while preserving support for legacy files
- expand brain snapshot tests to assert compression and cover loading historical pickle files

## Testing
- pytest tests/test_brain_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe4b79f8c8327bad804fc2044aa28