### PR TITLE
Fix prep latency tracking for batched quality run

### DIFF
--- a/examples/run_hf_image_quality_dc.py
+++ b/examples/run_hf_image_quality_dc.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 print("Importing packages..")
 
 from typing import Iterator, Any, Dict
+from collections import deque
 from collections.abc import Mapping
 import io
 import os
@@ -52,7 +53,7 @@ from marble import learnableON, learnableIsOn
 
 print("...complete")
 
-PREP_TIMES: list[float] = []
+PREP_TIMES: deque[float] = deque()
 
 
 QUALITY_LEARNABLES: tuple[str, ...] = (
@@ -467,7 +468,7 @@ def main(
 
     def _start_neuron(left: Any, br):
         if PREP_TIMES:
-            latency = time.perf_counter() - PREP_TIMES.pop(0)
+            latency = time.perf_counter() - PREP_TIMES.popleft()
             print(f"prep-to-train latency: {latency:.4f}s")
         sentinel = object()
         enc: Any = left


### PR DESCRIPTION
## Summary
- switch the quality DC example to track prep timestamps in a deque
- drain the queue with `popleft()` so batched runs no longer accumulate latency

## Testing
- python -m unittest tests.test_quality_learnables


------
https://chatgpt.com/codex/tasks/task_e_68ce7a6968a88327b8d23be472fb6cf8