### PR TITLE
Store snapshot pools as arrays

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -2498,10 +2498,13 @@ class Brain:
         data["synapses"] = synapses_block
         data["string_table"] = string_table
         if tensor_pool:
-            data["tensor_pool"] = [list(entry) for entry in tensor_pool]
+            data["tensor_pool"] = [
+                array("f", [float(v) for v in entry])
+                for entry in tensor_pool
+            ]
         if tensor_pool_fills:
             data["tensor_pool_fills"] = [
-                {"value": float(value), "length": int(length)}
+                (float(value), int(length))
                 for value, length in tensor_pool_fills
             ]
         codec_obj = getattr(self, "codec", None)


### PR DESCRIPTION
## Summary
- store saved snapshot tensor pool entries as float arrays and emit uniform fill metadata as value-length tuples
- keep snapshot loading compatible with both legacy dict/list formats and the new containers
- update snapshot-focused tests to validate the array-based pool and tuple fill records

## Testing
- python -m pytest tests/test_brain_snapshot.py

------
https://chatgpt.com/codex/tasks/task_e_68cd10b9b8508327939f405e63e4be3c