### PR TITLE
Add plugin telemetry catalogue and usage metrics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -181,6 +181,23 @@ Packaging and Layout
   - Wanderer and brain-training plugin implementations (e.g., L2 penalty, curriculum, warmup-decay) are also hosted in their own modules under `marble/plugins/`.
   - Plugin IDs are allocated by scanning the `marble/plugins` package in name-sorted order, guaranteeing deterministic identifiers as long as the set of plugin files remains unchanged.
 
+### Plugin catalogue and telemetry
+
+- Every plugin instance created by the loader is forwarded to
+  `marble.plugin_telemetry.register_plugin_metadata`. The helper inspects the
+  module, class name, and docstring to tag the plugin with a functional niche
+  such as *feature_extractor*, *meta_optimizer*, or *path_planner*—the same
+  vocabulary outlined in this architecture overview. The catalogue is accessible
+  via `marble.plugin_telemetry.get_plugin_catalog()` and mirrored in the
+  reporter tree under `plugins/metadata/catalog` so downstream tooling can
+  explore available experts programmatically.
+- When a plugin hook executes, the dispatcher in `marble.marblemain._call_safely`
+  measures the elapsed time and calls
+  `marble.plugin_telemetry.record_plugin_activation`. Aggregated activation
+  counts, per-hook averages, and last-seen latencies are published at
+  `plugins/metrics/usage`, providing the raw telemetry that the upcoming MoE
+  router requires to balance expert utilisation and cost.
+
 Operational Policy Update
 
 - Show tool fallback: If the `show` tool is unavailable, we assume a Linux environment and use Linux commands only for file reads until `show` becomes available again. This is an additive troubleshooting/fallback rule documented in AGENTS.md and does not change any existing behaviors or constraints.

--- a/docs/plugin_catalog.md
+++ b/docs/plugin_catalog.md
@@ -1,0 +1,50 @@
+# Plugin Catalogue & Telemetry Quickstart
+
+Marble now produces a live catalogue of every automatically registered plugin
+alongside runtime telemetry for their activations.  The catalogue is generated
+while the plugin loader scans `marble/plugins` and captures the following data
+per plugin:
+
+- plugin type (neuron, synapse, wanderer, brain-train, self-attention,
+  neuroplasticity, or building block),
+- implementation module and class,
+- a functional niche inferred from the module and docstring vocabulary,
+- the deterministic plugin identifier assigned by the loader,
+- public hooks exposed by the plugin instance.
+
+Both the catalogue and the telemetry feed into the central reporter so future
+Mixture-of-Experts routing can reason about expert coverage and cost without
+inspecting Python modules manually.
+
+## Accessing the catalogue
+
+```python
+from marble.plugin_telemetry import get_plugin_catalog
+
+catalogue = get_plugin_catalog()
+
+conv1d = catalogue["conv1d"]
+print(conv1d["niche"], conv1d["module"], conv1d["hooks"])
+```
+
+The same information is mirrored in the reporter tree under
+`plugins/metadata/catalog`, making it available to dashboards and external
+orchestration layers.
+
+## Inspecting runtime telemetry
+
+```python
+from marble.plugin_telemetry import get_plugin_usage
+
+usage = get_plugin_usage()
+for name, stats in usage.items():
+    print(name, stats["calls"], stats["avg_latency_ms"])
+```
+
+Telemetry entries are updated after every plugin hook invocation.  Each record
+tracks activation counts, per-hook average latency, and the most recent latency
+measurement.  Reporter consumers can read the data at
+`plugins/metrics/usage` to drive routing policies or alerting.
+
+For unit tests the helpers `reset_plugin_catalog()` and `reset_plugin_usage()`
+provide a clean slate between scenarios.

--- a/marble/marblemain.py
+++ b/marble/marblemain.py
@@ -33,6 +33,7 @@ import datetime
 import weakref
 from array import array
 from . import plugin_cost_profiler as _pcp
+from .plugin_telemetry import record_plugin_activation
 from .learnable_param import LearnableParam
 from .learnables_yaml import log_learnable_values, register_learnable
 from .snapshot_stream import SnapshotStreamWriter, SnapshotStreamError, read_latest_state
@@ -5178,7 +5179,9 @@ def _call_safely(fn: Optional[Callable], *args, plugin_name: Optional[str] = Non
             try:
                 return fn(*args, **kwargs)
             finally:
-                _pcp.record(plugin_name, time.perf_counter() - start)
+                elapsed = time.perf_counter() - start
+                _pcp.record(plugin_name, elapsed)
+                record_plugin_activation(plugin_name, getattr(fn, "__name__", "call"), elapsed)
         return fn(*args, **kwargs)
     except Exception:
         return None

--- a/marble/plugin_telemetry.py
+++ b/marble/plugin_telemetry.py
@@ -1,0 +1,312 @@
+"""Runtime catalogues and telemetry for Marble plugins.
+
+This module fulfils the Step 1.1 requirement from the improvement development
+plan by collecting rich metadata about every plugin that is automatically
+registered and by emitting reporter metrics that track activation frequency and
+latency.  The telemetry is designed to power upcoming Mixture-of-Experts routing
+logic, where we need detailed information about which plugins act as feature
+extractors, meta-optimisers, path planners, or other functional niches.
+
+Usage overview
+--------------
+
+``register_plugin_metadata`` is invoked from :mod:`marble.plugins` during the
+auto-discovery pass.  It inspects the plugin implementation, infers a functional
+niche via keyword heuristics (sourced from the architecture notes), and stores a
+serialisable metadata snapshot.  ``record_plugin_activation`` is called by the
+generic plugin dispatcher in :mod:`marble.marblemain` whenever a plugin hook is
+executed.  The dispatcher supplies the plugin name, hook name, and measured
+latency so we can update exponential statistics.
+
+The collected information is exposed through ``get_plugin_catalog`` and
+``get_plugin_usage`` for programmatic access and is mirrored into the central
+reporter tree under ``plugins/metadata/catalog`` and ``plugins/metrics/usage``.
+Tests can call ``reset_plugin_usage`` to clear metrics between scenarios.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, List, MutableMapping, Optional
+
+from .reporter import report
+
+
+_DEFAULT_NICHES: Dict[str, str] = {
+    "neuron": "activation_shaper",
+    "synapse": "connectivity_modulator",
+    "wanderer": "path_planner",
+    "brain_train": "training_controller",
+    "selfattention": "attention_moderator",
+    "neuroplasticity": "plasticity_regulator",
+    "buildingblock": "graph_editor",
+}
+
+_KEYWORD_NICHES: List[tuple[str, str]] = [
+    ("conv", "feature_extractor"),
+    ("pool", "feature_compactor"),
+    ("fold", "feature_compactor"),
+    ("unpool", "feature_expander"),
+    ("attention", "attention_controller"),
+    ("entropy", "stochastic_explorer"),
+    ("quantum", "quantum_explorer"),
+    ("optimizer", "meta_optimizer"),
+    ("schedule", "schedule_controller"),
+    ("memory", "memory_stabiliser"),
+    ("loss", "loss_shaper"),
+    ("builder", "structure_builder"),
+    ("plastic", "plasticity_regulator"),
+    ("synapse", "connectivity_modulator"),
+    ("wander", "path_planner"),
+    ("neuro", "plasticity_regulator"),
+    ("train", "training_controller"),
+]
+
+
+@dataclass
+class PluginMetadata:
+    """Metadata snapshot describing a Marble plugin."""
+
+    name: str
+    plugin_type: str
+    module: str
+    class_name: str
+    description: str
+    niche: str
+    plugin_id: Optional[int]
+    hooks: List[str]
+
+    def serialise(self) -> Dict[str, Any]:
+        """Return a dict representation safe for reporting."""
+
+        data = asdict(self)
+        # Hooks are short names; keep them sorted for readability.
+        data["hooks"] = sorted(set(self.hooks))
+        return data
+
+
+class _PluginCatalog:
+    """In-memory catalogue of plugin metadata."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._entries: Dict[str, PluginMetadata] = {}
+
+    def register(
+        self,
+        name: str,
+        plugin_type: str,
+        plugin: Any,
+        plugin_id: Optional[int] = None,
+    ) -> PluginMetadata:
+        """Register (or update) metadata for ``name``."""
+
+        cls = plugin.__class__
+        module = getattr(cls, "__module__", "")
+        class_name = getattr(cls, "__name__", "")
+        doc = inspect.getdoc(cls) or inspect.getdoc(plugin) or ""
+        description = doc.splitlines()[0].strip() if doc else f"Plugin {class_name}"
+        hooks = [
+            attr
+            for attr, value in inspect.getmembers(plugin)
+            if not attr.startswith("_") and callable(value)
+        ]
+        text = f"{name} {module} {class_name} {doc}".lower()
+        niche = _DEFAULT_NICHES.get(plugin_type, "generalist")
+        for keyword, mapped in _KEYWORD_NICHES:
+            if keyword in text:
+                niche = mapped
+                break
+        meta = PluginMetadata(
+            name=name,
+            plugin_type=plugin_type,
+            module=module,
+            class_name=class_name,
+            description=description,
+            niche=niche,
+            plugin_id=plugin_id,
+            hooks=hooks,
+        )
+        with self._lock:
+            self._entries[name] = meta
+        self._report_single(meta)
+        return meta
+
+    def snapshot(self) -> Dict[str, PluginMetadata]:
+        with self._lock:
+            return dict(self._entries)
+
+    def serialised_snapshot(self) -> Dict[str, Dict[str, Any]]:
+        snap = self.snapshot()
+        return {name: meta.serialise() for name, meta in snap.items()}
+
+    def lookup(self, name: str) -> Optional[PluginMetadata]:
+        with self._lock:
+            return self._entries.get(name)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._entries.clear()
+        report("plugins", "catalog", {}, "metadata")
+
+    def _report_single(self, meta: PluginMetadata) -> None:
+        try:
+            report("plugins", "catalog", {meta.name: meta.serialise()}, "metadata")
+        except Exception:
+            pass
+
+
+class _PluginUsage:
+    """Aggregate per-plugin activation statistics."""
+
+    def __init__(self, catalog: _PluginCatalog) -> None:
+        self._catalog = catalog
+        self._lock = threading.Lock()
+        self._stats: Dict[str, Dict[str, Any]] = {}
+
+    def record(self, name: str, hook_name: str, elapsed: float) -> None:
+        hook = hook_name or "call"
+        lat = max(float(elapsed), 0.0)
+        hook_key = hook
+        with self._lock:
+            entry = self._stats.setdefault(
+                name,
+                {
+                    "calls": 0,
+                    "total_latency": 0.0,
+                    "last_latency_ms": 0.0,
+                    "hooks": {},
+                    "plugin_type": None,
+                },
+            )
+            entry["calls"] += 1
+            entry["total_latency"] += lat
+            entry["last_latency_ms"] = lat * 1_000.0
+            meta = self._catalog.lookup(name)
+            if meta is not None:
+                entry["plugin_type"] = meta.plugin_type
+            hooks: MutableMapping[str, Dict[str, Any]] = entry["hooks"]
+            hook_stats = hooks.setdefault(
+                hook_key,
+                {"calls": 0, "total_latency": 0.0, "last_latency_ms": 0.0},
+            )
+            hook_stats["calls"] += 1
+            hook_stats["total_latency"] += lat
+            hook_stats["last_latency_ms"] = lat * 1_000.0
+            entry_copy = self._format_entry(name, entry)
+        self._report_usage(name, entry_copy)
+
+    def snapshot(self) -> Dict[str, Dict[str, Any]]:
+        with self._lock:
+            return {name: self._format_entry(name, entry) for name, entry in self._stats.items()}
+
+    def reset(self) -> None:
+        with self._lock:
+            self._stats.clear()
+        report("plugins", "usage", {}, "metrics")
+
+    def _format_entry(self, name: str, entry: Dict[str, Any]) -> Dict[str, Any]:
+        calls = int(entry.get("calls", 0))
+        total_latency = float(entry.get("total_latency", 0.0))
+        avg_ms = (total_latency / calls * 1_000.0) if calls else 0.0
+        hooks = {
+            hook: {
+                "calls": int(stats.get("calls", 0)),
+                "avg_latency_ms": (
+                    (float(stats.get("total_latency", 0.0)) / stats.get("calls", 1)) * 1_000.0
+                    if stats.get("calls", 0)
+                    else 0.0
+                ),
+                "last_latency_ms": float(stats.get("last_latency_ms", 0.0)),
+            }
+            for hook, stats in entry.get("hooks", {}).items()
+        }
+        return {
+            "plugin": name,
+            "plugin_type": entry.get("plugin_type"),
+            "calls": calls,
+            "avg_latency_ms": avg_ms,
+            "last_latency_ms": float(entry.get("last_latency_ms", 0.0)),
+            "hooks": hooks,
+        }
+
+    def _report_usage(self, name: str, entry: Dict[str, Any]) -> None:
+        try:
+            report("plugins", "usage", {name: entry}, "metrics")
+        except Exception:
+            pass
+
+
+_CATALOG = _PluginCatalog()
+_USAGE = _PluginUsage(_CATALOG)
+
+
+def register_plugin_metadata(
+    name: str,
+    plugin_type: str,
+    plugin: Any,
+    *,
+    plugin_id: Optional[int] = None,
+) -> PluginMetadata:
+    """Public helper for registering plugin metadata.
+
+    Parameters
+    ----------
+    name:
+        The public plugin identifier.
+    plugin_type:
+        One of ``{"neuron", "synapse", "wanderer", "brain_train",
+        "selfattention", "neuroplasticity", "buildingblock"}``.
+    plugin:
+        The instantiated plugin object.
+    plugin_id:
+        Optional numeric identifier from the plugin discovery system.
+    """
+
+    return _CATALOG.register(name, plugin_type, plugin, plugin_id)
+
+
+def record_plugin_activation(name: str, hook_name: str, elapsed: float) -> None:
+    """Record a plugin activation with the measured elapsed time."""
+
+    if not name:
+        return
+    _USAGE.record(name, hook_name, elapsed)
+
+
+def get_plugin_catalog() -> Dict[str, Dict[str, Any]]:
+    """Return a serialisable snapshot of the plugin catalogue."""
+
+    return _CATALOG.serialised_snapshot()
+
+
+def get_plugin_usage() -> Dict[str, Dict[str, Any]]:
+    """Return aggregated plugin usage statistics."""
+
+    return _USAGE.snapshot()
+
+
+def reset_plugin_usage() -> None:
+    """Clear accumulated usage metrics (primarily for tests)."""
+
+    _USAGE.reset()
+
+
+def reset_plugin_catalog() -> None:
+    """Clear the plugin metadata catalogue."""
+
+    _CATALOG.reset()
+
+
+__all__ = [
+    "PluginMetadata",
+    "register_plugin_metadata",
+    "record_plugin_activation",
+    "get_plugin_catalog",
+    "get_plugin_usage",
+    "reset_plugin_usage",
+    "reset_plugin_catalog",
+]
+

--- a/marble/plugins/__init__.py
+++ b/marble/plugins/__init__.py
@@ -25,6 +25,7 @@ from ..marblemain import register_brain_train_type
 from ..buildingblock import register_buildingblock_type
 from ..plugin_graph import PLUGIN_GRAPH
 from .. import plugin_cost_profiler as _pcp
+from ..plugin_telemetry import register_plugin_metadata
 
 # Global registry assigning a unique numeric ID to every plugin.  The IDs are
 # stable across runs as long as the set of available plugins does not change.
@@ -103,6 +104,7 @@ for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
         _wrap_public_methods(inst, pname)
         inst.plugin_id = pid
         register_wanderer_type(pname, inst)
+        register_plugin_metadata(pname, "wanderer", inst, plugin_id=pid)
     elif name.startswith("neuroplasticity_"):
         base = name[len("neuroplasticity_") :]
         pname = plugin_name or base
@@ -111,6 +113,7 @@ for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
         _wrap_public_methods(inst, pname)
         inst.plugin_id = pid
         register_neuroplasticity_type(pname, inst)
+        register_plugin_metadata(pname, "neuroplasticity", inst, plugin_id=pid)
     elif name.startswith("selfattention_"):
         base = name[len("selfattention_") :]
         pname = plugin_name or base
@@ -119,6 +122,7 @@ for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
         _wrap_public_methods(inst, pname)
         inst.plugin_id = pid
         register_selfattention_type(pname, inst)
+        register_plugin_metadata(pname, "selfattention", inst, plugin_id=pid)
     elif name.startswith("synapse_"):
         base = name[len("synapse_") :]
         pname = plugin_name or base
@@ -127,6 +131,7 @@ for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
         _wrap_public_methods(inst, pname)
         inst.plugin_id = pid
         register_synapse_type(pname, inst)
+        register_plugin_metadata(pname, "synapse", inst, plugin_id=pid)
     elif name.startswith("brain_train_"):
         base = name[len("brain_train_") :]
         pname = plugin_name or base
@@ -135,6 +140,7 @@ for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
         _wrap_public_methods(inst, pname)
         inst.plugin_id = pid
         register_brain_train_type(pname, inst)
+        register_plugin_metadata(pname, "brain_train", inst, plugin_id=pid)
     elif name.startswith("buildingblock_"):
         base = name[len("buildingblock_") :]
         pname = plugin_name or base
@@ -143,6 +149,7 @@ for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
         _wrap_public_methods(inst, pname)
         inst.plugin_id = pid
         register_buildingblock_type(pname, inst)
+        register_plugin_metadata(pname, "buildingblock", inst, plugin_id=pid)
     else:
         # Default to neuron plugin registration
         pname = plugin_name or name
@@ -151,6 +158,7 @@ for mod in sorted(pkgutil.iter_modules(__path__), key=lambda m: m.name):
         _wrap_public_methods(inst, pname)
         inst.plugin_id = pid
         register_neuron_type(pname, inst)
+        register_plugin_metadata(pname, "neuron", inst, plugin_id=pid)
 
     PLUGIN_GRAPH.add_plugin(pname)
     for dep in getattr(cls, "REQUIRES", []) or []:

--- a/tests/test_plugin_catalog.py
+++ b/tests/test_plugin_catalog.py
@@ -1,0 +1,40 @@
+import unittest
+
+from marble.plugin_telemetry import (
+    get_plugin_catalog,
+    get_plugin_usage,
+    record_plugin_activation,
+    reset_plugin_usage,
+)
+from marble.reporter import REPORTER
+
+
+class PluginTelemetryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_plugin_usage()
+
+    def test_catalog_contains_core_plugins(self) -> None:
+        catalogue = get_plugin_catalog()
+        self.assertIn("conv1d", catalogue)
+        conv1d = catalogue["conv1d"]
+        self.assertEqual(conv1d["plugin_type"], "neuron")
+        self.assertTrue(conv1d["niche"])
+        self.assertIsInstance(conv1d["hooks"], list)
+        self.assertGreater(len(conv1d["hooks"]), 0)
+
+    def test_record_updates_usage_and_reporter(self) -> None:
+        record_plugin_activation("unit_test_plugin", "forward", 0.005)
+        usage = get_plugin_usage()
+        self.assertIn("unit_test_plugin", usage)
+        stats = usage["unit_test_plugin"]
+        self.assertEqual(stats["calls"], 1)
+        self.assertGreater(stats["avg_latency_ms"], 0.0)
+        group_payload = REPORTER.group("plugins", "metrics")
+        self.assertIn("usage", group_payload)
+        reporter_usage = group_payload["usage"]
+        self.assertIn("unit_test_plugin", reporter_usage)
+        self.assertEqual(reporter_usage["unit_test_plugin"]["calls"], 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a plugin telemetry module that catalogues metadata and aggregates activation latency stats for every registered plugin
- wire the plugin loader and dispatcher to publish per-plugin metadata and usage metrics for upcoming MoE routing work, and document the new data surfaces
- provide a quickstart guide and unit tests covering the catalogue and telemetry helpers

## Testing
- python -m unittest tests.test_plugin_catalog
- python -m unittest tests.test_plugin_stacking


------
https://chatgpt.com/codex/tasks/task_e_68d38957c7408327b19e24f69fbfec66