### PR TITLE
Add binary tensor blob snapshot serialization

### DIFF
--- a/tests/test_brain_snapshot.py
+++ b/tests/test_brain_snapshot.py
@@ -4,6 +4,9 @@ import pickle
 import tempfile
 import unittest
 
+import numpy as np
+import torch
+
 from marble.marblemain import Brain, UniversalTensorCodec
 from marble.reporter import clear_report_group
 
@@ -27,6 +30,13 @@ class TestBrainSnapshot(unittest.TestCase):
         print("snapshot keys:", sorted(payload.keys()))
         self.assertIn("codec_state", payload)
         self.assertNotIn("codec_vocab", payload)
+        self.assertGreater(len(payload.get("neurons", [])), 0)
+        first_neuron = payload["neurons"][0]
+        self.assertIn("tensor_blob", first_neuron)
+        blob = first_neuron["tensor_blob"]
+        print("tensor_blob metadata:", blob)
+        self.assertIsInstance(blob.get("data"), bytes)
+        self.assertEqual(blob.get("shape"), [1])
         print("snapshot path:", snap_path)
         loaded = Brain.load_snapshot(snap_path)
         print("loaded brain neurons:", len(loaded.neurons))
@@ -110,6 +120,45 @@ class TestBrainSnapshot(unittest.TestCase):
             tensor_payload = list(tensor_value)
         self.assertEqual(tensor_payload, [0.25])
         self.assertEqual(neuron.type_name, "default")
+
+    def test_tensor_blob_round_trip_multi_dimensional(self):
+        clear_report_group("brain")
+        tmp = tempfile.mkdtemp()
+        b = Brain(2, size=None, store_snapshots=True, snapshot_path=tmp, snapshot_freq=1)
+        base_tensor = torch.arange(12, dtype=torch.float32).reshape(2, 2, 3)
+        b.add_neuron((0, 0), tensor=base_tensor)
+        snap_path = b.save_snapshot()
+        with gzip.open(snap_path, "rb") as payload_file:
+            payload = pickle.load(payload_file)
+        self.assertEqual(len(payload.get("neurons", [])), 1)
+        neuron_payload = payload["neurons"][0]
+        self.assertIn("tensor_blob", neuron_payload)
+        blob = neuron_payload["tensor_blob"]
+        print("blob schema:", {k: type(v).__name__ for k, v in blob.items()})
+        expected_shape = list(base_tensor.shape)
+        self.assertEqual(blob.get("shape"), expected_shape)
+        self.assertIsInstance(blob.get("data"), bytes)
+        self.assertEqual(len(blob.get("data", b"")), base_tensor.numel() * base_tensor.element_size())
+        adjusted_payload = payload
+        for neuron in adjusted_payload.get("neurons", []):
+            neuron.pop("tensor", None)
+        blob_only_path = os.path.join(tmp, "blob_only_snapshot.marble")
+        with gzip.open(blob_only_path, "wb") as f:
+            pickle.dump(adjusted_payload, f, protocol=pickle.HIGHEST_PROTOCOL)
+        restored = Brain.load_snapshot(blob_only_path)
+        restored_neuron = restored.get_neuron((0, 0))
+        self.assertIsNotNone(restored_neuron)
+        assert restored_neuron is not None
+        restored_tensor = restored_neuron.tensor
+        expected_cpu = base_tensor.detach().cpu()
+        if hasattr(restored_tensor, "detach") and hasattr(restored_tensor, "to"):
+            round_tripped = restored_tensor.detach().to("cpu")
+            self.assertEqual(tuple(round_tripped.shape), tuple(expected_cpu.shape))
+            self.assertTrue(torch.allclose(round_tripped, expected_cpu))
+        else:
+            round_tripped_np = np.asarray(restored_tensor)
+            self.assertEqual(round_tripped_np.shape, expected_cpu.numpy().shape)
+            self.assertTrue(np.allclose(round_tripped_np, expected_cpu.numpy()))
 
     def test_snapshot_dynamic_brain_without_size(self):
         clear_report_group("brain")


### PR DESCRIPTION
## Summary
- export tensor dtype/shape/raw bytes alongside legacy lists when saving brain snapshots
- teach Brain.load_snapshot to rebuild tensors from stored blobs while still handling legacy list data
- add regression coverage for tensor blobs and legacy snapshot compatibility

## Testing
- python -m pytest tests/test_brain_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe901a3a48327af3524ad6dbe3c7f