### PR TITLE
Add snapshot tensor precision configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ resource_allocator:
   disk_usage_threshold: 0.95  # stop offloading when disk usage exceeds this ratio
 snapshot:
   compress_level: 2  # gzip compression level (1-9) for Brain.save_snapshot
+  tensor_precision: 16  # bit precision for tensors stored in Brain.save_snapshot (8, 16, or 32)
 reporter:
   tensorboard:
     enabled: true  # write all reporter updates to TensorBoard

--- a/yaml-manual.txt
+++ b/yaml-manual.txt
@@ -57,6 +57,16 @@
   failures raise an error so snapshots never silently downgrade to single-threaded gzip. The value must be an
   integer between 1 and 9; out-of-range values are clamped automatically.
 
+- snapshot.tensor_precision (int | str, default: 16)
+  Controls the numeric precision used when persisting tensor payloads inside
+  snapshot streams. The value accepts either bit-widths (``8``, ``16``, ``32``)
+  or their string aliases (``"uint8"``, ``"float16"``, ``"float32"``). Tensor
+  elements are rounded to the requested precision before encoding; ``8``-bit
+  mode applies linear quantisation with a stored scale and offset so values can
+  be reconstructed approximately during snapshot loading. ``16``-bit mode uses
+  IEEE ``float16`` storage, while ``32``-bit mode preserves the legacy
+  ``float32`` representation. Invalid values fall back to the default.
+
 ## Reporter Settings
 
 - reporter.tensorboard.enabled (bool, default: true)


### PR DESCRIPTION
## Summary
- add a `snapshot.tensor_precision` option to control snapshot tensor bit width with a float16 default
- update snapshot saving/loading logic to honor float32/float16/uint8 targets, including quantized storage and metadata
- document the new setting and adapt snapshot tests to decode quantized payloads and accept 16-bit arrays

## Testing
- python -m unittest -v tests.test_brain_snapshot
- python -m unittest -v tests.test_snapshot_visualization

------
https://chatgpt.com/codex/tasks/task_e_68cdf3e0d02c83278d73e75ef71aba6d