### PR TITLE
Fix batched left_to_start error handling

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -3683,10 +3683,7 @@ def run_training_with_datapairs(
         start: Optional[Neuron] = None
         if left_to_start is not None:
             for raw_left in raw_left_values:
-                try:
-                    candidate = left_to_start(raw_left, brain)  # type: ignore[arg-type]
-                except Exception:
-                    candidate = None
+                candidate = left_to_start(raw_left, brain)  # type: ignore[arg-type]
                 if start is None and candidate is not None:
                     start = candidate
         if start is None:


### PR DESCRIPTION
## Summary
- remove the broad exception handler around batched `left_to_start` callback invocations
- let callback failures raise immediately so batched training matches single datapair behavior

## Testing
- python -m unittest -v tests.test_batch_training_plugin

------
https://chatgpt.com/codex/tasks/task_e_68ccee99460c8327a8ce892005ac2a27