### PR TITLE
Stream brain snapshots incrementally

### DIFF
--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 # Only file allowed to import
 import json
 import pickle
-import gzip
 import math
 import random
 import threading
@@ -31,12 +30,12 @@ import importlib
 import itertools
 import gc
 import datetime
-import subprocess
-import shutil
+import weakref
 from array import array
 from . import plugin_cost_profiler as _pcp
 from .learnable_param import LearnableParam
 from .learnables_yaml import log_learnable_values, register_learnable
+from .snapshot_stream import SnapshotStreamWriter, SnapshotStreamError, read_latest_state
 try:
     import msvcrt  # type: ignore
 except Exception:
@@ -84,66 +83,6 @@ _DEFAULT_SNAPSHOT_COMPRESS_LEVEL = _coerce_snapshot_compress_level(
     default=2,
 )
 
-
-_PIGZ_REPO_URL = "https://github.com/madler/pigz.git"
-_PIGZ_PATH: Optional[str] = None
-
-
-def _which_pigz() -> Optional[str]:
-    from shutil import which
-
-    path = which("pigz")
-    if path:
-        return path
-    home_bin = os.path.join(os.path.expanduser("~"), ".local", "bin", "pigz")
-    if os.path.exists(home_bin):
-        return home_bin
-    return None
-
-
-def _install_pigz() -> Optional[str]:
-    tmp_root = tempfile.mkdtemp(prefix="pigz_build_")
-    repo_dir = os.path.join(tmp_root, "pigz")
-    try:
-        clone_cmd = [
-            "git",
-            "clone",
-            "--depth",
-            "1",
-            _PIGZ_REPO_URL,
-            repo_dir,
-        ]
-        subprocess.run(clone_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
-        subprocess.run(["make"], cwd=repo_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
-        bin_dir = os.path.join(os.path.expanduser("~"), ".local", "bin")
-        os.makedirs(bin_dir, exist_ok=True)
-        for binary in ("pigz", "unpigz"):
-            src = os.path.join(repo_dir, binary)
-            if os.path.exists(src):
-                dst = os.path.join(bin_dir, binary)
-                shutil.copy2(src, dst)
-                try:
-                    os.chmod(dst, 0o755)
-                except Exception:
-                    pass
-        return _which_pigz()
-    except Exception:
-        return None
-    finally:
-        shutil.rmtree(tmp_root, ignore_errors=True)
-
-
-def _ensure_pigz_path() -> str:
-    global _PIGZ_PATH
-    if _PIGZ_PATH and os.path.exists(_PIGZ_PATH):
-        return _PIGZ_PATH
-    path = _which_pigz()
-    if not path:
-        path = _install_pigz()
-    if not path or not os.path.exists(path):
-        raise RuntimeError("pigz compressor is required for snapshots but could not be installed")
-    _PIGZ_PATH = path
-    return _PIGZ_PATH
 
 from .codec import UniversalTensorCodec, TensorLike
 
@@ -1050,6 +989,9 @@ class Brain:
         # Snapshot enforcement policy: by default disallow CPU snapshots when CUDA is available.
         self._allow_cpu_snapshot_when_cuda = False
         self._snapshot_compress_level = _DEFAULT_SNAPSHOT_COMPRESS_LEVEL
+        self._snapshot_stream_writer: Optional[SnapshotStreamWriter] = None
+        self._current_snapshot_path: Optional[str] = None
+        self._snapshot_stream_finalizer = weakref.finalize(self, Brain._finalize_snapshot_stream, self)
         if self.store_snapshots:
             if not self.snapshot_path:
                 raise ValueError("snapshot_path must be provided when store_snapshots is True")
@@ -1331,6 +1273,7 @@ class Brain:
                     )
                 self.connect(idx, connect_to, direction=direction)
             self._notify_tensorboard_graph()
+            self._stream_snapshot_if_configured("add_neuron")
             return neuron
         else:
             coords = tuple(float(v) for v in index)
@@ -1357,6 +1300,7 @@ class Brain:
                     )
                 self.connect(coords, connect_to, direction=direction)
             self._notify_tensorboard_graph()
+            self._stream_snapshot_if_configured("add_neuron")
             return neuron
 
     def get_neuron(self, index: Sequence[int]) -> Optional[Neuron]:
@@ -1394,6 +1338,7 @@ class Brain:
             except Exception:
                 pass
         self._notify_tensorboard_graph()
+        self._stream_snapshot_if_configured("connect")
         return syn
 
     def define_lobe(
@@ -1485,11 +1430,12 @@ class Brain:
         else:
             self.sparse_bounds = self.sparse_bounds + ((0.0, None),)
             new_map: Dict[Tuple[float, ...], Neuron] = {}
-            for pos, n in list(self.neurons.items()):
-                new_pos = tuple(list(pos) + [0.0])
-                setattr(n, "position", new_pos)
-                new_map[new_pos] = n
-            self.neurons = new_map
+        for pos, n in list(self.neurons.items()):
+            new_pos = tuple(list(pos) + [0.0])
+            setattr(n, "position", new_pos)
+            new_map[new_pos] = n
+        self.neurons = new_map
+        self._stream_snapshot_if_configured("add_dimension")
 
     def remove_last_dimension(self) -> None:
         if self.n <= 1:
@@ -1511,6 +1457,7 @@ class Brain:
             new_map[new_pos] = n
         self.neurons = new_map
         self.n -= 1
+        self._stream_snapshot_if_configured("remove_dimension")
 
     # Remove a synapse and clean references
     def remove_synapse(self, synapse: "Synapse") -> None:
@@ -1551,6 +1498,7 @@ class Brain:
         except Exception:
             pass
         self._notify_tensorboard_graph()
+        self._stream_snapshot_if_configured("remove_synapse")
 
     # Remove a neuron and bridge its synapses to avoid gaps
     def remove_neuron(self, neuron: "Neuron") -> None:
@@ -1599,6 +1547,7 @@ class Brain:
         except Exception:
             pass
         self._notify_tensorboard_graph()
+        self._stream_snapshot_if_configured("remove_neuron")
 
     def status(self) -> Dict[str, Any]:
         """Return a snapshot of training/runtime stats."""
@@ -2011,29 +1960,47 @@ class Brain:
         return brain
 
     # --- Snapshot persistence ---
-    def save_snapshot(self, path: Optional[str] = None) -> str:
+    def _finalize_snapshot_stream(self) -> None:
+        writer = getattr(self, "_snapshot_stream_writer", None)
+        if writer is not None:
+            try:
+                writer.close()
+            except Exception:
+                pass
+            self._snapshot_stream_writer = None
+
+    def _stream_snapshot_if_configured(self, reason: str) -> None:
+        if not getattr(self, "store_snapshots", False):
+            return
+        try:
+            self.save_snapshot(reason=reason)
+        except Exception:
+            pass
+
+    def save_snapshot(self, path: Optional[str] = None, *, reason: str = "manual") -> str:
         """Persist full brain state to a single `.marble` file.
 
         If *path* is None, uses configured ``snapshot_path`` and auto-generates a
         filename ``snapshot_<timestamp>.marble``. Returns the path written.
         """
-        target = path
+        target = path if path is not None else self._current_snapshot_path
         if target is None:
             if not self.snapshot_path:
                 raise ValueError("snapshot_path is not configured")
             ts = datetime.datetime.fromtimestamp(time.time())
             base = ts.strftime("%Y%m%d_%H%M%S_%f")
-            candidate = os.path.join(self.snapshot_path, f"snapshot_{base}.marble")
-            if os.path.exists(candidate):
-                suffix = 1
-                while os.path.exists(candidate):
-                    candidate = os.path.join(
-                        self.snapshot_path, f"snapshot_{base}_{suffix}.marble"
-                    )
-                    suffix += 1
+            candidate = os.path.join(self.snapshot_path, f"stream_{base}.marble")
+            suffix = 1
+            while os.path.exists(candidate):
+                candidate = os.path.join(
+                    self.snapshot_path, f"stream_{base}_{suffix}.marble"
+                )
+                suffix += 1
             target = candidate
         if not str(target).endswith(".marble"):
             target = str(target) + ".marble"
+        target = str(target)
+        self._current_snapshot_path = target
 
         snapshot_torch: Any
         allow_cpu_override = bool(getattr(self, "_allow_cpu_snapshot_when_cuda", False))
@@ -2517,35 +2484,30 @@ class Brain:
         compress_level = _coerce_snapshot_compress_level(raw_compress_level, _DEFAULT_SNAPSHOT_COMPRESS_LEVEL)
         self._snapshot_compress_level = compress_level
 
-        pigz_path = _ensure_pigz_path()
-        tmp_target = f"{target}.tmp"
         try:
-            payload = pickle.dumps(data, protocol=pickle.HIGHEST_PROTOCOL)
-            with open(tmp_target, "wb") as outfile:
-                subprocess.run(
-                    [pigz_path, f"-{compress_level}", "-c"],
-                    input=payload,
-                    stdout=outfile,
-                    stderr=subprocess.PIPE,
-                    check=True,
-                )
-            os.replace(tmp_target, target)
+            writer = self._snapshot_stream_writer
+            if writer is None or getattr(writer, "path", None) != target:
+                if writer is not None:
+                    try:
+                        writer.close()
+                    except Exception:
+                        pass
+                writer = SnapshotStreamWriter(target, compress_level=compress_level)
+                self._snapshot_stream_writer = writer
+            writer.append_state(data, reason=reason)
         except Exception as exc:
-            try:
-                if os.path.exists(tmp_target):
-                    os.remove(tmp_target)
-            except Exception:
-                pass
-            raise RuntimeError(f"pigz compression failed: {exc}") from exc
+            raise RuntimeError(f"snapshot streaming failed: {exc}") from exc
         self._last_snapshot_meta = {
             "path": target,
             "time": time.time(),
             "device": "cuda" if use_cuda_for_snapshot else "cpu",
             "compress_level": compress_level,
-            "compressor": "pigz",
+            "compressor": "zlib-stream",
+            "mode": "append",
+            "reason": reason,
         }
-        # Retention: keep only the newest N snapshots if configured
-        if getattr(self, "snapshot_keep", None) is not None:
+        # Retention: keep only the newest N snapshot streams if configured
+        if getattr(self, "snapshot_keep", None) is not None and self.snapshot_path:
             files = [
                 os.path.join(self.snapshot_path, p)
                 for p in os.listdir(self.snapshot_path)
@@ -2553,26 +2515,24 @@ class Brain:
             ]
             files.sort(key=os.path.getmtime, reverse=True)
             for old in files[int(self.snapshot_keep) :]:
-                os.remove(old)
-        report("brain", "snapshot_saved", {"path": target}, "io")
+                if os.path.abspath(old) == os.path.abspath(target):
+                    continue
+                try:
+                    os.remove(old)
+                except Exception:
+                    pass
+        report("brain", "snapshot_saved", {"path": target, "reason": reason}, "io")
         return target
 
     @classmethod
     def load_snapshot(cls, path: str) -> "Brain":
         """Load a brain snapshot previously saved with ``save_snapshot``."""
         try:
-            with open(path, "rb") as probe:
-                magic = probe.read(2)
-        except FileNotFoundError:
-            raise
-        if magic == b"\x1f\x8b":
-            with gzip.open(path, "rb") as f:
-                data = pickle.load(f)
-        else:
-            with open(path, "rb") as f:
-                data = pickle.load(f)
-        if not isinstance(data, dict):
-            raise ValueError("Invalid brain snapshot")
+            data = read_latest_state(path)
+        except SnapshotStreamError as exc:
+            raise ValueError(f"Invalid brain snapshot stream: {exc}") from exc
+        if data is None or not isinstance(data, dict):
+            raise ValueError("Snapshot stream does not contain a valid state")
         mode = data.get("mode", "grid")
         if mode == "sparse":
             brain = cls(

--- a/marble/snapshot_stream.py
+++ b/marble/snapshot_stream.py
@@ -1,0 +1,197 @@
+"""Incremental snapshot stream helpers.
+
+This module provides a crash-resistant append-only stream format used by
+``Brain.save_snapshot``.  Each snapshot write appends a self-describing frame
+containing the full serialized state so that readers can reconstruct the most
+recent brain layout even while training is still running.
+
+The stream format is intentionally simple:
+
+* 8-byte magic header ``MBSTREAM`` followed by a 1-byte version and a 1-byte
+  compression level hint.  Readers ignore the hint but it documents the
+  intended zlib level.
+* Repeated frames, each encoded as ``[type(4s)][length(8)][crc(4)][payload]
+  [length(4)]``.  ``type`` is ASCII (``FULL`` for full-state frames),
+  ``length`` is the payload size in bytes and is repeated at the end for quick
+  sanity checks.  ``crc`` stores the zlib CRC32 of the compressed payload.
+* ``payload`` is ``zlib.compress`` of a pickled mapping
+  ``{"time": float, "reason": str, "state": Mapping}``.
+
+The framing guarantees that incomplete writes (e.g. power failure) are simply
+ignored by readers—the last fully written frame remains accessible.  Writers
+flush and fsync after every append so the file is always readable by
+``snapshot_to_image`` while training continues.
+"""
+
+from __future__ import annotations
+
+import os
+import pickle
+import struct
+import threading
+import time
+import zlib
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, Optional
+
+
+MAGIC = b"MBSTREAM"
+VERSION = 1
+HEADER_STRUCT = struct.Struct(">8sBB")
+FRAME_HEADER_STRUCT = struct.Struct(">4sQI")
+FRAME_FOOTER_STRUCT = struct.Struct(">I")
+FRAME_TYPE_FULL = b"FULL"
+
+
+@dataclass(frozen=True)
+class SnapshotFrame:
+    """In-memory representation of a decoded stream frame."""
+
+    frame_type: str
+    timestamp: float
+    reason: str
+    state: Dict[str, Any]
+
+
+class SnapshotStreamError(RuntimeError):
+    """Raised when the on-disk stream is irrecoverably malformed."""
+
+
+class SnapshotStreamWriter:
+    """Append-only writer that produces crash-safe snapshot streams."""
+
+    def __init__(self, path: str, *, compress_level: int = 2) -> None:
+        self.path = str(path)
+        self.compress_level = int(max(1, min(9, compress_level)))
+        self._lock = threading.Lock()
+        self._file = self._open_file()
+        self._frame_index = self._scan_existing_frames()
+
+    # -- private helpers -------------------------------------------------
+    def _open_file(self):
+        directory = os.path.dirname(self.path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        is_new = not os.path.exists(self.path) or os.path.getsize(self.path) == 0
+        mode = "r+b" if not is_new else "w+b"
+        fh = open(self.path, mode)
+        if is_new:
+            fh.write(HEADER_STRUCT.pack(MAGIC, VERSION, self.compress_level))
+            fh.flush()
+            os.fsync(fh.fileno())
+        else:
+            header = fh.read(HEADER_STRUCT.size)
+            if len(header) != HEADER_STRUCT.size:
+                raise SnapshotStreamError("Snapshot stream header is truncated")
+            magic, version, stored_level = HEADER_STRUCT.unpack(header)
+            if magic != MAGIC:
+                raise SnapshotStreamError("Not a marble snapshot stream")
+            if version != VERSION:
+                raise SnapshotStreamError(
+                    f"Unsupported snapshot stream version: {version}"
+                )
+            # If the stored compression level differs we keep using the original
+            # setting to avoid mixing payload encodings mid-stream.
+            self.compress_level = int(stored_level) or self.compress_level
+        fh.seek(0, os.SEEK_END)
+        return fh
+
+    def _scan_existing_frames(self) -> int:
+        count = 0
+        for _ in iterate_snapshot_frames(self.path):
+            count += 1
+        return count
+
+    # -- public API ------------------------------------------------------
+    def append_state(self, state: Dict[str, Any], *, reason: str = "manual") -> None:
+        payload = {
+            "time": float(time.time()),
+            "reason": str(reason),
+            "state": dict(state),
+        }
+        raw = pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)
+        compressed = zlib.compress(raw, self.compress_level)
+        length = len(compressed)
+        crc = zlib.crc32(compressed) & 0xFFFFFFFF
+        header = FRAME_HEADER_STRUCT.pack(FRAME_TYPE_FULL, length, crc)
+        footer = FRAME_FOOTER_STRUCT.pack(length)
+        with self._lock:
+            self._file.write(header)
+            self._file.write(compressed)
+            self._file.write(footer)
+            self._file.flush()
+            os.fsync(self._file.fileno())
+            self._frame_index += 1
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                self._file.flush()
+                os.fsync(self._file.fileno())
+            except Exception:
+                pass
+            self._file.close()
+
+
+def iterate_snapshot_frames(path: str) -> Iterator[SnapshotFrame]:
+    """Yield decoded frames from *path* until the stream terminates."""
+
+    if not os.path.exists(path):
+        return
+    with open(path, "rb") as fh:
+        header = fh.read(HEADER_STRUCT.size)
+        if len(header) != HEADER_STRUCT.size:
+            return
+        magic, version, _level = HEADER_STRUCT.unpack(header)
+        if magic != MAGIC or version != VERSION:
+            raise SnapshotStreamError("Unsupported snapshot stream header")
+        while True:
+            prefix = fh.read(FRAME_HEADER_STRUCT.size)
+            if len(prefix) < FRAME_HEADER_STRUCT.size:
+                break
+            frame_type, length, crc = FRAME_HEADER_STRUCT.unpack(prefix)
+            payload = fh.read(length)
+            if len(payload) < length:
+                break
+            suffix = fh.read(FRAME_FOOTER_STRUCT.size)
+            if len(suffix) < FRAME_FOOTER_STRUCT.size:
+                break
+            (length_footer,) = FRAME_FOOTER_STRUCT.unpack(suffix)
+            if length_footer != length:
+                break
+            if zlib.crc32(payload) & 0xFFFFFFFF != crc:
+                break
+            try:
+                decoded = pickle.loads(zlib.decompress(payload))
+            except Exception:
+                break
+            state = decoded.get("state") or decoded.get("data")
+            if not isinstance(state, dict):
+                continue
+            timestamp = float(decoded.get("time", 0.0))
+            reason = str(decoded.get("reason", ""))
+            try:
+                frame_name = frame_type.decode("ascii", "ignore")
+            except Exception:
+                frame_name = "FULL"
+            yield SnapshotFrame(frame_name, timestamp, reason, state)
+
+
+def read_latest_state(path: str) -> Optional[Dict[str, Any]]:
+    """Return the most recent state dictionary from *path* if available."""
+
+    last_state: Optional[Dict[str, Any]] = None
+    for frame in iterate_snapshot_frames(path):
+        if frame.frame_type == "FULL":
+            last_state = frame.state
+    return last_state
+
+
+def append_state(path: str, state: Dict[str, Any], *, reason: str = "manual", compress_level: int = 2) -> None:
+    """Convenience helper mirroring :meth:`SnapshotStreamWriter.append_state`."""
+
+    writer = SnapshotStreamWriter(path, compress_level=compress_level)
+    try:
+        writer.append_state(state, reason=reason)
+    finally:
+        writer.close()


### PR DESCRIPTION
## Summary
- add an incremental snapshot stream writer and expose helpers for reading active frames
- refactor `Brain.save_snapshot` to append to the stream, auto-stream on graph mutations, and load from the new format
- update snapshot visualisation and unit tests to consume the live stream format

## Testing
- `python -m unittest -v tests.test_brain_snapshot`
- `python -m unittest -v tests.test_snapshot_visualization`


------
https://chatgpt.com/codex/tasks/task_e_68cd1d31788883279dd03f8bd0e15f11