### PR TITLE
Extend improvement development roadmap

### DIFF
--- a/improvementdevelopmentplan.md
+++ b/improvementdevelopmentplan.md
@@ -97,6 +97,79 @@ others. Add config switches for "data-free unlearning" policies, log each
 unlearning event via `REPORTER`, and craft tests that learn, unlearn, then
 re-learn tasks to verify retention, relapse prevention, and privacy guarantees.
 
+## Step 5 – Graph-of-thought introspection for Wanderer trajectories
+
+5.1 **Capture high-resolution walk state.** Extend the existing reporter hooks
+so every Wanderer step persists its predecessor/successor edges, decision logits,
+and plugin context into a graph-structured buffer. Export this buffer into a
+new `reporter.graph` stream that mirrors the Graph-of-Thought (GoT) notion of
+"thought" vertices with dependency edges, enabling downstream tooling to reason
+about alternative branches.[^5]
+
+5.2 **Author graph-native analyzers.** Build a diagnostics module that runs
+GoT-inspired graph algorithms—cycle detection, feedback edge trimming, and
+subgraph condensation—to flag loops, redundant plugin sequences, and high-impact
+branches. Surface these metrics in the Wanderer dashboards and throttle
+low-value branches via `decision_controller` policies.
+
+5.3 **Interactive replay + testing.** Create CLI tooling that can replay a
+stored walk graph, allowing developers to prune/merge nodes and run counterfactual
+routes. Augment existing Wanderer regression tests with graph snapshots to
+ensure coverage for branching, merging, and pruning behaviours.
+
+## Step 6 – Carbon-aware scheduling and telemetry
+
+6.1 **Instrument energy estimators.** Embed hooks similar to the Carbontracker
+workflow to log estimated energy draw per plugin family, factoring in device
+type, run duration, and datacenter carbon intensity. Record the metrics alongside
+loss/latency so optimization loops can jointly minimize emissions and cost.[^6]
+
+6.2 **Plan adaptive scheduling.** Extend `config.yaml` with a `sustainability`
+section (e.g., `target_co2eq_per_walk`, `prefer_offpeak: true`) and update the
+execution scheduler to shift intensive tasks toward greener time windows or
+lower-carbon devices when thresholds are exceeded. Provide CPU-only fallbacks
+for environments that cannot meet the emission budget.
+
+6.3 **Publish sustainability reports.** Enhance reporter exports to summarize
+per-run emissions, energy, and cost estimates. Pipe the aggregates into
+documentation (e.g., markdown tables in `docs/`) and include regression tests
+that validate the telemetry fields populate even when wanders are short.
+
+## Step 7 – Multi-agent automation for evaluation and remediation
+
+7.1 **Design agent protocols.** Introduce an orchestration layer that spins up
+lightweight analysis agents to review reporter logs, config diffs, and test
+artifacts. Base the interaction loops on AutoGen-style role hand-offs so agents
+can debate anomalies and agree on remediation plans before code changes land.[^7]
+
+7.2 **Automate regression triage.** Attach the agent layer to CI so a failure in
+`tests/` triggers a conversation between diagnostics, reproduction, and fix-scout
+agents. Feed their summarized findings back into Git metadata and `REPORTER`
+annotations to streamline human review.
+
+7.3 **Agent-in-the-loop safeguards.** Provide guardrails that cap agent retries,
+require human acknowledgement for destructive fixes, and log all agent decisions
+for auditability. Extend tests to simulate stuck conversations and verify the
+fallback path hands control back to maintainers.
+
+## Step 8 – Temporal transformation reasoning benchmarks
+
+8.1 **Curate multimodal task suites.** Adapt datasets inspired by Visual
+Transformation Telling so Wanderer walkthroughs can train on ordered state
+pairs—images, sensor traces, or serialized graph states—and produce transformation
+descriptions. Store dataset manifests under `examples/` with streaming loaders
+to stay consistent with Step 3's ingestion goals.[^8]
+
+8.2 **Plugin adapters for transformations.** Implement neuron and synapse
+plugins that consume paired states and learn to narrate or predict the underlying
+transformation. Ensure `expose_learnable_params` covers temporal attention spans,
+state-diff thresholds, and generative decoder knobs.
+
+8.3 **Evaluation harness.** Add reporter metrics that score narrative fidelity,
+temporal consistency, and downstream task benefit (e.g., better Wanderer path
+selection). Expand tests to replay curated sequences and assert the new plugins
+stabilize when transformations repeat or branch.
+
 ---
 
 ### Cross-cutting deliverables
@@ -107,6 +180,8 @@ or workflows appear.
 compression path, or streaming helper introduced in the steps above.
 - Ensure reporter metrics surface the before/after impact of each improvement so
 future runs can compare memory, throughput, and accuracy at a glance.
+- Publish sustainability and agent-audit appendices when Steps 6–7 add new
+telemetry, keeping the documentation in sync with emitted metrics.
 
 ### Research references
 
@@ -119,3 +194,10 @@ Binary Neural Networks*. https://arxiv.org/abs/2407.12075
 dataset without downloading it.* https://huggingface.co/docs/datasets/stream
 [^4]: Adhikari et al., 2025 — *An Unlearning Framework for Continual Learning
 (UnCLe).* https://arxiv.org/abs/2509.17530
+[^5]: Besta et al., 2024 — *Graph of Thoughts: Solving Elaborate Problems with
+Large Language Models*. https://arxiv.org/abs/2308.09687
+[^6]: Anthony et al., 2020 — *Carbontracker: Tracking and Predicting the Carbon
+Footprint of Training Deep Learning Models*. https://arxiv.org/abs/2007.03051
+[^7]: Wu et al., 2023 — *AutoGen: Enabling Next-Gen LLM Applications via
+Multi-Agent Conversation*. https://arxiv.org/abs/2308.08155
+[^8]: Cui et al., 2024 — *Visual Transformation Telling*. https://arxiv.org/abs/2305.01928


### PR DESCRIPTION
## Summary
- add graph-of-thought telemetry, sustainability, agent automation, and temporal reasoning initiatives to the improvement development plan
- reference contemporary research (GoT, Carbontracker, AutoGen, Visual Transformation Telling) supporting the new roadmap items

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68d2699aed988327a7f5fa38707ea4c2