### PR TITLE
Avoid storing redundant codec vocab in snapshots

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -2007,11 +2007,10 @@ class Brain:
             try:
                 data["codec_state"] = codec_obj.export_state()
             except Exception:
-                pass
-            try:
-                data["codec_vocab"] = codec_obj.dump_vocab()
-            except Exception:
-                pass
+                try:
+                    data["codec_vocab"] = codec_obj.dump_vocab()
+                except Exception:
+                    pass
         with gzip.open(target, "wb") as f:
             pickle.dump(data, f, protocol=pickle.HIGHEST_PROTOCOL)
         # Retention: keep only the newest N snapshots if configured


### PR DESCRIPTION
## Summary
- update `Brain.save_snapshot` to only fall back to storing `codec_vocab` when exporting the codec state fails
- extend the brain snapshot tests to cover the absence of `codec_vocab` in new snapshots and verify the legacy loader path

## Testing
- pip install --index-url https://download.pytorch.org/whl/cpu torch
- python -m pytest tests/test_brain_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe643b5f08327a96e1948f379da8c